### PR TITLE
fix: use `kubb` instead of `@kubb/core` for defineConfig import in all plugin YAML fullExamples

### DIFF
--- a/plugins/plugin-client.yaml
+++ b/plugins/plugin-client.yaml
@@ -137,7 +137,7 @@ options:
     required: false
     description: Define additional generators next to the client generators.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
   import { pluginClient } from '@kubb/plugin-client'

--- a/plugins/plugin-client.yaml
+++ b/plugins/plugin-client.yaml
@@ -1,0 +1,25 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-client
+name: Client
+description: Generate type-safe HTTP clients (Axios, Fetch) from OpenAPI specifications for making API requests.
+category: utility
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-client"
+docsPath: /plugins/plugin-client
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - api-client
+  - axios
+  - fetch
+  - http-client
+  - codegen
+  - openapi
+dependencies:
+  - plugin-ts

--- a/plugins/plugin-client.yaml
+++ b/plugins/plugin-client.yaml
@@ -23,3 +23,138 @@ tags:
   - openapi
 dependencies:
   - plugin-ts
+resources:
+  documentation: https://kubb.dev/plugins/plugin-client
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-client/CHANGELOG.md
+icon: 🌐
+featured: true
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'clients', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: group
+    type: Group
+    required: false
+    description: Group the clients based on the provided name (e.g. by tag).
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: client
+    type: "'axios' | 'fetch'"
+    required: false
+    default: "'axios'"
+    description: Which HTTP client to use. Use importPath instead to provide a custom client.
+  - name: importPath
+    type: string
+    required: false
+    description: Custom client import path used as `import client from '${importPath}'`. Mutually exclusive with client.
+  - name: operations
+    type: boolean
+    required: false
+    default: "false"
+    description: Create an operations.ts file with all operations grouped by methods.
+  - name: urlType
+    type: "'export' | false"
+    required: false
+    default: "false"
+    description: Export URLs used by each operation. 'export' makes them part of your barrel file.
+  - name: baseURL
+    type: string
+    required: false
+    description: Custom base URL for all generated calls.
+  - name: dataReturnType
+    type: "'data' | 'full'"
+    required: false
+    default: "'data'"
+    description: Return type when calling the client. 'data' returns ResponseConfig[data], 'full' returns ResponseConfig.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: parser
+    type: "'client' | 'zod'"
+    required: false
+    default: "'client'"
+    description: Which parser to use before returning the data. 'zod' uses @kubb/plugin-zod for validation.
+  - name: clientType
+    type: "'function' | 'class' | 'staticClass'"
+    required: false
+    default: "'function'"
+    description: How to generate the client code. 'function' generates standalone functions, 'class' generates a class, 'staticClass' generates a class with static methods.
+  - name: bundle
+    type: boolean
+    required: false
+    default: "false"
+    description: Bundle the selected client into the generated .kubb directory.
+  - name: paramsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How to pass your params. 'object' merges all params into a single object, 'inline' uses separate function arguments.
+  - name: pathParamsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How path parameters are arranged within the inline argument list. Only applies when paramsType is 'inline'.
+  - name: wrapper
+    type: "{ className: string }"
+    required: false
+    description: Generate a wrapper class that composes all tag-based client classes into a single entry point.
+  - name: resolver
+    type: "Partial<ResolverClient>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied to each node before printing.
+  - name: generators
+    type: "Array<Generator<PluginClient>>"
+    required: false
+    description: Define additional generators next to the client generators.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs(),
+      pluginClient({
+        output: { path: 'clients', barrelType: 'named' },
+        client: 'axios',
+        dataReturnType: 'data',
+        clientType: 'function',
+        paramsCasing: 'camelcase',
+        parser: 'client',
+        operations: false,
+      }),
+    ],
+  })

--- a/plugins/plugin-cypress.yaml
+++ b/plugins/plugin-cypress.yaml
@@ -99,7 +99,7 @@ options:
     required: false
     description: Define additional generators next to the default generators.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
   import { pluginCypress } from '@kubb/plugin-cypress'

--- a/plugins/plugin-cypress.yaml
+++ b/plugins/plugin-cypress.yaml
@@ -23,3 +23,97 @@ tags:
   - openapi
 dependencies:
   - plugin-ts
+resources:
+  documentation: https://kubb.dev/plugins/plugin-cypress
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-cypress/CHANGELOG.md
+icon: 🌲
+featured: false
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'cypress', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: dataReturnType
+    type: "'data' | 'full'"
+    required: false
+    default: "'data'"
+    description: Return type when calling cy.request. 'data' returns ResponseConfig[data], 'full' returns ResponseConfig.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: baseURL
+    type: string
+    required: false
+    description: Base URL prepended to every generated request URL.
+  - name: group
+    type: Group
+    required: false
+    description: Group the Cypress requests based on the provided name (e.g. by tag).
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: paramsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How to pass your params. 'object' merges all params into a single object, 'inline' uses separate arguments.
+  - name: pathParamsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How path parameters are arranged within the inline argument list. Only applies when paramsType is 'inline'.
+  - name: resolver
+    type: "Partial<ResolverCypress>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied before printing.
+  - name: generators
+    type: "Array<Generator<PluginCypress>>"
+    required: false
+    description: Define additional generators next to the default generators.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginCypress } from '@kubb/plugin-cypress'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs(),
+      pluginCypress({
+        output: { path: 'cypress', barrelType: 'named' },
+        dataReturnType: 'data',
+        paramsCasing: 'camelcase',
+        paramsType: 'inline',
+      }),
+    ],
+  })

--- a/plugins/plugin-cypress.yaml
+++ b/plugins/plugin-cypress.yaml
@@ -1,0 +1,25 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-cypress
+name: Cypress
+description: Generate Cypress end-to-end tests from OpenAPI specifications for automated API testing.
+category: testing
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-cypress"
+docsPath: /plugins/plugin-cypress
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - cypress
+  - e2e-testing
+  - api-testing
+  - test-generation
+  - codegen
+  - openapi
+dependencies:
+  - plugin-ts

--- a/plugins/plugin-faker.yaml
+++ b/plugins/plugin-faker.yaml
@@ -1,0 +1,26 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-faker
+name: Faker
+description: Generate realistic mock data using Faker.js from OpenAPI specifications for development and testing.
+category: testing
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-faker"
+docsPath: /plugins/plugin-faker
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - faker
+  - mock-data
+  - mocks
+  - fixtures
+  - testing
+  - codegen
+  - openapi
+dependencies:
+  - plugin-ts

--- a/plugins/plugin-faker.yaml
+++ b/plugins/plugin-faker.yaml
@@ -24,3 +24,100 @@ tags:
   - openapi
 dependencies:
   - plugin-ts
+resources:
+  documentation: https://kubb.dev/plugins/plugin-faker
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-faker/CHANGELOG.md
+icon: 🎭
+featured: false
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'mocks', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: group
+    type: Group
+    required: false
+    description: Group the Faker mocks based on the provided name (e.g. by tag).
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: dateParser
+    type: "'faker' | 'dayjs' | 'moment' | string"
+    required: false
+    default: "'faker'"
+    description: Which parser to use when date/time values are represented as strings.
+  - name: regexGenerator
+    type: "'faker' | 'randexp'"
+    required: false
+    default: "'faker'"
+    description: Choose which generator to use when using RegExp patterns.
+  - name: mapper
+    type: "Record<string, string>"
+    required: false
+    description: Provide per-property faker expressions keyed by property name.
+  - name: seed
+    type: "number | number[]"
+    required: false
+    description: Seed faker for deterministic output.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: generators
+    type: "Array<Generator<PluginFaker>>"
+    required: false
+    description: Define additional generators next to the faker generators.
+  - name: resolver
+    type: "Partial<ResolverFaker>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied to each node before rendering.
+  - name: printer
+    type: "{ nodes?: PrinterFakerNodes }"
+    required: false
+    description: Override individual faker printer node handlers to customize rendering.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginFaker } from '@kubb/plugin-faker'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs(),
+      pluginFaker({
+        output: { path: 'mocks', barrelType: 'named' },
+        dateParser: 'faker',
+        regexGenerator: 'faker',
+        paramsCasing: 'camelcase',
+      }),
+    ],
+  })

--- a/plugins/plugin-faker.yaml
+++ b/plugins/plugin-faker.yaml
@@ -103,7 +103,7 @@ options:
     required: false
     description: Override individual faker printer node handlers to customize rendering.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
   import { pluginFaker } from '@kubb/plugin-faker'

--- a/plugins/plugin-mcp.yaml
+++ b/plugins/plugin-mcp.yaml
@@ -26,3 +26,118 @@ dependencies:
   - plugin-ts
   - plugin-client
   - plugin-zod
+resources:
+  documentation: https://kubb.dev/plugins/plugin-mcp
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-mcp/CHANGELOG.md
+icon: 🤖
+featured: false
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'mcp', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: client
+    type: "ClientImportPath & { clientType?, dataReturnType?, baseURL?, bundle?, paramsCasing? }"
+    required: false
+    description: Client configuration for HTTP request generation, including client type, data return type, base URL, and bundling options.
+    properties:
+      - name: client
+        type: "'axios' | 'fetch'"
+        required: false
+        default: "'axios'"
+        description: Which HTTP client preset to use.
+      - name: importPath
+        type: string
+        required: false
+        description: Custom client import path. Mutually exclusive with client.
+      - name: clientType
+        type: "'function' | 'class' | 'staticClass'"
+        required: false
+        default: "'function'"
+        description: How to generate the client code.
+      - name: dataReturnType
+        type: "'data' | 'full'"
+        required: false
+        default: "'data'"
+        description: Return type when calling the client.
+      - name: baseURL
+        type: string
+        required: false
+        description: Custom base URL for all generated calls.
+      - name: bundle
+        type: boolean
+        required: false
+        default: "false"
+        description: Bundle the selected client into the generated .kubb directory.
+      - name: paramsCasing
+        type: "'camelcase'"
+        required: false
+        description: Transform parameter names to camelCase.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: group
+    type: Group
+    required: false
+    description: Group the MCP handlers based on the provided name (e.g. by tag).
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: resolver
+    type: "Partial<ResolverMcp>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied before printing.
+  - name: generators
+    type: "Array<Generator<PluginMcp>>"
+    required: false
+    description: Define additional generators next to the default MCP generators.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
+  import { pluginZod } from '@kubb/plugin-zod'
+  import { pluginMcp } from '@kubb/plugin-mcp'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs(),
+      pluginClient(),
+      pluginZod(),
+      pluginMcp({
+        output: { path: 'mcp', barrelType: 'named' },
+        client: { client: 'fetch', dataReturnType: 'data' },
+        paramsCasing: 'camelcase',
+      }),
+    ],
+  })

--- a/plugins/plugin-mcp.yaml
+++ b/plugins/plugin-mcp.yaml
@@ -1,0 +1,28 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-mcp
+name: MCP
+description: Generate Model Context Protocol (MCP) servers from OpenAPI specifications to enable AI assistants to interact with your API.
+category: ai
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-mcp"
+docsPath: /plugins/plugin-mcp
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - mcp
+  - model-context-protocol
+  - ai
+  - claude
+  - llm
+  - codegen
+  - openapi
+dependencies:
+  - plugin-ts
+  - plugin-client
+  - plugin-zod

--- a/plugins/plugin-mcp.yaml
+++ b/plugins/plugin-mcp.yaml
@@ -120,7 +120,7 @@ options:
     required: false
     description: Define additional generators next to the default MCP generators.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
   import { pluginClient } from '@kubb/plugin-client'

--- a/plugins/plugin-msw.yaml
+++ b/plugins/plugin-msw.yaml
@@ -25,3 +25,93 @@ tags:
 dependencies:
   - plugin-ts
   - plugin-faker
+resources:
+  documentation: https://kubb.dev/plugins/plugin-msw
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-msw/CHANGELOG.md
+icon: 🎯
+featured: false
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'handlers', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: baseURL
+    type: string
+    required: false
+    description: Base URL prepended to every generated handler URL path.
+  - name: group
+    type: Group
+    required: false
+    description: Group the MSW handlers based on the provided name (e.g. by tag).
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: handlers
+    type: boolean
+    required: false
+    default: "false"
+    description: Create a handlers.ts file with all handlers grouped by methods.
+  - name: parser
+    type: "'data' | 'faker'"
+    required: false
+    default: "'data'"
+    description: Which parser to use for generating response data. 'faker' uses @kubb/plugin-faker.
+  - name: transformers
+    type: "{ name?: (name: string, type?: string) => string }"
+    required: false
+    description: Customize the generated names based on the type provided by the plugin.
+  - name: resolver
+    type: "Partial<ResolverMsw>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied before printing.
+  - name: generators
+    type: "Array<Generator<PluginMsw>>"
+    required: false
+    description: Define additional generators next to the MSW generators.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginFaker } from '@kubb/plugin-faker'
+  import { pluginMsw } from '@kubb/plugin-msw'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs(),
+      pluginFaker(),
+      pluginMsw({
+        output: { path: 'handlers', barrelType: 'named' },
+        parser: 'faker',
+        handlers: false,
+      }),
+    ],
+  })

--- a/plugins/plugin-msw.yaml
+++ b/plugins/plugin-msw.yaml
@@ -96,7 +96,7 @@ options:
     required: false
     description: Define additional generators next to the MSW generators.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
   import { pluginFaker } from '@kubb/plugin-faker'

--- a/plugins/plugin-msw.yaml
+++ b/plugins/plugin-msw.yaml
@@ -1,0 +1,27 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-msw
+name: MSW
+description: Generate Mock Service Worker (MSW) handlers from OpenAPI specifications for frontend development and testing.
+category: testing
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-msw"
+docsPath: /plugins/plugin-msw
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - msw
+  - mock-service-worker
+  - api-mocking
+  - mocks
+  - testing
+  - codegen
+  - openapi
+dependencies:
+  - plugin-ts
+  - plugin-faker

--- a/plugins/plugin-react-query.yaml
+++ b/plugins/plugin-react-query.yaml
@@ -213,7 +213,7 @@ options:
     required: false
     description: Define additional generators next to the react-query generators.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
   import { pluginClient } from '@kubb/plugin-client'

--- a/plugins/plugin-react-query.yaml
+++ b/plugins/plugin-react-query.yaml
@@ -25,3 +25,214 @@ tags:
 dependencies:
   - plugin-ts
   - plugin-client
+resources:
+  documentation: https://kubb.dev/plugins/plugin-react-query
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-react-query/CHANGELOG.md
+icon: ⚛️
+featured: true
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'hooks', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: group
+    type: Group
+    required: false
+    description: Group the hooks based on the provided name (e.g. by tag).
+  - name: client
+    type: "ClientImportPath & { clientType?, dataReturnType?, baseURL?, bundle?, paramsCasing? }"
+    required: false
+    description: Client configuration for HTTP request generation.
+    properties:
+      - name: client
+        type: "'axios' | 'fetch'"
+        required: false
+        default: "'axios'"
+        description: Which HTTP client preset to use.
+      - name: importPath
+        type: string
+        required: false
+        description: Custom client import path. Mutually exclusive with client.
+      - name: clientType
+        type: "'function' | 'class' | 'staticClass'"
+        required: false
+        default: "'function'"
+        description: How to generate the client code.
+      - name: dataReturnType
+        type: "'data' | 'full'"
+        required: false
+        default: "'data'"
+        description: Return type when calling the client.
+      - name: baseURL
+        type: string
+        required: false
+        description: Custom base URL for all generated calls.
+      - name: bundle
+        type: boolean
+        required: false
+        default: "false"
+        description: Bundle the selected client into the generated .kubb directory.
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: paramsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How to pass your params. 'object' merges all params into a single object, 'inline' uses separate arguments.
+  - name: pathParamsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How path parameters are arranged within the inline argument list. Only applies when paramsType is 'inline'.
+  - name: infinite
+    type: "Partial<Infinite> | false"
+    required: false
+    description: When set, an infiniteQuery hook is added.
+    properties:
+      - name: queryParam
+        type: string
+        required: true
+        default: "'id'"
+        description: Specify the params key used for pageParam.
+      - name: initialPageParam
+        type: unknown
+        required: true
+        default: "0"
+        description: The initial value of the first page.
+      - name: nextParam
+        type: "string | string[] | undefined"
+        required: false
+        description: Which field of the data is used to get the cursor for the next page. Supports dot notation.
+      - name: previousParam
+        type: "string | string[] | undefined"
+        required: false
+        description: Which field of the data is used to get the cursor for the previous page. Supports dot notation.
+  - name: suspense
+    type: "Partial<Suspense> | false"
+    required: false
+    description: When set, a suspenseQuery hook is added.
+  - name: query
+    type: "Partial<Query> | false"
+    required: false
+    description: Override some useQuery behaviors.
+    properties:
+      - name: methods
+        type: "Array<string>"
+        required: false
+        default: "['get']"
+        description: Define which HTTP methods can be used for queries.
+      - name: importPath
+        type: string
+        required: false
+        default: "'@tanstack/react-query'"
+        description: Path to the useQuery hook import.
+  - name: mutation
+    type: "Partial<Mutation> | false"
+    required: false
+    description: Override some useMutation behaviors.
+    properties:
+      - name: methods
+        type: "Array<string>"
+        required: false
+        default: "['post', 'put', 'delete']"
+        description: Define which HTTP methods can be used for mutations.
+      - name: importPath
+        type: string
+        required: false
+        default: "'@tanstack/react-query'"
+        description: Path to the useMutation hook import.
+  - name: queryKey
+    type: QueryKey
+    required: false
+    description: Customize the queryKey transformer.
+  - name: mutationKey
+    type: MutationKey
+    required: false
+    description: Customize the mutationKey transformer.
+  - name: customOptions
+    type: "{ importPath: string; name?: string }"
+    required: false
+    description: When set, a custom hook is used to customize the options of the generated hooks.
+    properties:
+      - name: importPath
+        type: string
+        required: true
+        description: Path to the hook used to customize hook options.
+      - name: name
+        type: string
+        required: false
+        default: "'useCustomHookOptions'"
+        description: Name of the exported hook used to customize the hook options.
+  - name: parser
+    type: "'client' | 'zod'"
+    required: false
+    default: "'client'"
+    description: Which parser to use before returning the data to @tanstack/query. 'zod' uses @kubb/plugin-zod.
+  - name: transformers
+    type: "{ name?: (name: string, type?: string) => string }"
+    required: false
+    description: Customize the generated names based on the type provided by the plugin.
+  - name: resolver
+    type: "Partial<ResolverReactQuery>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied to each node before printing.
+  - name: generators
+    type: "Array<Generator<PluginReactQuery>>"
+    required: false
+    description: Define additional generators next to the react-query generators.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
+  import { pluginReactQuery } from '@kubb/plugin-react-query'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs(),
+      pluginClient(),
+      pluginReactQuery({
+        output: { path: 'hooks', barrelType: 'named' },
+        client: { client: 'axios', dataReturnType: 'data' },
+        paramsCasing: 'camelcase',
+        paramsType: 'inline',
+        query: { methods: ['get'] },
+        mutation: { methods: ['post', 'put', 'delete'] },
+        infinite: { queryParam: 'page', initialPageParam: 0 },
+      }),
+    ],
+  })

--- a/plugins/plugin-react-query.yaml
+++ b/plugins/plugin-react-query.yaml
@@ -1,0 +1,27 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-react-query
+name: React Query
+description: Generate React Query hooks (useQuery, useMutation) from OpenAPI specifications for type-safe data fetching in React applications.
+category: framework
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-react-query"
+docsPath: /plugins/plugin-react-query
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - react-query
+  - tanstack-query
+  - react
+  - hooks
+  - data-fetching
+  - codegen
+  - openapi
+dependencies:
+  - plugin-ts
+  - plugin-client

--- a/plugins/plugin-redoc.yaml
+++ b/plugins/plugin-redoc.yaml
@@ -22,3 +22,36 @@ tags:
   - codegen
   - openapi
 dependencies: []
+resources:
+  documentation: https://kubb.dev/plugins/plugin-redoc
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-redoc/CHANGELOG.md
+icon: 📖
+featured: false
+skills: []
+options:
+  - name: output
+    type: "{ path: string }"
+    required: false
+    description: Specify the output path for the generated documentation HTML file.
+    properties:
+      - name: path
+        type: string
+        required: true
+        default: "'docs.html'"
+        description: Output path for the generated Redoc documentation HTML file.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginRedoc } from '@kubb/plugin-redoc'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginRedoc({
+        output: { path: 'docs.html' },
+      }),
+    ],
+  })

--- a/plugins/plugin-redoc.yaml
+++ b/plugins/plugin-redoc.yaml
@@ -1,0 +1,24 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-redoc
+name: Redoc
+description: Generate beautiful, interactive API documentation using Redoc from OpenAPI specifications.
+category: documentation
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-redoc"
+docsPath: /plugins/plugin-redoc
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - redoc
+  - api-docs
+  - documentation
+  - interactive-docs
+  - codegen
+  - openapi
+dependencies: []

--- a/plugins/plugin-redoc.yaml
+++ b/plugins/plugin-redoc.yaml
@@ -42,7 +42,7 @@ options:
         default: "'docs.html'"
         description: Output path for the generated Redoc documentation HTML file.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginRedoc } from '@kubb/plugin-redoc'
 

--- a/plugins/plugin-ts.yaml
+++ b/plugins/plugin-ts.yaml
@@ -21,3 +21,117 @@ tags:
   - codegen
   - openapi
 dependencies: []
+resources:
+  documentation: https://kubb.dev/plugins/plugin-ts
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-ts/CHANGELOG.md
+icon: 🔷
+featured: true
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'types', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: group
+    type: Group
+    required: false
+    description: Group the generated types based on the provided name (e.g. by tag).
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: syntaxType
+    type: "'type' | 'interface'"
+    required: false
+    default: "'type'"
+    description: Switch between type alias or interface for creating TypeScript types.
+  - name: optionalType
+    type: "'questionToken' | 'undefined' | 'questionTokenAndUndefined'"
+    required: false
+    default: "'questionToken'"
+    description: Choose what to use as mode for an optional value.
+  - name: arrayType
+    type: "'generic' | 'array'"
+    required: false
+    default: "'array'"
+    description: "Choose between Array<string> or string[] for array types."
+  - name: enumType
+    type: "'asConst' | 'asPascalConst' | 'enum' | 'constEnum' | 'literal' | 'inlineLiteral'"
+    required: false
+    default: "'asConst'"
+    description: Choose how enums are generated. asConst/asPascalConst emit const objects, enum/constEnum emit TypeScript enums, literal/inlineLiteral emit union literals.
+  - name: enumTypeSuffix
+    type: string
+    required: false
+    default: "'Key'"
+    description: Suffix appended to the generated type alias name for asConst/asPascalConst enum types.
+  - name: enumKeyCasing
+    type: "'screamingSnakeCase' | 'snakeCase' | 'pascalCase' | 'camelCase' | 'none'"
+    required: false
+    default: "'none'"
+    description: Choose the casing for enum key names. Only applies to asConst, asPascalConst, enum, and constEnum types.
+  - name: contentType
+    type: "'application/json' | string"
+    required: false
+    description: Define which contentType should be used. By default uses the first valid JSON media type.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: generators
+    type: "Array<Generator<PluginTs>>"
+    required: false
+    description: Define additional generators next to the TypeScript generators.
+  - name: resolver
+    type: "Partial<ResolverTs>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: AST visitor applied to each schema/operation node before printing.
+  - name: printer
+    type: "{ nodes?: PrinterTsNodes }"
+    required: false
+    description: Override individual printer node handlers to customize rendering of specific schema types.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs({
+        output: { path: 'types', barrelType: 'named' },
+        syntaxType: 'type',
+        enumType: 'asConst',
+        enumKeyCasing: 'none',
+        optionalType: 'questionToken',
+        arrayType: 'array',
+        paramsCasing: 'camelcase',
+      }),
+    ],
+  })

--- a/plugins/plugin-ts.yaml
+++ b/plugins/plugin-ts.yaml
@@ -116,7 +116,7 @@ options:
     required: false
     description: Override individual printer node handlers to customize rendering of specific schema types.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
 

--- a/plugins/plugin-ts.yaml
+++ b/plugins/plugin-ts.yaml
@@ -1,0 +1,23 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-ts
+name: TypeScript
+description: Generate TypeScript types and interfaces from OpenAPI schemas with type-safe representations.
+category: utility
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-ts"
+docsPath: /plugins/plugin-ts
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - typescript
+  - types
+  - interfaces
+  - codegen
+  - openapi
+dependencies: []

--- a/plugins/plugin-vue-query.yaml
+++ b/plugins/plugin-vue-query.yaml
@@ -1,0 +1,27 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-vue-query
+name: Vue Query
+description: Generate Vue Query composables from OpenAPI specifications for type-safe data fetching in Vue.js applications.
+category: framework
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-vue-query"
+docsPath: /plugins/plugin-vue-query
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - vue-query
+  - tanstack-query
+  - vue
+  - composables
+  - data-fetching
+  - codegen
+  - openapi
+dependencies:
+  - plugin-ts
+  - plugin-client

--- a/plugins/plugin-vue-query.yaml
+++ b/plugins/plugin-vue-query.yaml
@@ -195,7 +195,7 @@ options:
     required: false
     description: Define additional generators next to the vue-query generators.
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginTs } from '@kubb/plugin-ts'
   import { pluginClient } from '@kubb/plugin-client'

--- a/plugins/plugin-vue-query.yaml
+++ b/plugins/plugin-vue-query.yaml
@@ -25,3 +25,195 @@ tags:
 dependencies:
   - plugin-ts
   - plugin-client
+resources:
+  documentation: https://kubb.dev/plugins/plugin-vue-query
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-vue-query/CHANGELOG.md
+icon: 💚
+featured: false
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'hooks', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: group
+    type: Group
+    required: false
+    description: Group the composables based on the provided name (e.g. by tag).
+  - name: client
+    type: "ClientImportPath & { clientType?, dataReturnType?, baseURL?, bundle?, paramsCasing? }"
+    required: false
+    description: Client configuration for HTTP request generation.
+    properties:
+      - name: client
+        type: "'axios' | 'fetch'"
+        required: false
+        default: "'axios'"
+        description: Which HTTP client preset to use.
+      - name: importPath
+        type: string
+        required: false
+        description: Custom client import path. Mutually exclusive with client.
+      - name: clientType
+        type: "'function' | 'class' | 'staticClass'"
+        required: false
+        default: "'function'"
+        description: How to generate the client code.
+      - name: dataReturnType
+        type: "'data' | 'full'"
+        required: false
+        default: "'data'"
+        description: Return type when calling the client.
+      - name: baseURL
+        type: string
+        required: false
+        description: Custom base URL for all generated calls.
+      - name: bundle
+        type: boolean
+        required: false
+        default: "false"
+        description: Bundle the selected client into the generated .kubb directory.
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: paramsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How to pass your params. 'object' merges all params into a single object, 'inline' uses separate arguments.
+  - name: pathParamsType
+    type: "'object' | 'inline'"
+    required: false
+    default: "'inline'"
+    description: How path parameters are arranged within the inline argument list. Only applies when paramsType is 'inline'.
+  - name: infinite
+    type: "Partial<Infinite> | false"
+    required: false
+    description: When set, an infiniteQuery composable is added.
+    properties:
+      - name: queryParam
+        type: string
+        required: true
+        default: "'id'"
+        description: Specify the params key used for pageParam.
+      - name: initialPageParam
+        type: unknown
+        required: true
+        default: "0"
+        description: The initial value of the first page.
+      - name: nextParam
+        type: "string | string[] | undefined"
+        required: false
+        description: Which field of the data is used to get the cursor for the next page.
+      - name: previousParam
+        type: "string | string[] | undefined"
+        required: false
+        description: Which field of the data is used to get the cursor for the previous page.
+  - name: query
+    type: "Partial<Query> | false"
+    required: false
+    description: Override some useQuery behaviors.
+    properties:
+      - name: methods
+        type: "Array<string>"
+        required: false
+        default: "['get']"
+        description: Define which HTTP methods can be used for queries.
+      - name: importPath
+        type: string
+        required: false
+        default: "'@tanstack/vue-query'"
+        description: Path to the useQuery composable import.
+  - name: mutation
+    type: "Partial<Mutation> | false"
+    required: false
+    description: Override some useMutation behaviors.
+    properties:
+      - name: methods
+        type: "Array<string>"
+        required: false
+        default: "['post', 'put', 'delete']"
+        description: Define which HTTP methods can be used for mutations.
+      - name: importPath
+        type: string
+        required: false
+        default: "'@tanstack/vue-query'"
+        description: Path to the useMutation composable import.
+  - name: queryKey
+    type: QueryKey
+    required: false
+    description: Customize the queryKey transformer.
+  - name: mutationKey
+    type: MutationKey
+    required: false
+    description: Customize the mutationKey transformer.
+  - name: parser
+    type: "'client' | 'zod'"
+    required: false
+    default: "'client'"
+    description: Which parser to use before returning the data to @tanstack/query. 'zod' uses @kubb/plugin-zod.
+  - name: transformers
+    type: "{ name?: (name: string, type?: string) => string }"
+    required: false
+    description: Customize the generated names based on the type provided by the plugin.
+  - name: resolver
+    type: "Partial<ResolverVueQuery>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied to each node before printing.
+  - name: generators
+    type: "Array<Generator<PluginVueQuery>>"
+    required: false
+    description: Define additional generators next to the vue-query generators.
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
+  import { pluginVueQuery } from '@kubb/plugin-vue-query'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginTs(),
+      pluginClient(),
+      pluginVueQuery({
+        output: { path: 'hooks', barrelType: 'named' },
+        client: { client: 'axios', dataReturnType: 'data' },
+        paramsCasing: 'camelcase',
+        paramsType: 'inline',
+        query: { methods: ['get'] },
+        mutation: { methods: ['post', 'put', 'delete'] },
+      }),
+    ],
+  })

--- a/plugins/plugin-zod.yaml
+++ b/plugins/plugin-zod.yaml
@@ -22,3 +22,124 @@ tags:
   - codegen
   - openapi
 dependencies: []
+resources:
+  documentation: https://kubb.dev/plugins/plugin-zod
+  repository: https://github.com/kubb-labs/plugins
+  issues: https://github.com/kubb-labs/plugins/issues
+  changelog: https://github.com/kubb-labs/plugins/blob/main/packages/plugin-zod/CHANGELOG.md
+icon: 🛡️
+featured: true
+skills: []
+options:
+  - name: output
+    type: Output
+    required: false
+    default: "{ path: 'zod', barrelType: 'named' }"
+    description: Specify the export location for the files and define the behavior of the output.
+    properties:
+      - name: path
+        type: string
+        required: true
+        description: Output directory for generated files, relative to the global output path.
+      - name: barrelType
+        type: "'all' | 'named' | 'propagate' | false"
+        required: false
+        default: "'named'"
+        description: Controls how index.ts barrel files are generated.
+  - name: group
+    type: Group
+    required: false
+    description: Group the Zod schemas based on the provided name (e.g. by tag).
+  - name: exclude
+    type: "Array<Exclude>"
+    required: false
+    description: Array containing exclude parameters to skip tags/operations/methods/paths.
+  - name: include
+    type: "Array<Include>"
+    required: false
+    description: Array containing include parameters to include tags/operations/methods/paths.
+  - name: override
+    type: "Array<Override>"
+    required: false
+    description: Array containing override parameters to override options based on tags/operations/methods/paths.
+  - name: importPath
+    type: "'zod' | 'zod/mini' | string"
+    required: false
+    default: "'zod'"
+    description: Path to Zod, used as `import { z } from '${importPath}'`. Use 'zod/mini' for the functional API.
+  - name: dateType
+    type: "false | 'string' | 'stringOffset' | 'stringLocal' | 'date'"
+    required: false
+    default: "'string'"
+    description: Choose how date/datetime values are represented. 'string' uses z.string().datetime(), 'date' uses z.date().
+  - name: typed
+    type: boolean
+    required: false
+    description: Use TypeScript (@kubb/plugin-ts) to add type annotation to generated schemas.
+  - name: inferred
+    type: boolean
+    required: false
+    description: Return Zod generated schema as type with z.infer<TYPE>.
+  - name: coercion
+    type: "boolean | { dates?: boolean; strings?: boolean; numbers?: boolean }"
+    required: false
+    description: Use z.coerce.string() instead of z.string(). Can be an object to enable coercion selectively.
+  - name: operations
+    type: boolean
+    required: false
+    description: Generate operation-level schemas grouped by operationId.
+  - name: guidType
+    type: "'uuid' | 'guid'"
+    required: false
+    default: "'uuid'"
+    description: Which Zod GUID validator to use for OpenAPI format uuid.
+  - name: mini
+    type: boolean
+    required: false
+    default: "false"
+    description: Use Zod Mini's functional API for better tree-shaking. When true, importPath defaults to 'zod/mini'.
+  - name: paramsCasing
+    type: "'camelcase'"
+    required: false
+    description: Transform parameter names to camelCase for path, query, and header params.
+  - name: generators
+    type: "Array<Generator<PluginZod>>"
+    required: false
+    description: Define additional generators next to the Zod generators.
+  - name: resolver
+    type: "Partial<ResolverZod>"
+    required: false
+    description: Override individual resolver methods to customize naming conventions.
+  - name: printer
+    type: "{ nodes?: PrinterZodNodes | PrinterZodMiniNodes }"
+    required: false
+    description: Override individual printer node handlers to customize rendering of specific schema types.
+  - name: transformer
+    type: ast.Visitor
+    required: false
+    description: Single AST visitor applied to each schema/operation node before printing.
+  - name: wrapOutput
+    type: "(arg: { output: string; schema: ast.SchemaNode }) => string | undefined"
+    required: false
+    description: Callback function to wrap the output of the generated zod schema (e.g. adding .openapi() metadata).
+fullExample: |
+  import { defineConfig } from '@kubb/core'
+  import { adapterOas } from '@kubb/adapter-oas'
+  import { pluginZod } from '@kubb/plugin-zod'
+
+  export default defineConfig({
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
+    plugins: [
+      pluginZod({
+        output: { path: 'zod', barrelType: 'named' },
+        importPath: 'zod',
+        dateType: 'string',
+        typed: true,
+        coercion: false,
+        guidType: 'uuid',
+        mini: false,
+        paramsCasing: 'camelcase',
+      }),
+    ],
+  })

--- a/plugins/plugin-zod.yaml
+++ b/plugins/plugin-zod.yaml
@@ -1,0 +1,24 @@
+$schema: "https://raw.githubusercontent.com/kubb-labs/kubb/main/schemas/plugins/plugin.json"
+id: plugin-zod
+name: Zod
+description: Generate Zod validation schemas from OpenAPI specifications for runtime data validation.
+category: utility
+type: official
+version: 5.0.0-alpha.51
+npmPackage: "@kubb/plugin-zod"
+docsPath: /plugins/plugin-zod
+repo: https://github.com/kubb-labs/plugins
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: ">=5.0.0"
+  node: ">=22"
+tags:
+  - zod
+  - validation
+  - schema
+  - runtime-validation
+  - codegen
+  - openapi
+dependencies: []

--- a/plugins/plugin-zod.yaml
+++ b/plugins/plugin-zod.yaml
@@ -123,7 +123,7 @@ options:
     required: false
     description: Callback function to wrap the output of the generated zod schema (e.g. adding .openapi() metadata).
 fullExample: |
-  import { defineConfig } from '@kubb/core'
+  import { defineConfig } from 'kubb'
   import { adapterOas } from '@kubb/adapter-oas'
   import { pluginZod } from '@kubb/plugin-zod'
 


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).