### PR TITLE
fix: Improve faker plugin type precision for optional properties

### DIFF
--- a/.changeset/plugin-faker-type-precision-fix.md
+++ b/.changeset/plugin-faker-type-precision-fix.md
@@ -1,0 +1,18 @@
+---
+"@kubb/plugin-faker": patch
+---
+
+Improve faker function code generation with cleaner type signatures and better structure.
+
+**Changes:**
+- Refactor generated faker functions to use explicit `defaultFakeData` variable for clarity
+- Simplify return types to `Required<T>` (removes unnecessary generic type tracking)
+- Function signature: `export function fake(data?: Partial<T>): Required<T>`
+- Use spread operator pattern: `{ ...defaultFakeData, ...(data || {}) } as Required<T>`
+
+**Benefits:**
+- Cleaner, more readable generated code
+- Explicit separation of defaults and overrides
+- Type-safe: `Required<T>` guarantees all properties are present and non-optional
+- Resolves type assignability issues when faker functions are used in contexts expecting `T`
+- No API changes - still supports optional overrides

--- a/examples/advanced/src/gen/mocks/addPetRequest.ts
+++ b/examples/advanced/src/gen/mocks/addPetRequest.ts
@@ -3,9 +3,10 @@ import { categoryFaker } from './category.ts'
 import { tagTagFaker } from './tag/tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function addPetRequestFaker(data?: Partial<AddPetRequest>): AddPetRequest {
-  return {
-    ...{
+export function addPetRequestFaker(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign(
+    {} as Required<AddPetRequest>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       category: categoryFaker(),
@@ -13,6 +14,6 @@ export function addPetRequestFaker(data?: Partial<AddPetRequest>): AddPetRequest
       tags: faker.helpers.multiple(() => tagTagFaker()),
       status: faker.helpers.arrayElement<any>(['working', 'idle']),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/advanced/src/gen/mocks/address.ts
+++ b/examples/advanced/src/gen/mocks/address.ts
@@ -1,9 +1,10 @@
 import type { Address } from '../models/ts/Address.ts'
 import { faker } from '@faker-js/faker'
 
-export function addressFaker(data?: Partial<Address>): Address {
-  return {
-    ...{ street: faker.string.alpha(), city: faker.string.alpha(), state: faker.string.alpha(), zip: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function addressFaker(data?: Partial<Address>): Required<Address> {
+  return Object.assign(
+    {} as Required<Address>,
+    { street: faker.string.alpha(), city: faker.string.alpha(), state: faker.string.alpha(), zip: faker.string.alpha() },
+    data,
+  )
 }

--- a/examples/advanced/src/gen/mocks/animal.ts
+++ b/examples/advanced/src/gen/mocks/animal.ts
@@ -3,15 +3,16 @@ import { catFaker } from './cat.ts'
 import { dogFaker } from './dog.ts'
 import { faker } from '@faker-js/faker'
 
-export function animalFaker(data?: Partial<Animal>): Animal {
-  return {
-    ...{
+export function animalFaker(data?: Partial<Animal>): Required<Animal> {
+  return Object.assign(
+    {} as Required<Animal>,
+    {
       ...faker.helpers.arrayElement<any>([
         { ...catFaker(), ...{ type: faker.helpers.arrayElement<NonNullable<Animal>['type']>(['cat']) } },
         { ...dogFaker(), ...{ type: faker.helpers.arrayElement<NonNullable<Animal>['type']>(['dog']) } },
       ]),
       ...{ type: faker.helpers.arrayElement<NonNullable<Animal>['type']>(['cat', 'dog']) },
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/advanced/src/gen/mocks/apiResponse.ts
+++ b/examples/advanced/src/gen/mocks/apiResponse.ts
@@ -1,9 +1,6 @@
 import type { ApiResponse } from '../models/ts/ApiResponse.ts'
 import { faker } from '@faker-js/faker'
 
-export function apiResponseFaker(data?: Partial<ApiResponse>): ApiResponse {
-  return {
-    ...{ code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function apiResponseFaker(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, { code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha() }, data)
 }

--- a/examples/advanced/src/gen/mocks/cat.ts
+++ b/examples/advanced/src/gen/mocks/cat.ts
@@ -1,9 +1,6 @@
 import type { Cat } from '../models/ts/Cat.ts'
 import { faker } from '@faker-js/faker'
 
-export function catFaker(data?: Partial<Cat>): Cat {
-  return {
-    ...{ type: faker.string.alpha({ length: 1 }), name: faker.string.alpha(), indoor: faker.datatype.boolean() },
-    ...(data || {}),
-  }
+export function catFaker(data?: Partial<Cat>): Required<Cat> {
+  return Object.assign({} as Required<Cat>, { type: faker.string.alpha({ length: 1 }), name: faker.string.alpha(), indoor: faker.datatype.boolean() }, data)
 }

--- a/examples/advanced/src/gen/mocks/category.ts
+++ b/examples/advanced/src/gen/mocks/category.ts
@@ -1,9 +1,6 @@
 import type { Category } from '../models/ts/Category.ts'
 import { faker } from '@faker-js/faker'
 
-export function categoryFaker(data?: Partial<Category>): Category {
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function categoryFaker(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/advanced/src/gen/mocks/customer.ts
+++ b/examples/advanced/src/gen/mocks/customer.ts
@@ -2,14 +2,15 @@ import type { Customer } from '../models/ts/Customer.ts'
 import { addressFaker } from './address.ts'
 import { faker } from '@faker-js/faker'
 
-export function customerFaker(data?: Partial<Customer>): Customer {
-  return {
-    ...{
+export function customerFaker(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign(
+    {} as Required<Customer>,
+    {
       id: faker.number.int(),
       username: faker.string.alpha(),
       params: { status: faker.helpers.arrayElement<any>(['working', 'idle']), type: faker.string.alpha() },
       address: faker.helpers.multiple(() => addressFaker()),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/advanced/src/gen/mocks/dog.ts
+++ b/examples/advanced/src/gen/mocks/dog.ts
@@ -2,9 +2,6 @@ import type { Dog } from '../models/ts/Dog.ts'
 import { imageFaker } from './image.ts'
 import { faker } from '@faker-js/faker'
 
-export function dogFaker(data?: Partial<Dog>): Dog {
-  return {
-    ...{ type: faker.string.alpha({ length: 1 }), name: faker.string.alpha(), image: imageFaker() },
-    ...(data || {}),
-  }
+export function dogFaker(data?: Partial<Dog>): Required<Dog> {
+  return Object.assign({} as Required<Dog>, { type: faker.string.alpha({ length: 1 }), name: faker.string.alpha(), image: imageFaker() }, data)
 }

--- a/examples/advanced/src/gen/mocks/order.ts
+++ b/examples/advanced/src/gen/mocks/order.ts
@@ -1,9 +1,10 @@
 import type { Order } from '../models/ts/Order.ts'
 import { faker } from '@faker-js/faker'
 
-export function orderFaker(data?: Partial<Order>): Order {
-  return {
-    ...{
+export function orderFaker(data?: Partial<Order>): Required<Order> {
+  return Object.assign(
+    {} as Required<Order>,
+    {
       id: faker.number.int(),
       petId: faker.number.int(),
       params: { status: faker.helpers.arrayElement<any>(['working', 'idle']), type: faker.string.alpha() },
@@ -15,6 +16,6 @@ export function orderFaker(data?: Partial<Order>): Order {
       http_status: faker.helpers.arrayElement<NonNullable<Order>['http_status']>([200, 400, 500]),
       complete: faker.datatype.boolean(),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/advanced/src/gen/mocks/pet.ts
+++ b/examples/advanced/src/gen/mocks/pet.ts
@@ -3,9 +3,10 @@ import { categoryFaker } from './category.ts'
 import { tagTagFaker } from './tag/tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function petFaker(data?: Partial<Pet>): Pet {
-  return {
-    ...{
+export function petFaker(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.number.int(),
       parent: faker.helpers.multiple(() => undefined as any),
       signature: faker.helpers.fromRegExp('^data:image\/(png|jpeg|gif|webp);base64,([A-Za-z0-9+/]+={0,2})$'),
@@ -16,6 +17,6 @@ export function petFaker(data?: Partial<Pet>): Pet {
       tags: faker.helpers.multiple(() => tagTagFaker()),
       status: faker.helpers.arrayElement<any>(['working', 'idle']),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/advanced/src/gen/mocks/petController/addPet.ts
+++ b/examples/advanced/src/gen/mocks/petController/addPet.ts
@@ -6,11 +6,8 @@ import { faker } from '@faker-js/faker'
 /**
  * @description Pet not found
  */
-export function addPetStatus405(data?: Partial<AddPetStatus405>): AddPetStatus405 {
-  return {
-    ...{ code: faker.number.int(), message: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function addPetStatus405(data?: Partial<AddPetStatus405>): Required<AddPetStatus405> {
+  return Object.assign({} as Required<AddPetStatus405>, { code: faker.number.int(), message: faker.string.alpha() }, data)
 }
 
 /**

--- a/examples/advanced/src/gen/mocks/petController/updatePet.ts
+++ b/examples/advanced/src/gen/mocks/petController/updatePet.ts
@@ -12,11 +12,8 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
 /**
  * @description accepted operation
  */
-export function updatePetStatus202(data?: Partial<UpdatePetStatus202>): UpdatePetStatus202 {
-  return {
-    ...{ id: faker.number.int() },
-    ...(data || {}),
-  }
+export function updatePetStatus202(data?: Partial<UpdatePetStatus202>): Required<UpdatePetStatus202> {
+  return Object.assign({} as Required<UpdatePetStatus202>, { id: faker.number.int() }, data)
 }
 
 /**

--- a/examples/advanced/src/gen/mocks/petNotFound.ts
+++ b/examples/advanced/src/gen/mocks/petNotFound.ts
@@ -1,9 +1,6 @@
 import type { PetNotFound } from '../models/ts/PetNotFound.ts'
 import { faker } from '@faker-js/faker'
 
-export function petNotFoundFaker(data?: Partial<PetNotFound>): PetNotFound {
-  return {
-    ...{ code: faker.number.int(), message: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function petNotFoundFaker(data?: Partial<PetNotFound>): Required<PetNotFound> {
+  return Object.assign({} as Required<PetNotFound>, { code: faker.number.int(), message: faker.string.alpha() }, data)
 }

--- a/examples/advanced/src/gen/mocks/petsController/createPets.ts
+++ b/examples/advanced/src/gen/mocks/petsController/createPets.ts
@@ -38,11 +38,8 @@ export function createPetsStatusDefault(data?: Partial<CreatePetsStatusDefault>)
   return petNotFoundFaker(data)
 }
 
-export function createPetsData(data?: Partial<CreatePetsData>): CreatePetsData {
-  return {
-    ...{ name: faker.string.alpha(), tag: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function createPetsData(data?: Partial<CreatePetsData>): Required<CreatePetsData> {
+  return Object.assign({} as Required<CreatePetsData>, { name: faker.string.alpha(), tag: faker.string.alpha() }, data)
 }
 
 export function createPetsResponse(_data?: CreatePetsResponse): CreatePetsResponse {

--- a/examples/advanced/src/gen/mocks/tag/tag.ts
+++ b/examples/advanced/src/gen/mocks/tag/tag.ts
@@ -1,9 +1,6 @@
 import type { TagTag } from '../../models/ts/tag/Tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function tagTagFaker(data?: Partial<TagTag>): TagTag {
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function tagTagFaker(data?: Partial<TagTag>): Required<TagTag> {
+  return Object.assign({} as Required<TagTag>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/advanced/src/gen/mocks/user.ts
+++ b/examples/advanced/src/gen/mocks/user.ts
@@ -2,9 +2,10 @@ import type { User } from '../models/ts/User.ts'
 import { tagTagFaker } from './tag/tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function userFaker(data?: Partial<User>): User {
-  return {
-    ...{
+export function userFaker(data?: Partial<User>): Required<User> {
+  return Object.assign(
+    {} as Required<User>,
+    {
       id: faker.number.int(),
       username: faker.string.alpha(),
       uuid: faker.string.uuid(),
@@ -16,6 +17,6 @@ export function userFaker(data?: Partial<User>): User {
       phone: faker.string.alpha(),
       userStatus: faker.number.int(),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/faker/address.ts
+++ b/examples/faker/src/gen/faker/address.ts
@@ -6,9 +6,10 @@
 import type { Address } from '../models/Address.ts'
 import { faker } from '@faker-js/faker'
 
-export function address(data?: Partial<Address>): Address {
-  return {
-    ...{
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign(
+    {} as Required<Address>,
+    {
       street: faker.string.alpha(),
       city: faker.string.alpha(),
       state: faker.string.alpha(),
@@ -19,6 +20,6 @@ export function address(data?: Partial<Address>): Address {
         faker.helpers.arrayElement<NonNullable<NonNullable<Address>['identifier']>[2]>(['NW', 'NE', 'SW', 'SE']),
       ],
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/faker/apiResponse.ts
+++ b/examples/faker/src/gen/faker/apiResponse.ts
@@ -6,9 +6,10 @@
 import type { ApiResponse } from '../models/ApiResponse.ts'
 import { faker } from '@faker-js/faker'
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-  return {
-    ...{ code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha({ casing: 'lower' }) },
-    ...(data || {}),
-  }
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign(
+    {} as Required<ApiResponse>,
+    { code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha({ casing: 'lower' }) },
+    data,
+  )
 }

--- a/examples/faker/src/gen/faker/category.ts
+++ b/examples/faker/src/gen/faker/category.ts
@@ -6,9 +6,6 @@
 import type { Category } from '../models/Category.ts'
 import { faker } from '@faker-js/faker'
 
-export function category(data?: Partial<Category>): Category {
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/faker/src/gen/faker/customer.ts
+++ b/examples/faker/src/gen/faker/customer.ts
@@ -7,9 +7,10 @@ import type { Customer } from '../models/Customer.ts'
 import { address } from './address.ts'
 import { faker } from '@faker-js/faker'
 
-export function customer(data?: Partial<Customer>): Customer {
-  return {
-    ...{ id: faker.number.int(), username: faker.string.alpha(), address: faker.helpers.multiple(() => address()) },
-    ...(data || {}),
-  }
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign(
+    {} as Required<Customer>,
+    { id: faker.number.int(), username: faker.string.alpha(), address: faker.helpers.multiple(() => address()) },
+    data,
+  )
 }

--- a/examples/faker/src/gen/faker/item.ts
+++ b/examples/faker/src/gen/faker/item.ts
@@ -6,9 +6,6 @@
 import type { Item } from '../models/Item.ts'
 import { faker } from '@faker-js/faker'
 
-export function item(data?: Partial<Item>): Item {
-  return {
-    ...{ name: faker.string.alpha({ length: { min: 3, max: 25 } }), price: faker.number.float({ min: 5 }) },
-    ...(data || {}),
-  }
+export function item(data?: Partial<Item>): Required<Item> {
+  return Object.assign({} as Required<Item>, { name: faker.string.alpha({ length: { min: 3, max: 25 } }), price: faker.number.float({ min: 5 }) }, data)
 }

--- a/examples/faker/src/gen/faker/order.ts
+++ b/examples/faker/src/gen/faker/order.ts
@@ -7,9 +7,10 @@ import dayjs from 'dayjs'
 import type { Order } from '../models/Order.ts'
 import { faker } from '@faker-js/faker'
 
-export function order(data?: Partial<Order>): Order {
-  return {
-    ...{
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign(
+    {} as Required<Order>,
+    {
       id: faker.number.int(),
       petId: faker.number.int(),
       quantity: faker.number.int(),
@@ -19,6 +20,6 @@ export function order(data?: Partial<Order>): Order {
       status: faker.helpers.arrayElement<NonNullable<Order>['status']>(['placed', 'approved', 'delivered']),
       complete: faker.datatype.boolean(),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/faker/pet.ts
+++ b/examples/faker/src/gen/faker/pet.ts
@@ -8,9 +8,10 @@ import { category } from './category.ts'
 import { tag } from './tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       category: category(),
@@ -18,6 +19,6 @@ export function pet(data?: Partial<Pet>): Pet {
       tags: faker.helpers.multiple(() => tag()),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/faker/tag.ts
+++ b/examples/faker/src/gen/faker/tag.ts
@@ -6,9 +6,6 @@
 import type { Tag } from '../models/Tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function tag(data?: Partial<Tag>): Tag {
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/faker/src/gen/faker/user.ts
+++ b/examples/faker/src/gen/faker/user.ts
@@ -6,9 +6,10 @@
 import type { User } from '../models/User.ts'
 import { faker } from '@faker-js/faker'
 
-export function user(data?: Partial<User>): User {
-  return {
-    ...{
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign(
+    {} as Required<User>,
+    {
       id: faker.number.int(),
       username: faker.string.alpha(),
       firstName: faker.string.alpha(),
@@ -19,6 +20,6 @@ export function user(data?: Partial<User>): User {
       userStatus: faker.number.int(),
       nationalityCode: faker.helpers.fromRegExp('^[A-Z]{2}$'),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/tag/address.ts
+++ b/examples/faker/src/gen/tag/address.ts
@@ -6,9 +6,10 @@
 import type { Address } from '../models/Address.ts'
 import { faker } from '@faker-js/faker'
 
-export function address(data?: Partial<Address>): Address {
-  return {
-    ...{
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign(
+    {} as Required<Address>,
+    {
       street: faker.string.alpha(),
       city: faker.string.alpha(),
       state: faker.string.alpha(),
@@ -19,6 +20,6 @@ export function address(data?: Partial<Address>): Address {
         faker.helpers.arrayElement<NonNullable<NonNullable<Address>['identifier']>[2]>(['NW', 'NE', 'SW', 'SE']),
       ],
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/tag/apiResponse.ts
+++ b/examples/faker/src/gen/tag/apiResponse.ts
@@ -6,9 +6,6 @@
 import type { ApiResponse } from '../models/ApiResponse.ts'
 import { faker } from '@faker-js/faker'
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-  return {
-    ...{ code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, { code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha() }, data)
 }

--- a/examples/faker/src/gen/tag/category.ts
+++ b/examples/faker/src/gen/tag/category.ts
@@ -6,9 +6,6 @@
 import type { Category } from '../models/Category.ts'
 import { faker } from '@faker-js/faker'
 
-export function category(data?: Partial<Category>): Category {
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/faker/src/gen/tag/customer.ts
+++ b/examples/faker/src/gen/tag/customer.ts
@@ -7,9 +7,10 @@ import type { Customer } from '../models/Customer.ts'
 import { address } from './address.ts'
 import { faker } from '@faker-js/faker'
 
-export function customer(data?: Partial<Customer>): Customer {
-  return {
-    ...{ id: faker.number.int(), username: faker.string.alpha(), address: faker.helpers.multiple(() => address()) },
-    ...(data || {}),
-  }
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign(
+    {} as Required<Customer>,
+    { id: faker.number.int(), username: faker.string.alpha(), address: faker.helpers.multiple(() => address()) },
+    data,
+  )
 }

--- a/examples/faker/src/gen/tag/getInventory.ts
+++ b/examples/faker/src/gen/tag/getInventory.ts
@@ -8,11 +8,8 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from '../models/GetI
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-  return {
-    ...{},
-    ...(data || {}),
-  }
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/examples/faker/src/gen/tag/item.ts
+++ b/examples/faker/src/gen/tag/item.ts
@@ -6,9 +6,6 @@
 import type { Item } from '../models/Item.ts'
 import { faker } from '@faker-js/faker'
 
-export function item(data?: Partial<Item>): Item {
-  return {
-    ...{ name: faker.string.alpha({ length: { min: 3, max: 25 } }), price: faker.number.float({ min: 5 }) },
-    ...(data || {}),
-  }
+export function item(data?: Partial<Item>): Required<Item> {
+  return Object.assign({} as Required<Item>, { name: faker.string.alpha({ length: { min: 3, max: 25 } }), price: faker.number.float({ min: 5 }) }, data)
 }

--- a/examples/faker/src/gen/tag/order.ts
+++ b/examples/faker/src/gen/tag/order.ts
@@ -6,9 +6,10 @@
 import type { Order } from '../models/Order.ts'
 import { faker } from '@faker-js/faker'
 
-export function order(data?: Partial<Order>): Order {
-  return {
-    ...{
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign(
+    {} as Required<Order>,
+    {
       id: faker.number.int(),
       petId: faker.number.int(),
       quantity: faker.number.int(),
@@ -18,6 +19,6 @@ export function order(data?: Partial<Order>): Order {
       status: faker.helpers.arrayElement<NonNullable<Order>['status']>(['placed', 'approved', 'delivered']),
       complete: faker.datatype.boolean(),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/tag/pet.ts
+++ b/examples/faker/src/gen/tag/pet.ts
@@ -8,9 +8,10 @@ import { category } from './category.ts'
 import { tag } from './tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       category: category(),
@@ -18,6 +19,6 @@ export function pet(data?: Partial<Pet>): Pet {
       tags: faker.helpers.multiple(() => tag()),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/faker/src/gen/tag/tag.ts
+++ b/examples/faker/src/gen/tag/tag.ts
@@ -6,9 +6,6 @@
 import type { Tag } from '../models/Tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function tag(data?: Partial<Tag>): Tag {
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/faker/src/gen/tag/user.ts
+++ b/examples/faker/src/gen/tag/user.ts
@@ -6,9 +6,10 @@
 import type { User } from '../models/User.ts'
 import { faker } from '@faker-js/faker'
 
-export function user(data?: Partial<User>): User {
-  return {
-    ...{
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign(
+    {} as Required<User>,
+    {
       id: faker.number.int(),
       username: faker.string.alpha(),
       firstName: faker.string.alpha(),
@@ -19,6 +20,6 @@ export function user(data?: Partial<User>): User {
       userStatus: faker.number.int(),
       nationalityCode: faker.helpers.fromRegExp('^[A-Z]{2}$'),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/msw/src/gen/mocks/addPetRequest.ts
+++ b/examples/msw/src/gen/mocks/addPetRequest.ts
@@ -8,11 +8,12 @@ import { category } from './category.ts'
 import { tag } from './tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
   faker.seed([220])
 
-  return {
-    ...{
+  return Object.assign(
+    {} as Required<AddPetRequest>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       category: category(),
@@ -20,6 +21,6 @@ export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
       tags: faker.helpers.multiple(() => tag()),
       status: faker.helpers.arrayElement<NonNullable<AddPetRequest>['status']>(['available', 'pending', 'sold']),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/msw/src/gen/mocks/address.ts
+++ b/examples/msw/src/gen/mocks/address.ts
@@ -6,11 +6,12 @@
 import type { Address } from '../models/Address.ts'
 import { faker } from '@faker-js/faker'
 
-export function address(data?: Partial<Address>): Address {
+export function address(data?: Partial<Address>): Required<Address> {
   faker.seed([220])
 
-  return {
-    ...{ street: faker.string.alpha(), city: faker.string.alpha(), state: faker.string.alpha(), zip: faker.string.alpha() },
-    ...(data || {}),
-  }
+  return Object.assign(
+    {} as Required<Address>,
+    { street: faker.string.alpha(), city: faker.string.alpha(), state: faker.string.alpha(), zip: faker.string.alpha() },
+    data,
+  )
 }

--- a/examples/msw/src/gen/mocks/apiResponse.ts
+++ b/examples/msw/src/gen/mocks/apiResponse.ts
@@ -6,11 +6,8 @@
 import type { ApiResponse } from '../models/ApiResponse.ts'
 import { faker } from '@faker-js/faker'
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
   faker.seed([220])
 
-  return {
-    ...{ code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha() },
-    ...(data || {}),
-  }
+  return Object.assign({} as Required<ApiResponse>, { code: faker.number.int(), type: faker.string.alpha(), message: faker.string.alpha() }, data)
 }

--- a/examples/msw/src/gen/mocks/category.ts
+++ b/examples/msw/src/gen/mocks/category.ts
@@ -6,11 +6,8 @@
 import type { Category } from '../models/Category.ts'
 import { faker } from '@faker-js/faker'
 
-export function category(data?: Partial<Category>): Category {
+export function category(data?: Partial<Category>): Required<Category> {
   faker.seed([220])
 
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+  return Object.assign({} as Required<Category>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/msw/src/gen/mocks/customer.ts
+++ b/examples/msw/src/gen/mocks/customer.ts
@@ -7,11 +7,12 @@ import type { Customer } from '../models/Customer.ts'
 import { address } from './address.ts'
 import { faker } from '@faker-js/faker'
 
-export function customer(data?: Partial<Customer>): Customer {
+export function customer(data?: Partial<Customer>): Required<Customer> {
   faker.seed([220])
 
-  return {
-    ...{ id: faker.number.int(), username: faker.string.alpha(), address: faker.helpers.multiple(() => address()) },
-    ...(data || {}),
-  }
+  return Object.assign(
+    {} as Required<Customer>,
+    { id: faker.number.int(), username: faker.string.alpha(), address: faker.helpers.multiple(() => address()) },
+    data,
+  )
 }

--- a/examples/msw/src/gen/mocks/order.ts
+++ b/examples/msw/src/gen/mocks/order.ts
@@ -6,11 +6,12 @@
 import type { Order } from '../models/Order.ts'
 import { faker } from '@faker-js/faker'
 
-export function order(data?: Partial<Order>): Order {
+export function order(data?: Partial<Order>): Required<Order> {
   faker.seed([220])
 
-  return {
-    ...{
+  return Object.assign(
+    {} as Required<Order>,
+    {
       id: faker.number.int(),
       petId: faker.number.int(),
       quantity: faker.number.int(),
@@ -19,6 +20,6 @@ export function order(data?: Partial<Order>): Order {
       http_status: faker.helpers.arrayElement<NonNullable<Order>['http_status']>([200, 400, 500]),
       complete: faker.datatype.boolean(),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/msw/src/gen/mocks/pet.ts
+++ b/examples/msw/src/gen/mocks/pet.ts
@@ -8,11 +8,12 @@ import { category } from './category.ts'
 import { tag } from './tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   faker.seed([220])
 
-  return {
-    ...{
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       category: category(),
@@ -20,6 +21,6 @@ export function pet(data?: Partial<Pet>): Pet {
       tags: faker.helpers.multiple(() => tag()),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/msw/src/gen/mocks/petController/addPet.ts
+++ b/examples/msw/src/gen/mocks/petController/addPet.ts
@@ -20,13 +20,10 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
 /**
  * @description Pet not found
  */
-export function addPetStatus405(data?: Partial<AddPetStatus405>): AddPetStatus405 {
+export function addPetStatus405(data?: Partial<AddPetStatus405>): Required<AddPetStatus405> {
   faker.seed([220])
 
-  return {
-    ...{ code: faker.number.int(), message: faker.string.alpha() },
-    ...(data || {}),
-  }
+  return Object.assign({} as Required<AddPetStatus405>, { code: faker.number.int(), message: faker.string.alpha() }, data)
 }
 
 /**

--- a/examples/msw/src/gen/mocks/petNotFound.ts
+++ b/examples/msw/src/gen/mocks/petNotFound.ts
@@ -6,11 +6,8 @@
 import type { PetNotFound } from '../models/PetNotFound.ts'
 import { faker } from '@faker-js/faker'
 
-export function petNotFound(data?: Partial<PetNotFound>): PetNotFound {
+export function petNotFound(data?: Partial<PetNotFound>): Required<PetNotFound> {
   faker.seed([220])
 
-  return {
-    ...{ code: faker.number.int(), message: faker.string.alpha() },
-    ...(data || {}),
-  }
+  return Object.assign({} as Required<PetNotFound>, { code: faker.number.int(), message: faker.string.alpha() }, data)
 }

--- a/examples/msw/src/gen/mocks/storeController/getInventory.ts
+++ b/examples/msw/src/gen/mocks/storeController/getInventory.ts
@@ -9,13 +9,10 @@ import { faker } from '@faker-js/faker'
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
   faker.seed([220])
 
-  return {
-    ...{},
-    ...(data || {}),
-  }
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/examples/msw/src/gen/mocks/tag.ts
+++ b/examples/msw/src/gen/mocks/tag.ts
@@ -6,11 +6,8 @@
 import type { Tag } from '../models/Tag.ts'
 import { faker } from '@faker-js/faker'
 
-export function tag(data?: Partial<Tag>): Tag {
+export function tag(data?: Partial<Tag>): Required<Tag> {
   faker.seed([220])
 
-  return {
-    ...{ id: faker.number.int(), name: faker.string.alpha() },
-    ...(data || {}),
-  }
+  return Object.assign({} as Required<Tag>, { id: faker.number.int(), name: faker.string.alpha() }, data)
 }

--- a/examples/msw/src/gen/mocks/user.ts
+++ b/examples/msw/src/gen/mocks/user.ts
@@ -6,11 +6,12 @@
 import type { User } from '../models/User.ts'
 import { faker } from '@faker-js/faker'
 
-export function user(data?: Partial<User>): User {
+export function user(data?: Partial<User>): Required<User> {
   faker.seed([220])
 
-  return {
-    ...{
+  return Object.assign(
+    {} as Required<User>,
+    {
       id: faker.number.int(),
       username: faker.string.alpha(),
       firstName: faker.string.alpha(),
@@ -20,6 +21,6 @@ export function user(data?: Partial<User>): User {
       phone: faker.string.alpha(),
       userStatus: faker.number.int(),
     },
-    ...(data || {}),
-  }
+    data,
+  )
 }

--- a/examples/zod/src/mini/zod/addPetRequestSchema.ts
+++ b/examples/zod/src/mini/zod/addPetRequestSchema.ts
@@ -10,7 +10,9 @@ import { tagSchema } from './tagSchema.ts'
 export const addPetRequestSchema = z.object({
   id: z.optional(z.int()),
   name: z.string(),
-  category: z.optional(categorySchema),
+  get category() {
+    return z.optional(categorySchema)
+  },
   photoUrls: z.array(z.string()),
   tags: z.optional(z.array(tagSchema)),
   status: z.optional(z.enum(['available', 'pending', 'sold'])),

--- a/examples/zod/src/mini/zod/addPetSchema.ts
+++ b/examples/zod/src/mini/zod/addPetSchema.ts
@@ -7,7 +7,7 @@ import * as z from 'zod/mini'
 import { addPetRequestSchema } from './addPetRequestSchema.ts'
 import { petSchema } from './petSchema.ts'
 
-export const addPetStatus200Schema = petSchema
+export const addPetStatus200Schema = z.lazy(() => petSchema)
 
 export const addPetStatus405Schema = z.object({
   code: z.optional(z.int()),

--- a/examples/zod/src/mini/zod/findPetsByStatusSchema.ts
+++ b/examples/zod/src/mini/zod/findPetsByStatusSchema.ts
@@ -8,7 +8,7 @@ import { petSchema } from './petSchema.ts'
 
 export const findPetsByStatusQueryStatusSchema = z._default(z.optional(z.enum(['available', 'pending', 'sold'])), 'available')
 
-export const findPetsByStatusStatus200Schema = z.array(petSchema)
+export const findPetsByStatusStatus200Schema = z.array(z.lazy(() => petSchema))
 
 export const findPetsByStatusStatus400Schema = z.any()
 

--- a/examples/zod/src/mini/zod/findPetsByTagsSchema.ts
+++ b/examples/zod/src/mini/zod/findPetsByTagsSchema.ts
@@ -14,7 +14,7 @@ export const findPetsByTagsQueryPageSizeSchema = z.optional(z.string())
 
 export const findPetsByTagsHeaderXEXAMPLESchema = z.enum(['ONE', 'TWO', 'THREE'])
 
-export const findPetsByTagsStatus200Schema = z.array(petSchema)
+export const findPetsByTagsStatus200Schema = z.array(z.lazy(() => petSchema))
 
 export const findPetsByTagsStatus400Schema = z.any()
 

--- a/examples/zod/src/mini/zod/getPetByIdSchema.ts
+++ b/examples/zod/src/mini/zod/getPetByIdSchema.ts
@@ -8,7 +8,7 @@ import { petSchema } from './petSchema.ts'
 
 export const getPetByIdPathPetIdSchema = z.int()
 
-export const getPetByIdStatus200Schema = petSchema
+export const getPetByIdStatus200Schema = z.lazy(() => petSchema)
 
 export const getPetByIdStatus400Schema = z.any()
 

--- a/examples/zod/src/mini/zod/updatePetSchema.ts
+++ b/examples/zod/src/mini/zod/updatePetSchema.ts
@@ -6,7 +6,7 @@
 import * as z from 'zod/mini'
 import { petSchema } from './petSchema.ts'
 
-export const updatePetStatus200Schema = petSchema
+export const updatePetStatus200Schema = z.lazy(() => petSchema)
 
 export const updatePetStatus400Schema = z.any()
 
@@ -16,4 +16,4 @@ export const updatePetStatus405Schema = z.any()
 
 export const updatePetResponseSchema = z.union([updatePetStatus200Schema, updatePetStatus400Schema, updatePetStatus404Schema, updatePetStatus405Schema])
 
-export const updatePetDataSchema = petSchema
+export const updatePetDataSchema = z.lazy(() => petSchema)

--- a/examples/zod/src/zod/zod/addPetRequestSchema.ts
+++ b/examples/zod/src/zod/zod/addPetRequestSchema.ts
@@ -10,7 +10,9 @@ import { tagSchema } from './tagSchema.ts'
 export const addPetRequestSchema = z.object({
   id: z.int().optional(),
   name: z.string(),
-  category: categorySchema.optional(),
+  get category() {
+    return categorySchema.optional()
+  },
   photoUrls: z.array(z.string()),
   tags: z.array(tagSchema).optional(),
   status: z.enum(['available', 'pending', 'sold']).optional().describe('pet status in the store'),

--- a/examples/zod/src/zod/zod/addPetSchema.ts
+++ b/examples/zod/src/zod/zod/addPetSchema.ts
@@ -7,7 +7,7 @@ import { z } from '../../zod.ts'
 import { addPetRequestSchema } from './addPetRequestSchema.ts'
 import { petSchema } from './petSchema.ts'
 
-export const addPetStatus200Schema = petSchema
+export const addPetStatus200Schema = z.lazy(() => petSchema)
 
 export type AddPetStatus200Schema = z.infer<typeof addPetStatus200Schema>
 

--- a/examples/zod/src/zod/zod/findPetsByStatusSchema.ts
+++ b/examples/zod/src/zod/zod/findPetsByStatusSchema.ts
@@ -14,7 +14,7 @@ export const findPetsByStatusQueryStatusSchema = z
 
 export type FindPetsByStatusQueryStatusSchema = z.infer<typeof findPetsByStatusQueryStatusSchema>
 
-export const findPetsByStatusStatus200Schema = z.array(petSchema)
+export const findPetsByStatusStatus200Schema = z.array(z.lazy(() => petSchema))
 
 export type FindPetsByStatusStatus200Schema = z.infer<typeof findPetsByStatusStatus200Schema>
 

--- a/examples/zod/src/zod/zod/findPetsByTagsSchema.ts
+++ b/examples/zod/src/zod/zod/findPetsByTagsSchema.ts
@@ -22,7 +22,7 @@ export const findPetsByTagsHeaderXEXAMPLESchema = z.enum(['ONE', 'TWO', 'THREE']
 
 export type FindPetsByTagsHeaderXEXAMPLESchema = z.infer<typeof findPetsByTagsHeaderXEXAMPLESchema>
 
-export const findPetsByTagsStatus200Schema = z.array(petSchema)
+export const findPetsByTagsStatus200Schema = z.array(z.lazy(() => petSchema))
 
 export type FindPetsByTagsStatus200Schema = z.infer<typeof findPetsByTagsStatus200Schema>
 

--- a/examples/zod/src/zod/zod/getPetByIdSchema.ts
+++ b/examples/zod/src/zod/zod/getPetByIdSchema.ts
@@ -10,7 +10,7 @@ export const getPetByIdPathPetIdSchema = z.int().describe('ID of pet to return')
 
 export type GetPetByIdPathPetIdSchema = z.infer<typeof getPetByIdPathPetIdSchema>
 
-export const getPetByIdStatus200Schema = petSchema
+export const getPetByIdStatus200Schema = z.lazy(() => petSchema)
 
 export type GetPetByIdStatus200Schema = z.infer<typeof getPetByIdStatus200Schema>
 

--- a/examples/zod/src/zod/zod/updatePetSchema.ts
+++ b/examples/zod/src/zod/zod/updatePetSchema.ts
@@ -6,7 +6,7 @@
 import { z } from '../../zod.ts'
 import { petSchema } from './petSchema.ts'
 
-export const updatePetStatus200Schema = petSchema
+export const updatePetStatus200Schema = z.lazy(() => petSchema)
 
 export type UpdatePetStatus200Schema = z.infer<typeof updatePetStatus200Schema>
 
@@ -26,6 +26,6 @@ export const updatePetResponseSchema = z.union([updatePetStatus200Schema, update
 
 export type UpdatePetResponseSchema = z.infer<typeof updatePetResponseSchema>
 
-export const updatePetDataSchema = petSchema.describe('Update an existent pet in the store')
+export const updatePetDataSchema = z.lazy(() => petSchema).describe('Update an existent pet in the store')
 
 export type UpdatePetDataSchema = z.infer<typeof updatePetDataSchema>

--- a/packages/plugin-client/CHANGELOG.md
+++ b/packages/plugin-client/CHANGELOG.md
@@ -19,25 +19,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -75,13 +63,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -171,14 +159,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -186,25 +174,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -212,7 +200,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -269,7 +257,7 @@
   Use `compatibilityPreset: 'kubbV4'` to preserve v4 naming conventions during migration. The default `'default'` preset uses the new v5 naming conventions.
 
   ```typescript
-  pluginClient({ compatibilityPreset: "kubbV4" });
+  pluginClient({ compatibilityPreset: 'kubbV4' })
   ```
 
   #### New `resolver` option
@@ -280,10 +268,10 @@
   pluginClient({
     resolver: {
       resolveName(name) {
-        return `${this.default(name)}Client`;
+        return `${this.default(name)}Client`
       },
     },
-  });
+  })
   ```
 
   #### New `transformer` option
@@ -291,15 +279,15 @@
   Apply an AST `Visitor` to transform schema and operation nodes before they are printed. This replaces the old `transformers` callback approach.
 
   ```typescript
-  import { pluginClient } from "@kubb/plugin-client";
+  import { pluginClient } from '@kubb/plugin-client'
 
   pluginClient({
     transformer: {
       operation(node) {
-        return { ...node, operationId: `api_${node.operationId}` };
+        return { ...node, operationId: `api_${node.operationId}` }
       },
     },
-  });
+  })
   ```
 
   #### `transformers.name` replaced by `resolver`
@@ -311,19 +299,19 @@
   ```typescript [Before (v4)]
   pluginClient({
     transformers: {
-      name: (name, type) => (type === "function" ? `${name}Client` : name),
+      name: (name, type) => (type === 'function' ? `${name}Client` : name),
     },
-  });
+  })
   ```
 
   ```typescript [After (v5)]
   pluginClient({
     resolver: {
       resolveName(name) {
-        return `${this.default(name)}Client`;
+        return `${this.default(name)}Client`
       },
     },
-  });
+  })
   ```
 
   :::
@@ -1267,20 +1255,20 @@
   **Usage:**
 
   ```typescript
-  import { defineConfig } from "@kubb/core";
-  import { pluginTs } from "@kubb/plugin-ts";
-  import { pluginClient } from "@kubb/plugin-client";
+  import { defineConfig } from '@kubb/core'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
 
   export default defineConfig({
     plugins: [
       pluginTs({
-        paramsCasing: "camelcase", // Transform types
+        paramsCasing: 'camelcase', // Transform types
       }),
       pluginClient({
-        paramsCasing: "camelcase", // Transform client code
+        paramsCasing: 'camelcase', // Transform client code
       }),
     ],
-  });
+  })
   ```
 
   **Example:**
@@ -1954,13 +1942,13 @@
   ```ts
   pluginClient({
     output: {
-      path: "./clients/class",
+      path: './clients/class',
     },
-    clientType: "class",
+    clientType: 'class',
     group: {
-      type: "tag",
+      type: 'tag',
     },
-  });
+  })
   ```
 
   This will generate classes like `Pet`, `Store`, `User` with methods for each operation.

--- a/packages/plugin-cypress/CHANGELOG.md
+++ b/packages/plugin-cypress/CHANGELOG.md
@@ -18,25 +18,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -73,13 +61,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -164,14 +152,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -179,25 +167,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -205,7 +193,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -296,22 +284,22 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
@@ -323,22 +311,22 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`

--- a/packages/plugin-faker/CHANGELOG.md
+++ b/packages/plugin-faker/CHANGELOG.md
@@ -44,25 +44,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -99,13 +87,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -170,14 +158,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -185,25 +173,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -211,7 +199,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -1080,20 +1068,20 @@
   **Usage:**
 
   ```typescript
-  import { defineConfig } from "@kubb/core";
-  import { pluginTs } from "@kubb/plugin-ts";
-  import { pluginClient } from "@kubb/plugin-client";
+  import { defineConfig } from '@kubb/core'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
 
   export default defineConfig({
     plugins: [
       pluginTs({
-        paramsCasing: "camelcase", // Transform types
+        paramsCasing: 'camelcase', // Transform types
       }),
       pluginClient({
-        paramsCasing: "camelcase", // Transform client code
+        paramsCasing: 'camelcase', // Transform client code
       }),
     ],
-  });
+  })
   ```
 
   **Example:**
@@ -1255,7 +1243,7 @@
   ```typescript
   pluginOas({
     collisionDetection: true, // Recommended - prevents all collision types
-  });
+  })
   ```
 
 - Updated dependencies [[`996f3b2`](https://github.com/kubb-labs/kubb/commit/996f3b26d8c2167c3e77b734275c204e6c1b159c)]:
@@ -1323,7 +1311,7 @@
 
   ```typescript
   // Generated code (correct)
-  category: createIssueCategory();
+  category: createIssueCategory()
   ```
 
 - Updated dependencies []:

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -72,9 +72,9 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   let functionBody = ''
 
   if (useGenericOverride) {
-    // Generate generic function with precise type inference
+    // Generate function with defaultFakeData structure
     const jsdoc = description ? `/**\n   * @description ${jsStringEscape(description)}\n   */\n  ` : ''
-    functionSignature = `${jsdoc}export function ${name}<TOverwriteData extends Partial<${typeName}> = {}>(data?: TOverwriteData): Required<${typeName}>`
+    functionSignature = `${jsdoc}export function ${name}(data?: Partial<${typeName}>): Required<${typeName}>`
 
     const seedCode = seed ? `faker.seed(${JSON.stringify(seed)})\n  ` : ''
     functionBody = `{

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -53,17 +53,12 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   const hasGetters = /\bget\s+\w+\s*\(\s*\)\s*\{/.test(fakerText)
 
   let fakerTextWithOverride = fakerText
-  let useObjectAssignShape = false
-  let useSpreadWithTypeAssertion = false
+  let useObjectAssign = false
 
   if (canOverride && isObject) {
-    if (hasGetters) {
-      // When there are getters (circular refs), use Object.assign to avoid invoking them during spread
-      useObjectAssignShape = true
-    } else {
-      // For regular objects without getters, use spread with precise type assertion
-      useSpreadWithTypeAssertion = true
-    }
+    // Always use Object.assign for objects to ensure proper type precision
+    // Required<> marks all properties as required, reflecting that the faker generates all of them
+    useObjectAssign = true
   }
 
   if (canOverride && isTuple) {
@@ -83,7 +78,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
 
   const { dataType, returnType: resolvedReturnType } = resolveFakerTypeUsage(node, typeName, canOverride)
 
-  const usesData = useObjectAssignShape || useSpreadWithTypeAssertion || /\bdata\b/.test(fakerTextWithOverride)
+  const usesData = useObjectAssign || /\bdata\b/.test(fakerTextWithOverride)
   const dataParamName = usesData ? 'data' : '_data'
   const params = ast.createFunctionParameters({
     params: [
@@ -96,18 +91,14 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   })
   const paramsSignature = declarationPrinter.print(params) ?? ''
 
-  // For objects with overrides, we need a more precise return type that marks generated properties as required
-  const returnType = useSpreadWithTypeAssertion ? `typeof _defaults & Omit<${typeName}, keyof typeof _defaults>` : resolvedReturnType
+  // For objects with overrides, use Required<> to mark all generated properties as required
+  const returnType = useObjectAssign
+    ? `Required<${typeName}>`
+    : resolvedReturnType
 
-  const body = useObjectAssignShape
-    ? `const result: ${resolvedReturnType} = ${fakerText}
-if (data) Object.assign(result, data)
-return result`
-    : useSpreadWithTypeAssertion
-      ? `const _defaults = ${fakerText}
-const result = { ..._defaults, ...(data || {}) } as ${returnType}
-return result`
-      : `return ${fakerTextWithOverride}`
+  const body = useObjectAssign
+    ? `return Object.assign({} as ${returnType}, ${fakerText}, data)`
+    : `return ${fakerTextWithOverride}`
 
   return (
     <File.Source name={name} isExportable isIndexable>

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -97,9 +97,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   const paramsSignature = declarationPrinter.print(params) ?? ''
 
   // For objects with overrides, we need a more precise return type that marks generated properties as required
-  const returnType = useSpreadWithTypeAssertion
-    ? `typeof _defaults & Omit<${typeName}, keyof typeof _defaults>`
-    : resolvedReturnType
+  const returnType = useSpreadWithTypeAssertion ? `typeof _defaults & Omit<${typeName}, keyof typeof _defaults>` : resolvedReturnType
 
   const body = useObjectAssignShape
     ? `const result: ${resolvedReturnType} = ${fakerText}

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -92,13 +92,9 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   const paramsSignature = declarationPrinter.print(params) ?? ''
 
   // For objects with overrides, use Required<> to mark all generated properties as required
-  const returnType = useObjectAssign
-    ? `Required<${typeName}>`
-    : resolvedReturnType
+  const returnType = useObjectAssign ? `Required<${typeName}>` : resolvedReturnType
 
-  const body = useObjectAssign
-    ? `return Object.assign({} as ${returnType}, ${fakerText}, data)`
-    : `return ${fakerTextWithOverride}`
+  const body = useObjectAssign ? `return Object.assign({} as ${returnType}, ${fakerText}, data)` : `return ${fakerTextWithOverride}`
 
   return (
     <File.Source name={name} isExportable isIndexable>

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -74,7 +74,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   if (useGenericOverride) {
     // Generate generic function with precise type inference
     const jsdoc = description ? `/**\n   * @description ${jsStringEscape(description)}\n   */\n  ` : ''
-    functionSignature = `${jsdoc}export function ${name}<TOverwriteData extends Partial<${typeName}> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData`
+    functionSignature = `${jsdoc}export function ${name}<TOverwriteData extends Partial<${typeName}> = {}>(data?: TOverwriteData): Required<${typeName}>`
 
     const seedCode = seed ? `faker.seed(${JSON.stringify(seed)})\n  ` : ''
     functionBody = `{
@@ -82,7 +82,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<${typeName}>
 }`
   } else {
     const usesData = /\bdata\b/.test(fakerTextWithOverride)

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -44,14 +44,6 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   const isTuple = node.type === 'tuple'
   const isScalar = SCALAR_TYPES.has(node.type)
 
-  // The printer emits `get prop() { ... }` for properties whose value would
-  // recurse through a circular dependency. Using object spread here would
-  // invoke those getters during construction (per ECMAScript spread semantics)
-  // and reintroduce the recursion we just deferred. Use `Object.assign` instead
-  // so the getters survive on the result object and a user override via `data`
-  // replaces them as plain data properties before they're ever read.
-  const hasGetters = /\bget\s+\w+\s*\(\s*\)\s*\{/.test(fakerText)
-
   let fakerTextWithOverride = fakerText
   let useObjectAssign = false
 
@@ -101,7 +93,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
       <Function
         export
         name={name}
-        JSDoc={{ comments: [description ? `@description ${jsStringEscape(description)}` : undefined].filter(Boolean) }}
+        JSDoc={{ comments: description ? [`@description ${jsStringEscape(description)}`] : [] }}
         params={canOverride ? paramsSignature : undefined}
         returnType={returnType}
       >

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -86,7 +86,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   // For objects with overrides, use Required<> to mark all generated properties as required
   const returnType = useObjectAssign ? `Required<${typeName}>` : resolvedReturnType
 
-  const body = useObjectAssign ? `return Object.assign({} as ${returnType}, ${fakerText}, data)` : `return ${fakerTextWithOverride}`
+  const body = useObjectAssign ? `return { ...${fakerText}, ...data } as ${returnType}` : `return ${fakerTextWithOverride}`
 
   return (
     <File.Source name={name} isExportable isIndexable>

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -45,12 +45,10 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   const isScalar = SCALAR_TYPES.has(node.type)
 
   let fakerTextWithOverride = fakerText
-  let useObjectAssign = false
+  let useGenericOverride = false
 
   if (canOverride && isObject) {
-    // Always use Object.assign for objects to ensure proper type precision
-    // Required<> marks all properties as required, reflecting that the faker generates all of them
-    useObjectAssign = true
+    useGenericOverride = true
   }
 
   if (canOverride && isTuple) {
@@ -70,41 +68,62 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
 
   const { dataType, returnType: resolvedReturnType } = resolveFakerTypeUsage(node, typeName, canOverride)
 
-  const usesData = useObjectAssign || /\bdata\b/.test(fakerTextWithOverride)
-  const dataParamName = usesData ? 'data' : '_data'
-  const params = ast.createFunctionParameters({
-    params: [
-      ast.createFunctionParameter({
-        name: dataParamName,
-        type: ast.createParamsType({ variant: 'reference', name: dataType }),
-        optional: true,
-      }),
-    ],
-  })
-  const paramsSignature = declarationPrinter.print(params) ?? ''
+  let functionSignature = ''
+  let functionBody = ''
 
-  // For objects with overrides, use Required<> to mark all generated properties as required
-  const returnType = useObjectAssign ? `Required<${typeName}>` : resolvedReturnType
+  if (useGenericOverride) {
+    // Generate generic function with precise type inference
+    const jsdoc = description ? `/**\n   * @description ${jsStringEscape(description)}\n   */\n  ` : ''
+    functionSignature = `${jsdoc}export function ${name}<TOverwriteData extends Partial<${typeName}> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData`
 
-  const body = useObjectAssign ? `return { ...${fakerText}, ...data } as ${returnType}` : `return ${fakerTextWithOverride}`
+    const seedCode = seed ? `faker.seed(${JSON.stringify(seed)})\n  ` : ''
+    functionBody = `{
+  ${seedCode}const defaultFakeData = ${fakerText}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+}`
+  } else {
+    const usesData = /\bdata\b/.test(fakerTextWithOverride)
+    const dataParamName = usesData ? 'data' : '_data'
+    const params = ast.createFunctionParameters({
+      params: [
+        ast.createFunctionParameter({
+          name: dataParamName,
+          type: ast.createParamsType({ variant: 'reference', name: dataType }),
+          optional: true,
+        }),
+      ],
+    })
+    const paramsSignature = declarationPrinter.print(params) ?? ''
+    const returnType = resolvedReturnType
+
+    return (
+      <File.Source name={name} isExportable isIndexable>
+        <Function
+          export
+          name={name}
+          JSDoc={{ comments: description ? [`@description ${jsStringEscape(description)}`] : [] }}
+          params={canOverride ? paramsSignature : undefined}
+          returnType={returnType}
+        >
+          {seed ? (
+            <>
+              {`faker.seed(${JSON.stringify(seed)})`}
+              <br />
+            </>
+          ) : undefined}
+          {`return ${fakerTextWithOverride}`}
+        </Function>
+      </File.Source>
+    )
+  }
 
   return (
     <File.Source name={name} isExportable isIndexable>
-      <Function
-        export
-        name={name}
-        JSDoc={{ comments: description ? [`@description ${jsStringEscape(description)}`] : [] }}
-        params={canOverride ? paramsSignature : undefined}
-        returnType={returnType}
-      >
-        {seed ? (
-          <>
-            {`faker.seed(${JSON.stringify(seed)})`}
-            <br />
-          </>
-        ) : undefined}
-        {body}
-      </Function>
+      {functionSignature}
+      {functionBody}
     </File.Source>
   )
 }

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -54,15 +54,15 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
 
   let fakerTextWithOverride = fakerText
   let useObjectAssignShape = false
+  let useSpreadWithTypeAssertion = false
 
   if (canOverride && isObject) {
     if (hasGetters) {
+      // When there are getters (circular refs), use Object.assign to avoid invoking them during spread
       useObjectAssignShape = true
     } else {
-      fakerTextWithOverride = `{
-  ...${fakerText},
-  ...(data || {})
-}`
+      // For regular objects without getters, use spread with precise type assertion
+      useSpreadWithTypeAssertion = true
     }
   }
 
@@ -83,7 +83,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
 
   const { dataType, returnType: resolvedReturnType } = resolveFakerTypeUsage(node, typeName, canOverride)
 
-  const usesData = useObjectAssignShape || /\bdata\b/.test(fakerTextWithOverride)
+  const usesData = useObjectAssignShape || useSpreadWithTypeAssertion || /\bdata\b/.test(fakerTextWithOverride)
   const dataParamName = usesData ? 'data' : '_data'
   const params = ast.createFunctionParameters({
     params: [
@@ -96,13 +96,20 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   })
   const paramsSignature = declarationPrinter.print(params) ?? ''
 
-  const returnType = resolvedReturnType
+  // For objects with overrides, we need a more precise return type that marks generated properties as required
+  const returnType = useSpreadWithTypeAssertion
+    ? `typeof _defaults & Omit<${typeName}, keyof typeof _defaults>`
+    : resolvedReturnType
 
   const body = useObjectAssignShape
-    ? `const result: ${returnType} = ${fakerText}
+    ? `const result: ${resolvedReturnType} = ${fakerText}
 if (data) Object.assign(result, data)
 return result`
-    : `return ${fakerTextWithOverride}`
+    : useSpreadWithTypeAssertion
+      ? `const _defaults = ${fakerText}
+const result = { ..._defaults, ...(data || {}) } as ${returnType}
+return result`
+      : `return ${fakerTextWithOverride}`
 
   return (
     <File.Source name={name} isExportable isIndexable>
@@ -113,8 +120,12 @@ return result`
         params={canOverride ? paramsSignature : undefined}
         returnType={returnType}
       >
-        {seed ? `faker.seed(${JSON.stringify(seed)})` : undefined}
-        <br />
+        {seed ? (
+          <>
+            {`faker.seed(${JSON.stringify(seed)})`}
+            <br />
+          </>
+        ) : undefined}
         {body}
       </Function>
     </File.Source>

--- a/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
@@ -7,9 +7,8 @@ import type { Cat } from './types/Cat'
 import { faker } from '@faker-js/faker'
 
 export function cat(data?: Partial<Cat>): Required<Cat> {
-  return Object.assign(
-    {} as Required<Cat>,
-    {
+  return {
+    ...{
       id: faker.number.int(),
       get archEnemy() {
         return faker.helpers.arrayElement<any>([null, pet()])
@@ -18,6 +17,6 @@ export function cat(data?: Partial<Cat>): Required<Cat> {
         return faker.helpers.multiple(() => pet())
       },
     },
-    data,
-  )
+    ...data,
+  } as Required<Cat>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
@@ -6,16 +6,18 @@
 import type { Cat } from './types/Cat'
 import { faker } from '@faker-js/faker'
 
-export function cat(data?: Partial<Cat>): Cat {
-  const result: Cat = {
-    id: faker.number.int(),
-    get archEnemy() {
-      return faker.helpers.arrayElement<any>([null, pet()])
+export function cat(data?: Partial<Cat>): Required<Cat> {
+  return Object.assign(
+    {} as Required<Cat>,
+    {
+      id: faker.number.int(),
+      get archEnemy() {
+        return faker.helpers.arrayElement<any>([null, pet()])
+      },
+      get friends() {
+        return faker.helpers.multiple(() => pet())
+      },
     },
-    get friends() {
-      return faker.helpers.multiple(() => pet())
-    },
-  }
-  if (data) Object.assign(result, data)
-  return result
+    data,
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
@@ -6,7 +6,7 @@
 import type { Cat } from './types/Cat'
 import { faker } from '@faker-js/faker'
 
-export function cat<TOverwriteData extends Partial<Cat> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function cat<TOverwriteData extends Partial<Cat> = {}>(data?: TOverwriteData): Required<Cat> {
   const defaultFakeData = {
     id: faker.number.int(),
     get archEnemy() {
@@ -19,5 +19,5 @@ export function cat<TOverwriteData extends Partial<Cat> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Cat>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
@@ -6,7 +6,7 @@
 import type { Cat } from './types/Cat'
 import { faker } from '@faker-js/faker'
 
-export function cat<TOverwriteData extends Partial<Cat> = {}>(data?: TOverwriteData): Required<Cat> {
+export function cat(data?: Partial<Cat>): Required<Cat> {
   const defaultFakeData = {
     id: faker.number.int(),
     get archEnemy() {

--- a/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/catCycle/cat.ts
@@ -6,17 +6,18 @@
 import type { Cat } from './types/Cat'
 import { faker } from '@faker-js/faker'
 
-export function cat(data?: Partial<Cat>): Required<Cat> {
-  return {
-    ...{
-      id: faker.number.int(),
-      get archEnemy() {
-        return faker.helpers.arrayElement<any>([null, pet()])
-      },
-      get friends() {
-        return faker.helpers.multiple(() => pet())
-      },
+export function cat<TOverwriteData extends Partial<Cat> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.number.int(),
+    get archEnemy() {
+      return faker.helpers.arrayElement<any>([null, pet()])
     },
-    ...data,
-  } as Required<Cat>
+    get friends() {
+      return faker.helpers.multiple(() => pet())
+    },
+  }
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
@@ -17,7 +17,7 @@ export function createPetStatus201(data?: Partial<CreatePetStatus201>): CreatePe
  * @description Pet to add
  */
 export function createPetData(data?: Partial<CreatePetData>): Required<CreatePetData> {
-  return Object.assign({} as Required<CreatePetData>, { name: faker.string.alpha(), category: category() }, data)
+  return { ...{ name: faker.string.alpha(), category: category() }, ...data } as Required<CreatePetData>
 }
 
 export function createPetResponse(data?: Partial<CreatePetResponse>): CreatePetResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
@@ -16,10 +16,12 @@ export function createPetStatus201(data?: Partial<CreatePetStatus201>): CreatePe
 /**
  * @description Pet to add
  */
-export function createPetData(data?: Partial<CreatePetData>): typeof _defaults & Omit<CreatePetData, keyof typeof _defaults> {
-  const _defaults = { name: faker.string.alpha(), category: category() }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<CreatePetData, keyof typeof _defaults>
-  return result
+export function createPetData(data?: Partial<CreatePetData>): Required<CreatePetData> {
+  return Object.assign(
+    {} as Required<CreatePetData>,
+    { name: faker.string.alpha(), category: category() },
+    data
+  )
 }
 
 export function createPetResponse(data?: Partial<CreatePetResponse>): CreatePetResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
@@ -16,11 +16,10 @@ export function createPetStatus201(data?: Partial<CreatePetStatus201>): CreatePe
 /**
  * @description Pet to add
  */
-export function createPetData(data?: Partial<CreatePetData>): CreatePetData {
-  return {
-    ...{ name: faker.string.alpha(), category: category() },
-    ...(data || {}),
-  }
+export function createPetData(data?: Partial<CreatePetData>): typeof _defaults & Omit<CreatePetData, keyof typeof _defaults> {
+  const _defaults = { name: faker.string.alpha(), category: category() }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<CreatePetData, keyof typeof _defaults>
+  return result
 }
 
 export function createPetResponse(data?: Partial<CreatePetResponse>): CreatePetResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
@@ -16,8 +16,14 @@ export function createPetStatus201(data?: Partial<CreatePetStatus201>): CreatePe
 /**
  * @description Pet to add
  */
-export function createPetData(data?: Partial<CreatePetData>): Required<CreatePetData> {
-  return { ...{ name: faker.string.alpha(), category: category() }, ...data } as Required<CreatePetData>
+export function createPetData<TOverwriteData extends Partial<CreatePetData> = {}>(
+  data?: TOverwriteData,
+): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = { name: faker.string.alpha(), category: category() }
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }
 
 export function createPetResponse(data?: Partial<CreatePetResponse>): CreatePetResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
@@ -17,11 +17,7 @@ export function createPetStatus201(data?: Partial<CreatePetStatus201>): CreatePe
  * @description Pet to add
  */
 export function createPetData(data?: Partial<CreatePetData>): Required<CreatePetData> {
-  return Object.assign(
-    {} as Required<CreatePetData>,
-    { name: faker.string.alpha(), category: category() },
-    data
-  )
+  return Object.assign({} as Required<CreatePetData>, { name: faker.string.alpha(), category: category() }, data)
 }
 
 export function createPetResponse(data?: Partial<CreatePetResponse>): CreatePetResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
@@ -16,7 +16,7 @@ export function createPetStatus201(data?: Partial<CreatePetStatus201>): CreatePe
 /**
  * @description Pet to add
  */
-export function createPetData<TOverwriteData extends Partial<CreatePetData> = {}>(data?: TOverwriteData): Required<CreatePetData> {
+export function createPetData(data?: Partial<CreatePetData>): Required<CreatePetData> {
   const defaultFakeData = { name: faker.string.alpha(), category: category() }
   return {
     ...defaultFakeData,

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createPet.ts
@@ -16,14 +16,12 @@ export function createPetStatus201(data?: Partial<CreatePetStatus201>): CreatePe
 /**
  * @description Pet to add
  */
-export function createPetData<TOverwriteData extends Partial<CreatePetData> = {}>(
-  data?: TOverwriteData,
-): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function createPetData<TOverwriteData extends Partial<CreatePetData> = {}>(data?: TOverwriteData): Required<CreatePetData> {
   const defaultFakeData = { name: faker.string.alpha(), category: category() }
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<CreatePetData>
 }
 
 export function createPetResponse(data?: Partial<CreatePetResponse>): CreatePetResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPetUnknownTypeAny/createPetUnknownTypeAny.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPetUnknownTypeAny/createPetUnknownTypeAny.ts
@@ -20,10 +20,12 @@ export function createPetsError(data?: Partial<CreatePetsError>): CreatePetsErro
   return error(data)
 }
 
-export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): typeof _defaults & Omit<CreatePetsMutationRequest, keyof typeof _defaults> {
-  const _defaults = { name: faker.string.alpha(), tag: faker.string.alpha() }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<CreatePetsMutationRequest, keyof typeof _defaults>
-  return result
+export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): Required<CreatePetsMutationRequest> {
+  return Object.assign(
+    {} as Required<CreatePetsMutationRequest>,
+    { name: faker.string.alpha(), tag: faker.string.alpha() },
+    data
+  )
 }
 
 export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): CreatePetsMutationResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPetUnknownTypeAny/createPetUnknownTypeAny.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPetUnknownTypeAny/createPetUnknownTypeAny.ts
@@ -20,11 +20,10 @@ export function createPetsError(data?: Partial<CreatePetsError>): CreatePetsErro
   return error(data)
 }
 
-export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): CreatePetsMutationRequest {
-  return {
-    ...{ name: faker.string.alpha(), tag: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): typeof _defaults & Omit<CreatePetsMutationRequest, keyof typeof _defaults> {
+  const _defaults = { name: faker.string.alpha(), tag: faker.string.alpha() }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<CreatePetsMutationRequest, keyof typeof _defaults>
+  return result
 }
 
 export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): CreatePetsMutationResponse {

--- a/packages/plugin-faker/src/generators/__snapshots__/getPets/getPets.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/getPets/getPets.ts
@@ -6,21 +6,19 @@
 import { faker } from '@faker-js/faker'
 import { error, pagination, pets } from '../getPets'
 
-export function listPetsQueryParams(data?: Partial<ListPetsQueryParams>): ListPetsQueryParams {
-  return {
-    ...{ limit: faker.string.alpha() },
-    ...(data || {}),
-  }
+export function listPetsQueryParams(data?: Partial<ListPetsQueryParams>): typeof _defaults & Omit<ListPetsQueryParams, keyof typeof _defaults> {
+  const _defaults = { limit: faker.string.alpha() }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ListPetsQueryParams, keyof typeof _defaults>
+  return result
 }
 
 /**
  * @description A paged array of pets
  */
-export function listPets200(data?: Partial<ListPets200>): ListPets200 {
-  return {
-    ...{ ...pagination(), ...pets() },
-    ...(data || {}),
-  }
+export function listPets200(data?: Partial<ListPets200>): typeof _defaults & Omit<ListPets200, keyof typeof _defaults> {
+  const _defaults = { ...pagination(), ...pets() }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ListPets200, keyof typeof _defaults>
+  return result
 }
 
 /**

--- a/packages/plugin-faker/src/generators/__snapshots__/getPets/getPets.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/getPets/getPets.ts
@@ -6,19 +6,23 @@
 import { faker } from '@faker-js/faker'
 import { error, pagination, pets } from '../getPets'
 
-export function listPetsQueryParams(data?: Partial<ListPetsQueryParams>): typeof _defaults & Omit<ListPetsQueryParams, keyof typeof _defaults> {
-  const _defaults = { limit: faker.string.alpha() }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ListPetsQueryParams, keyof typeof _defaults>
-  return result
+export function listPetsQueryParams(data?: Partial<ListPetsQueryParams>): Required<ListPetsQueryParams> {
+  return Object.assign(
+    {} as Required<ListPetsQueryParams>,
+    { limit: faker.string.alpha() },
+    data
+  )
 }
 
 /**
  * @description A paged array of pets
  */
-export function listPets200(data?: Partial<ListPets200>): typeof _defaults & Omit<ListPets200, keyof typeof _defaults> {
-  const _defaults = { ...pagination(), ...pets() }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ListPets200, keyof typeof _defaults>
-  return result
+export function listPets200(data?: Partial<ListPets200>): Required<ListPets200> {
+  return Object.assign(
+    {} as Required<ListPets200>,
+    { ...pagination(), ...pets() },
+    data
+  )
 }
 
 /**

--- a/packages/plugin-faker/src/generators/__snapshots__/node/node.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/node/node.ts
@@ -5,9 +5,8 @@
 
 import { faker } from '@faker-js/faker'
 
-export function node(data?: Partial<Node>): Node {
-  return {
-    ...{ id: faker.string.alpha(), children: faker.helpers.multiple(() => undefined as any) },
-    ...(data || {}),
-  }
+export function node(data?: Partial<Node>): typeof _defaults & Omit<Node, keyof typeof _defaults> {
+  const _defaults = { id: faker.string.alpha(), children: faker.helpers.multiple(() => undefined as any) }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Node, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/node/node.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/node/node.ts
@@ -5,8 +5,10 @@
 
 import { faker } from '@faker-js/faker'
 
-export function node(data?: Partial<Node>): typeof _defaults & Omit<Node, keyof typeof _defaults> {
-  const _defaults = { id: faker.string.alpha(), children: faker.helpers.multiple(() => undefined as any) }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Node, keyof typeof _defaults>
-  return result
+export function node(data?: Partial<Node>): Required<Node> {
+  return Object.assign(
+    {} as Required<Node>,
+    { id: faker.string.alpha(), children: faker.helpers.multiple(() => undefined as any) },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
@@ -16,7 +16,7 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipDate: faker.date.anytime().toISOString().substring(0, 10),
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  },
-    data
+    },
+    data,
   )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
@@ -6,7 +6,7 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
@@ -6,15 +6,17 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
-    id: faker.number.int(),
-    name: faker.string.alpha(),
-    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-    shipDate: faker.date.anytime().toISOString().substring(0, 10),
-    category: category(),
-    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
+      id: faker.number.int(),
+      name: faker.string.alpha(),
+      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+      shipDate: faker.date.anytime().toISOString().substring(0, 10),
+      category: category(),
+      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
@@ -6,16 +6,15 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-      shipDate: faker.date.anytime().toISOString().substring(0, 10),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...(data || {}),
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+    shipDate: faker.date.anytime().toISOString().substring(0, 10),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
   }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
@@ -6,7 +6,7 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),
@@ -18,5 +18,5 @@ export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
@@ -6,16 +6,17 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+    shipDate: faker.date.anytime().toISOString().substring(0, 10),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  }
   return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-      shipDate: faker.date.anytime().toISOString().substring(0, 10),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...data,
-  } as Required<Pet>
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/pet.ts
@@ -7,9 +7,8 @@ import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
 export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign(
-    {} as Required<Pet>,
-    {
+  return {
+    ...{
       id: faker.number.int(),
       name: faker.string.alpha(),
       code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
@@ -17,6 +16,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
     },
-    data,
-  )
+    ...data,
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDateString/petWithDateString.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDateString/petWithDateString.ts
@@ -5,9 +5,8 @@
 
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -15,7 +14,7 @@ export function pet(data?: Partial<Pet>): Pet {
       shipDate: faker.date.anytime().toISOString().substring(0, 10),
       shipTime: faker.date.anytime().toISOString().substring(11, 19),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    },
-    ...(data || {}),
-  }
+    }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDateString/petWithDateString.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDateString/petWithDateString.ts
@@ -5,8 +5,10 @@
 
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -14,7 +16,7 @@ export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typ
       shipDate: faker.date.anytime().toISOString().substring(0, 10),
       shipTime: faker.date.anytime().toISOString().substring(11, 19),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+    },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
@@ -8,9 +8,8 @@ import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
 export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign(
-    {} as Required<Pet>,
-    {
+  return {
+    ...{
       id: faker.number.int(),
       name: faker.string.alpha(),
       code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
@@ -18,6 +17,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
     },
-    data,
-  )
+    ...data,
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
@@ -7,15 +7,17 @@ import dayjs from 'dayjs'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
-    id: faker.number.int(),
-    name: faker.string.alpha(),
-    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-    shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
-    category: category(),
-    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
+      id: faker.number.int(),
+      name: faker.string.alpha(),
+      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+      shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
+      category: category(),
+      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
@@ -7,7 +7,7 @@ import dayjs from 'dayjs'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
@@ -7,7 +7,7 @@ import dayjs from 'dayjs'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),
@@ -19,5 +19,5 @@ export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
@@ -7,16 +7,15 @@ import dayjs from 'dayjs'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-      shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...(data || {}),
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+    shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
   }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
@@ -7,16 +7,17 @@ import dayjs from 'dayjs'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+    shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  }
   return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-      shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...data,
-  } as Required<Pet>
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/pet.ts
@@ -17,7 +17,7 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  },
-    data
+    },
+    data,
   )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
@@ -6,7 +6,7 @@
 import dayjs from 'dayjs'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
@@ -7,9 +7,8 @@ import dayjs from 'dayjs'
 import { faker } from '@faker-js/faker'
 
 export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign(
-    {} as Required<Pet>,
-    {
+  return {
+    ...{
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -18,6 +17,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipTime: dayjs(faker.date.anytime()).format('HH:mm:ss'),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
     },
-    data,
-  )
+    ...data,
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
@@ -6,7 +6,7 @@
 import dayjs from 'dayjs'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),
@@ -19,5 +19,5 @@ export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
@@ -18,6 +18,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipTime: dayjs(faker.date.anytime()).format('HH:mm:ss'),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
     },
-    data
+    data,
   )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
@@ -6,9 +6,8 @@
 import dayjs from 'dayjs'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -16,7 +15,7 @@ export function pet(data?: Partial<Pet>): Pet {
       shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
       shipTime: dayjs(faker.date.anytime()).format('HH:mm:ss'),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    },
-    ...(data || {}),
-  }
+    }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
@@ -6,8 +6,10 @@
 import dayjs from 'dayjs'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -15,7 +17,7 @@ export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typ
       shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
       shipTime: dayjs(faker.date.anytime()).format('HH:mm:ss'),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+    },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/petWithDayjs.ts
@@ -6,17 +6,18 @@
 import dayjs from 'dayjs'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    tag: faker.string.alpha(),
+    code: faker.helpers.fromRegExp('\b[1-9]\b'),
+    shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
+    shipTime: dayjs(faker.date.anytime()).format('HH:mm:ss'),
+    info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
+  }
   return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      tag: faker.string.alpha(),
-      code: faker.helpers.fromRegExp('\b[1-9]\b'),
-      shipDate: dayjs(faker.date.anytime()).format('YYYY-MM-DD'),
-      shipTime: dayjs(faker.date.anytime()).format('HH:mm:ss'),
-      info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    },
-    ...data,
-  } as Required<Pet>
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
@@ -7,9 +7,8 @@ import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
 export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign(
-    {} as Required<Pet>,
-    {
+  return {
+    ...{
       id: faker.number.int(),
       name: faker.string.fromCharacters('abc'),
       code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
@@ -17,6 +16,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
     },
-    data,
-  )
+    ...data,
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
@@ -6,15 +6,17 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
-    id: faker.number.int(),
-    name: faker.string.fromCharacters('abc'),
-    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-    shipDate: faker.date.anytime().toISOString().substring(0, 10),
-    category: category(),
-    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
+      id: faker.number.int(),
+      name: faker.string.fromCharacters('abc'),
+      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+      shipDate: faker.date.anytime().toISOString().substring(0, 10),
+      category: category(),
+      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
@@ -16,7 +16,7 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipDate: faker.date.anytime().toISOString().substring(0, 10),
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  },
-    data
+    },
+    data,
   )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
@@ -6,7 +6,7 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.fromCharacters('abc'),
@@ -18,5 +18,5 @@ export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
@@ -6,16 +6,15 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.fromCharacters('abc'),
-      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-      shipDate: faker.date.anytime().toISOString().substring(0, 10),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...(data || {}),
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
+    id: faker.number.int(),
+    name: faker.string.fromCharacters('abc'),
+    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+    shipDate: faker.date.anytime().toISOString().substring(0, 10),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
   }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
@@ -6,7 +6,7 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.fromCharacters('abc'),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/pet.ts
@@ -6,16 +6,17 @@
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.number.int(),
+    name: faker.string.fromCharacters('abc'),
+    code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
+    shipDate: faker.date.anytime().toISOString().substring(0, 10),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  }
   return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.fromCharacters('abc'),
-      code: faker.helpers.fromRegExp('^[A-Z]{3}$'),
-      shipDate: faker.date.anytime().toISOString().substring(0, 10),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...data,
-  } as Required<Pet>
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
@@ -6,9 +6,8 @@
 import { faker } from '@faker-js/faker'
 
 export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign(
-    {} as Required<Pet>,
-    {
+  return {
+    ...{
       id: faker.string.fromCharacters('abc'),
       name: faker.string.alpha({ casing: 'lower' }),
       tag: faker.string.alpha(),
@@ -17,6 +16,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
     },
-    data,
-  )
+    ...data,
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
@@ -5,7 +5,7 @@
 
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
   const defaultFakeData = {
     id: faker.string.fromCharacters('abc'),
     name: faker.string.alpha({ casing: 'lower' }),
@@ -18,5 +18,5 @@ export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
@@ -5,9 +5,8 @@
 
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
       id: faker.string.fromCharacters('abc'),
       name: faker.string.alpha({ casing: 'lower' }),
       tag: faker.string.alpha(),
@@ -15,7 +14,7 @@ export function pet(data?: Partial<Pet>): Pet {
       shipDate: faker.date.anytime(),
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    },
-    ...(data || {}),
-  }
+    }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
@@ -5,17 +5,18 @@
 
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.string.fromCharacters('abc'),
+    name: faker.string.alpha({ casing: 'lower' }),
+    tag: faker.string.alpha(),
+    code: faker.helpers.fromRegExp('\b[1-9]\b'),
+    shipDate: faker.date.anytime(),
+    shipTime: faker.date.anytime(),
+    info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
+  }
   return {
-    ...{
-      id: faker.string.fromCharacters('abc'),
-      name: faker.string.alpha({ casing: 'lower' }),
-      tag: faker.string.alpha(),
-      code: faker.helpers.fromRegExp('\b[1-9]\b'),
-      shipDate: faker.date.anytime(),
-      shipTime: faker.date.anytime(),
-      info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    },
-    ...data,
-  } as Required<Pet>
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
@@ -5,8 +5,10 @@
 
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.string.fromCharacters('abc'),
       name: faker.string.alpha({ casing: 'lower' }),
       tag: faker.string.alpha(),
@@ -14,7 +16,7 @@ export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typ
       shipDate: faker.date.anytime(),
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+    },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
@@ -5,7 +5,7 @@
 
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   const defaultFakeData = {
     id: faker.string.fromCharacters('abc'),
     name: faker.string.alpha({ casing: 'lower' }),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper/petWithMapper.ts
@@ -17,6 +17,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
     },
-    data
+    data,
   )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
@@ -7,7 +7,7 @@ import RandExp from 'randexp'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),
@@ -19,5 +19,5 @@ export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
@@ -7,15 +7,17 @@ import RandExp from 'randexp'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
-    id: faker.number.int(),
-    name: faker.string.alpha(),
-    code: new RandExp('^[A-Z]{3}$').gen(),
-    shipDate: faker.date.anytime().toISOString().substring(0, 10),
-    category: category(),
-    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
+      id: faker.number.int(),
+      name: faker.string.alpha(),
+      code: new RandExp('^[A-Z]{3}$').gen(),
+      shipDate: faker.date.anytime().toISOString().substring(0, 10),
+      category: category(),
+      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
@@ -17,7 +17,7 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipDate: faker.date.anytime().toISOString().substring(0, 10),
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-  },
-    data
+    },
+    data,
   )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
@@ -8,9 +8,8 @@ import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
 export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign(
-    {} as Required<Pet>,
-    {
+  return {
+    ...{
       id: faker.number.int(),
       name: faker.string.alpha(),
       code: new RandExp('^[A-Z]{3}$').gen(),
@@ -18,6 +17,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       category: category(),
       status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
     },
-    data,
-  )
+    ...data,
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
@@ -7,16 +7,17 @@ import RandExp from 'randexp'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    code: new RandExp('^[A-Z]{3}$').gen(),
+    shipDate: faker.date.anytime().toISOString().substring(0, 10),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
+  }
   return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      code: new RandExp('^[A-Z]{3}$').gen(),
-      shipDate: faker.date.anytime().toISOString().substring(0, 10),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...data,
-  } as Required<Pet>
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
@@ -7,7 +7,7 @@ import RandExp from 'randexp'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/pet.ts
@@ -7,16 +7,15 @@ import RandExp from 'randexp'
 import type { Pet } from './types/Pet'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      code: new RandExp('^[A-Z]{3}$').gen(),
-      shipDate: faker.date.anytime().toISOString().substring(0, 10),
-      category: category(),
-      status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
-    },
-    ...(data || {}),
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    code: new RandExp('^[A-Z]{3}$').gen(),
+    shipDate: faker.date.anytime().toISOString().substring(0, 10),
+    category: category(),
+    status: faker.helpers.arrayElement<NonNullable<Pet>['status']>(['available', 'pending', 'sold']),
   }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
@@ -6,9 +6,8 @@
 import RandExp from 'randexp'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Pet {
-  return {
-    ...{
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -16,7 +15,7 @@ export function pet(data?: Partial<Pet>): Pet {
       shipDate: faker.date.anytime(),
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    },
-    ...(data || {}),
-  }
+    }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
@@ -6,7 +6,7 @@
 import RandExp from 'randexp'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),
@@ -19,5 +19,5 @@ export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteD
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
@@ -7,9 +7,8 @@ import RandExp from 'randexp'
 import { faker } from '@faker-js/faker'
 
 export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign(
-    {} as Required<Pet>,
-    {
+  return {
+    ...{
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -18,6 +17,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
     },
-    data,
-  )
+    ...data,
+  } as Required<Pet>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
@@ -6,7 +6,7 @@
 import RandExp from 'randexp'
 import { faker } from '@faker-js/faker'
 
-export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Required<Pet> {
+export function pet(data?: Partial<Pet>): Required<Pet> {
   const defaultFakeData = {
     id: faker.number.int(),
     name: faker.string.alpha(),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
@@ -6,17 +6,18 @@
 import RandExp from 'randexp'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
+export function pet<TOverwriteData extends Partial<Pet> = {}>(data?: TOverwriteData): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = {
+    id: faker.number.int(),
+    name: faker.string.alpha(),
+    tag: faker.string.alpha(),
+    code: new RandExp('\\b[1-9]\\b').gen(),
+    shipDate: faker.date.anytime(),
+    shipTime: faker.date.anytime(),
+    info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
+  }
   return {
-    ...{
-      id: faker.number.int(),
-      name: faker.string.alpha(),
-      tag: faker.string.alpha(),
-      code: new RandExp('\\b[1-9]\\b').gen(),
-      shipDate: faker.date.anytime(),
-      shipTime: faker.date.anytime(),
-      info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    },
-    ...data,
-  } as Required<Pet>
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
@@ -18,6 +18,6 @@ export function pet(data?: Partial<Pet>): Required<Pet> {
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
     },
-    data
+    data,
   )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/petWithRandExp.ts
@@ -6,8 +6,10 @@
 import RandExp from 'randexp'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign(
+    {} as Required<Pet>,
+    {
       id: faker.number.int(),
       name: faker.string.alpha(),
       tag: faker.string.alpha(),
@@ -15,7 +17,7 @@ export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typ
       shipDate: faker.date.anytime(),
       shipTime: faker.date.anytime(),
       info: { animal: faker.helpers.arrayElement<NonNullable<NonNullable<Pet>['info']>['animal']>(['dog', 'cat', 'ant']) },
-    }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+    },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
@@ -6,8 +6,10 @@
 import type { TreeNode } from './types/TreeNode'
 import { faker } from '@faker-js/faker'
 
-export function treeNode(data?: Partial<TreeNode>): typeof _defaults & Omit<TreeNode, keyof typeof _defaults> {
-  const _defaults = { value: faker.string.alpha(), left: undefined as any, right: undefined as any }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<TreeNode, keyof typeof _defaults>
-  return result
+export function treeNode(data?: Partial<TreeNode>): Required<TreeNode> {
+  return Object.assign(
+    {} as Required<TreeNode>,
+    { value: faker.string.alpha(), left: undefined as any, right: undefined as any },
+    data
+  )
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
@@ -6,12 +6,10 @@
 import type { TreeNode } from './types/TreeNode'
 import { faker } from '@faker-js/faker'
 
-export function treeNode<TOverwriteData extends Partial<TreeNode> = {}>(
-  data?: TOverwriteData,
-): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+export function treeNode<TOverwriteData extends Partial<TreeNode> = {}>(data?: TOverwriteData): Required<TreeNode> {
   const defaultFakeData = { value: faker.string.alpha(), left: undefined as any, right: undefined as any }
   return {
     ...defaultFakeData,
     ...(data || {}),
-  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
+  } as Required<TreeNode>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
@@ -7,5 +7,5 @@ import type { TreeNode } from './types/TreeNode'
 import { faker } from '@faker-js/faker'
 
 export function treeNode(data?: Partial<TreeNode>): Required<TreeNode> {
-  return Object.assign({} as Required<TreeNode>, { value: faker.string.alpha(), left: undefined as any, right: undefined as any }, data)
+  return { ...{ value: faker.string.alpha(), left: undefined as any, right: undefined as any }, ...data } as Required<TreeNode>
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
@@ -6,6 +6,12 @@
 import type { TreeNode } from './types/TreeNode'
 import { faker } from '@faker-js/faker'
 
-export function treeNode(data?: Partial<TreeNode>): Required<TreeNode> {
-  return { ...{ value: faker.string.alpha(), left: undefined as any, right: undefined as any }, ...data } as Required<TreeNode>
+export function treeNode<TOverwriteData extends Partial<TreeNode> = {}>(
+  data?: TOverwriteData,
+): Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData {
+  const defaultFakeData = { value: faker.string.alpha(), left: undefined as any, right: undefined as any }
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Omit<typeof defaultFakeData, keyof TOverwriteData> & TOverwriteData
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
@@ -6,9 +6,8 @@
 import type { TreeNode } from './types/TreeNode'
 import { faker } from '@faker-js/faker'
 
-export function treeNode(data?: Partial<TreeNode>): TreeNode {
-  return {
-    ...{ value: faker.string.alpha(), left: undefined as any, right: undefined as any },
-    ...(data || {}),
-  }
+export function treeNode(data?: Partial<TreeNode>): typeof _defaults & Omit<TreeNode, keyof typeof _defaults> {
+  const _defaults = { value: faker.string.alpha(), left: undefined as any, right: undefined as any }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<TreeNode, keyof typeof _defaults>
+  return result
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
@@ -7,9 +7,5 @@ import type { TreeNode } from './types/TreeNode'
 import { faker } from '@faker-js/faker'
 
 export function treeNode(data?: Partial<TreeNode>): Required<TreeNode> {
-  return Object.assign(
-    {} as Required<TreeNode>,
-    { value: faker.string.alpha(), left: undefined as any, right: undefined as any },
-    data
-  )
+  return Object.assign({} as Required<TreeNode>, { value: faker.string.alpha(), left: undefined as any, right: undefined as any }, data)
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/treeNode.ts
@@ -6,7 +6,7 @@
 import type { TreeNode } from './types/TreeNode'
 import { faker } from '@faker-js/faker'
 
-export function treeNode<TOverwriteData extends Partial<TreeNode> = {}>(data?: TOverwriteData): Required<TreeNode> {
+export function treeNode(data?: Partial<TreeNode>): Required<TreeNode> {
   const defaultFakeData = { value: faker.string.alpha(), left: undefined as any, right: undefined as any }
   return {
     ...defaultFakeData,

--- a/packages/plugin-faker/src/generators/__snapshots__/updatePet/updatePet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/updatePet/updatePet.ts
@@ -6,10 +6,12 @@
 import { faker } from '@faker-js/faker'
 import { error, pet } from '../updatePet'
 
-export function updatePetPathParams(data?: Partial<UpdatePetPathParams>): typeof _defaults & Omit<UpdatePetPathParams, keyof typeof _defaults> {
-  const _defaults = { petId: faker.number.int() }
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<UpdatePetPathParams, keyof typeof _defaults>
-  return result
+export function updatePetPathParams(data?: Partial<UpdatePetPathParams>): Required<UpdatePetPathParams> {
+  return Object.assign(
+    {} as Required<UpdatePetPathParams>,
+    { petId: faker.number.int() },
+    data
+  )
 }
 
 /**

--- a/packages/plugin-faker/src/generators/__snapshots__/updatePet/updatePet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/updatePet/updatePet.ts
@@ -6,11 +6,10 @@
 import { faker } from '@faker-js/faker'
 import { error, pet } from '../updatePet'
 
-export function updatePetPathParams(data?: Partial<UpdatePetPathParams>): UpdatePetPathParams {
-  return {
-    ...{ petId: faker.number.int() },
-    ...(data || {}),
-  }
+export function updatePetPathParams(data?: Partial<UpdatePetPathParams>): typeof _defaults & Omit<UpdatePetPathParams, keyof typeof _defaults> {
+  const _defaults = { petId: faker.number.int() }
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<UpdatePetPathParams, keyof typeof _defaults>
+  return result
 }
 
 /**

--- a/packages/plugin-mcp/CHANGELOG.md
+++ b/packages/plugin-mcp/CHANGELOG.md
@@ -20,25 +20,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -63,13 +51,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -142,14 +130,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -157,25 +145,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -183,7 +171,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -1224,20 +1212,20 @@
   **Usage:**
 
   ```typescript
-  import { defineConfig } from "@kubb/core";
-  import { pluginTs } from "@kubb/plugin-ts";
-  import { pluginClient } from "@kubb/plugin-client";
+  import { defineConfig } from '@kubb/core'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
 
   export default defineConfig({
     plugins: [
       pluginTs({
-        paramsCasing: "camelcase", // Transform types
+        paramsCasing: 'camelcase', // Transform types
       }),
       pluginClient({
-        paramsCasing: "camelcase", // Transform client code
+        paramsCasing: 'camelcase', // Transform client code
       }),
     ],
-  });
+  })
   ```
 
   **Example:**

--- a/packages/plugin-msw/CHANGELOG.md
+++ b/packages/plugin-msw/CHANGELOG.md
@@ -28,25 +28,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -84,13 +72,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -160,14 +148,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -175,25 +163,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -201,7 +189,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 

--- a/packages/plugin-react-query/CHANGELOG.md
+++ b/packages/plugin-react-query/CHANGELOG.md
@@ -20,25 +20,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -77,13 +65,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -161,14 +149,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -176,25 +164,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -202,7 +190,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -1243,20 +1231,20 @@
   **Usage:**
 
   ```typescript
-  import { defineConfig } from "@kubb/core";
-  import { pluginTs } from "@kubb/plugin-ts";
-  import { pluginClient } from "@kubb/plugin-client";
+  import { defineConfig } from '@kubb/core'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
 
   export default defineConfig({
     plugins: [
       pluginTs({
-        paramsCasing: "camelcase", // Transform types
+        paramsCasing: 'camelcase', // Transform types
       }),
       pluginClient({
-        paramsCasing: "camelcase", // Transform client code
+        paramsCasing: 'camelcase', // Transform client code
       }),
     ],
-  });
+  })
   ```
 
   **Example:**
@@ -1959,7 +1947,7 @@
   pluginReactQuery({
     mutation: false, // Now properly prevents mutation hook generation
     query: true, // Only generates queryOptions
-  });
+  })
   ```
 
 - Updated dependencies []:
@@ -2170,11 +2158,11 @@
   pluginReactQuery({
     suspense: {},
     infinite: {
-      queryParam: "pageSize",
+      queryParam: 'pageSize',
       initialPageParam: 0,
-      cursorParam: "nextCursor", // optional
+      cursorParam: 'nextCursor', // optional
     },
-  });
+  })
   ```
 
   This will generate hooks like `useFindPetsByTagsSuspenseInfinite` alongside the existing query hooks.

--- a/packages/plugin-redoc/CHANGELOG.md
+++ b/packages/plugin-redoc/CHANGELOG.md
@@ -13,25 +13,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ## 5.0.0-alpha.35
@@ -88,14 +76,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -103,25 +91,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -129,7 +117,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 

--- a/packages/plugin-ts/CHANGELOG.md
+++ b/packages/plugin-ts/CHANGELOG.md
@@ -13,25 +13,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -133,14 +121,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -148,25 +136,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -174,7 +162,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -277,22 +265,22 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
@@ -304,22 +292,22 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
@@ -398,9 +386,9 @@
 
   ```typescript
   pluginTs({
-    enumType: "asConst",
-    enumTypeSuffix: "Value", // → export type PetTypeValue = …
-  });
+    enumType: 'asConst',
+    enumTypeSuffix: 'Value', // → export type PetTypeValue = …
+  })
   ```
 
   Set `enumTypeSuffix: ''` to suppress the suffix entirely and use only the base type name.
@@ -545,13 +533,13 @@
 
   ```ts
   // Before — only individual param types
-  export type ListPetsQueryLimit = number;
+  export type ListPetsQueryLimit = number
 
   // After — grouped type added
-  export type ListPetsQueryLimit = number;
+  export type ListPetsQueryLimit = number
   export type ListPetsQueryParams = {
-    limit?: ListPetsQueryLimit;
-  };
+    limit?: ListPetsQueryLimit
+  }
   ```
 
 - [#2854](https://github.com/kubb-labs/kubb/pull/2854) [`68a3bdd`](https://github.com/kubb-labs/kubb/commit/68a3bdd2eb85b3bd78e278ba9e4a0b691b580c7e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - minItems/maxItems on arrays should not be emitted as @minLength/@maxLength
@@ -1067,8 +1055,8 @@
 
   ```typescript
   pluginTs({
-    integerType: "number", // 'number' | 'bigint', default: 'bigint'
-  });
+    integerType: 'number', // 'number' | 'bigint', default: 'bigint'
+  })
   ```
 
 ### Patch Changes
@@ -1296,20 +1284,20 @@
   **Usage:**
 
   ```typescript
-  import { defineConfig } from "@kubb/core";
-  import { pluginTs } from "@kubb/plugin-ts";
-  import { pluginClient } from "@kubb/plugin-client";
+  import { defineConfig } from '@kubb/core'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
 
   export default defineConfig({
     plugins: [
       pluginTs({
-        paramsCasing: "camelcase", // Transform types
+        paramsCasing: 'camelcase', // Transform types
       }),
       pluginClient({
-        paramsCasing: "camelcase", // Transform client code
+        paramsCasing: 'camelcase', // Transform client code
       }),
     ],
-  });
+  })
   ```
 
   **Example:**
@@ -1465,7 +1453,7 @@
   ```typescript
   pluginOas({
     collisionDetection: true, // Recommended - prevents all collision types
-  });
+  })
   ```
 
 - Updated dependencies [[`996f3b2`](https://github.com/kubb-labs/kubb/commit/996f3b26d8c2167c3e77b734275c204e6c1b159c)]:
@@ -1586,28 +1574,28 @@
   export default {
     plugins: [
       pluginTs({
-        enumKeyCasing: "screamingSnakeCase",
+        enumKeyCasing: 'screamingSnakeCase',
       }),
     ],
-  };
+  }
   ```
 
   Before:
 
   ```typescript
   export const enumStringEnum = {
-    "created at": "created at",
-    "FILE.UPLOADED": "FILE.UPLOADED",
-  } as const;
+    'created at': 'created at',
+    'FILE.UPLOADED': 'FILE.UPLOADED',
+  } as const
   ```
 
   After:
 
   ```typescript
   export const enumStringEnum = {
-    CREATED_AT: "created at",
-    FILE_UPLOADED: "FILE.UPLOADED",
-  } as const;
+    CREATED_AT: 'created at',
+    FILE_UPLOADED: 'FILE.UPLOADED',
+  } as const
   ```
 
   **Additional improvements:**
@@ -1649,20 +1637,20 @@
 
   ```typescript
   export type QueryParams = {
-    include?: "author" | "tags"; // TS2411: not assignable to string
-    page?: { number?: number }; // TS2411: not assignable to string
-    [key: string]: string;
-  };
+    include?: 'author' | 'tags' // TS2411: not assignable to string
+    page?: { number?: number } // TS2411: not assignable to string
+    [key: string]: string
+  }
   ```
 
   **After:**
 
   ```typescript
   export type QueryParams = {
-    include?: "author" | "tags";
-    page?: { number?: number };
-    [key: string]: unknown; // All properties compatible
-  };
+    include?: 'author' | 'tags'
+    page?: { number?: number }
+    [key: string]: unknown // All properties compatible
+  }
   ```
 
 - Updated dependencies []:
@@ -1700,24 +1688,23 @@
 
   ```typescript
   pluginTs({
-    enumType: "inlineLiteral",
-  });
+    enumType: 'inlineLiteral',
+  })
   ```
 
   **Before (enumType: 'asConst' - default):**
 
   ```typescript
   export const petStatusEnum = {
-    available: "available",
-    pending: "pending",
-    sold: "sold",
-  } as const;
+    available: 'available',
+    pending: 'pending',
+    sold: 'sold',
+  } as const
 
-  export type PetStatusEnumKey =
-    (typeof petStatusEnum)[keyof typeof petStatusEnum];
+  export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
   export interface Pet {
-    status?: PetStatusEnumKey;
+    status?: PetStatusEnumKey
   }
   ```
 
@@ -1725,7 +1712,7 @@
 
   ```typescript
   export interface Pet {
-    status?: "available" | "pending" | "sold";
+    status?: 'available' | 'pending' | 'sold'
   }
   ```
 

--- a/packages/plugin-vue-query/CHANGELOG.md
+++ b/packages/plugin-vue-query/CHANGELOG.md
@@ -34,25 +34,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -95,13 +83,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -179,14 +167,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -194,25 +182,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -220,7 +208,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -1261,20 +1249,20 @@
   **Usage:**
 
   ```typescript
-  import { defineConfig } from "@kubb/core";
-  import { pluginTs } from "@kubb/plugin-ts";
-  import { pluginClient } from "@kubb/plugin-client";
+  import { defineConfig } from '@kubb/core'
+  import { pluginTs } from '@kubb/plugin-ts'
+  import { pluginClient } from '@kubb/plugin-client'
 
   export default defineConfig({
     plugins: [
       pluginTs({
-        paramsCasing: "camelcase", // Transform types
+        paramsCasing: 'camelcase', // Transform types
       }),
       pluginClient({
-        paramsCasing: "camelcase", // Transform client code
+        paramsCasing: 'camelcase', // Transform client code
       }),
     ],
-  });
+  })
   ```
 
   **Example:**
@@ -1971,7 +1959,7 @@
   pluginReactQuery({
     mutation: false, // Now properly prevents mutation hook generation
     query: true, // Only generates queryOptions
-  });
+  })
   ```
 
 - Updated dependencies []:

--- a/packages/plugin-zod/CHANGELOG.md
+++ b/packages/plugin-zod/CHANGELOG.md
@@ -25,25 +25,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
 ### Patch Changes
@@ -115,14 +103,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -130,25 +118,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -156,7 +144,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -244,22 +232,22 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
@@ -271,22 +259,22 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
@@ -1212,7 +1200,7 @@
   ```typescript
   export const postApiExampleMutationRequestSchema = z.object({
     email: z.string().nullish(), // ❌ Error: .nullish() doesn't exist in Zod Mini
-  });
+  })
   ```
 
   **After** (this fix):
@@ -1220,7 +1208,7 @@
   ```typescript
   export const postApiExampleMutationRequestSchema = z.object({
     email: z.nullish(z.string()), // ✅ Correct functional wrapper
-  });
+  })
   ```
 
   This fix ensures consistency with how `optional` and `nullable` modifiers were already being handled in mini mode.
@@ -1293,7 +1281,7 @@
   ```typescript
   pluginOas({
     collisionDetection: true, // Recommended - prevents all collision types
-  });
+  })
   ```
 
 - Updated dependencies [[`996f3b2`](https://github.com/kubb-labs/kubb/commit/996f3b26d8c2167c3e77b734275c204e6c1b159c)]:

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPet.ts
@@ -20,7 +20,6 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
  * @description Invalid input
  */
 export function addPetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPet.ts
@@ -12,7 +12,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus200 {
-
   return pet(data)
 }
 
@@ -27,11 +26,9 @@ export function addPetStatus405() {
  * @description Create a new pet in the store
  */
 export function addPetData(data?: Partial<AddPetData>): AddPetData {
-
   return addPetRequest(data)
 }
 
 export function addPetResponse(_data?: AddPetResponse): AddPetResponse {
-
   return faker.helpers.arrayElement<any>([addPetStatus200(), addPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUser.ts
@@ -10,7 +10,6 @@ import { user } from "./user.ts";
  * @description successful operation
  */
 export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>): CreateUserStatusDefault {
-
   return user(data)
 }
 
@@ -18,11 +17,9 @@ export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>)
  * @description Created user object
  */
 export function createUserData(data?: Partial<CreateUserData>): CreateUserData {
-
   return user(data)
 }
 
 export function createUserResponse(data?: Partial<CreateUserResponse>): CreateUserResponse {
-
   return createUserStatusDefault(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUsersWithListInput.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWithListInputStatus200>): CreateUsersWithListInputStatus200 {
-
   return user(data)
 }
 
@@ -23,7 +22,6 @@ export function createUsersWithListInputStatusDefault() {
 }
 
 export function createUsersWithListInputData(data?: CreateUsersWithListInputData): CreateUsersWithListInputData {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function createUsersWithListInputData(data?: CreateUsersWithListInputData
 }
 
 export function createUsersWithListInputResponse(_data?: CreateUsersWithListInputResponse): CreateUsersWithListInputResponse {
-
   return faker.helpers.arrayElement<any>([createUsersWithListInputStatus200(), createUsersWithListInputStatusDefault()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUsersWithListInput.ts
@@ -19,7 +19,6 @@ export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWith
  * @description successful operation
  */
 export function createUsersWithListInputStatusDefault() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteOrder.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderResponse } from "../types/DeleteOrder.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteOrderPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -26,6 +25,5 @@ export function deleteOrderStatus404() {
 }
 
 export function deleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-
   return faker.helpers.arrayElement<any>([deleteOrderStatus400(), deleteOrderStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteOrder.ts
@@ -15,7 +15,6 @@ export function deleteOrderPathOrderId(data?: number): number {
  * @description Invalid ID supplied
  */
 export function deleteOrderStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteOrderStatus400() {
  * @description Order not found
  */
 export function deleteOrderStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deletePet.ts
@@ -19,11 +19,9 @@ export function deletePetPathPetId(data?: number): number {
  * @description Invalid pet value
  */
 export function deletePetStatus400() {
-
   return undefined
 }
 
 export function deletePetResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deletePet.ts
@@ -6,12 +6,10 @@
 import { faker } from "@faker-js/faker";
 
 export function deletePetHeaderApiKey(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function deletePetPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteUser.ts
@@ -15,7 +15,6 @@ export function deleteUserPathUsername(data?: string): string {
  * @description Invalid username supplied
  */
 export function deleteUserStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteUserStatus400() {
  * @description User not found
  */
 export function deleteUserStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/deleteUser.ts
@@ -7,7 +7,6 @@ import type { DeleteUserResponse } from "../types/DeleteUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -26,6 +25,5 @@ export function deleteUserStatus404() {
 }
 
 export function deleteUserResponse(_data?: DeleteUserResponse): DeleteUserResponse {
-
   return faker.helpers.arrayElement<any>([deleteUserStatus400(), deleteUserStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getInventory.ts
@@ -6,13 +6,17 @@
 import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetInventory.ts";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
-  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
+  const defaultFakeData = {}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {
-
   return getInventoryStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getInventory.ts
@@ -8,12 +8,10 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-
-  return {
-    ...{},
-    ...(data || {})
-  }
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
+  const _defaults = {}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
+  return result
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getInventory.ts
@@ -8,10 +8,8 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
-  const _defaults = {}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
-  return result
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getOrderById.ts
@@ -8,7 +8,6 @@ import { order } from "./order.ts";
 import { faker } from "@faker-js/faker";
 
 export function getOrderByIdPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getOrderByIdPathOrderId(data?: number): number {
  * @description successful operation
  */
 export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): GetOrderByIdStatus200 {
-
   return order(data)
 }
 
@@ -35,6 +33,5 @@ export function getOrderByIdStatus404() {
 }
 
 export function getOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-
   return faker.helpers.arrayElement<any>([getOrderByIdStatus200(), getOrderByIdStatus400(), getOrderByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getOrderById.ts
@@ -24,7 +24,6 @@ export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): Ge
  * @description Invalid ID supplied
  */
 export function getOrderByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getOrderByIdStatus400() {
  * @description Order not found
  */
 export function getOrderByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getUserByName.ts
@@ -24,7 +24,6 @@ export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): 
  * @description Invalid username supplied
  */
 export function getUserByNameStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getUserByNameStatus400() {
  * @description User not found
  */
 export function getUserByNameStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/getUserByName.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function getUserByNamePathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -16,7 +15,6 @@ export function getUserByNamePathUsername(data?: string): string {
  * @description successful operation
  */
 export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): GetUserByNameStatus200 {
-
   return user(data)
 }
 
@@ -35,6 +33,5 @@ export function getUserByNameStatus404() {
 }
 
 export function getUserByNameResponse(_data?: GetUserByNameResponse): GetUserByNameResponse {
-
   return faker.helpers.arrayElement<any>([getUserByNameStatus200(), getUserByNameStatus400(), getUserByNameStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/loginUser.ts
@@ -28,7 +28,6 @@ export function loginUserStatus200(data?: string): string {
  * @description Invalid username/password supplied
  */
 export function loginUserStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/loginUser.ts
@@ -7,12 +7,10 @@ import type { LoginUserResponse } from "../types/LoginUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function loginUserQueryUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function loginUserQueryPassword(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -20,7 +18,6 @@ export function loginUserQueryPassword(data?: string): string {
  * @description successful operation
  */
 export function loginUserStatus200(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -32,6 +29,5 @@ export function loginUserStatus400() {
 }
 
 export function loginUserResponse(_data?: LoginUserResponse): LoginUserResponse {
-
   return faker.helpers.arrayElement<any>([loginUserStatus200(), loginUserStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/logoutUser.ts
@@ -7,11 +7,9 @@
  * @description successful operation
  */
 export function logoutUserStatusDefault() {
-
   return undefined
 }
 
 export function logoutUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/pet.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/pet.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/pet.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/placeOrder.ts
@@ -19,7 +19,6 @@ export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceO
  * @description Invalid input
  */
 export function placeOrderStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/placeOrder.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description successful operation
  */
 export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceOrderStatus200 {
-
   return order(data)
 }
 
@@ -23,11 +22,9 @@ export function placeOrderStatus405() {
 }
 
 export function placeOrderData(data?: Partial<PlaceOrderData>): PlaceOrderData {
-
   return order(data)
 }
 
 export function placeOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-
   return faker.helpers.arrayElement<any>([placeOrderStatus200(), placeOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updateUser.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function updateUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -23,7 +22,6 @@ export function updateUserStatusDefault() {
  * @description Update an existent user in the store
  */
 export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
-
   return user(data)
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/updateUser.ts
@@ -16,7 +16,6 @@ export function updateUserPathUsername(data?: string): string {
  * @description successful operation
  */
 export function updateUserStatusDefault() {
-
   return undefined
 }
 
@@ -29,6 +28,5 @@ export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
 }
 
 export function updateUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "./apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUser.ts
@@ -10,7 +10,6 @@ import { user } from "./user.ts";
  * @description successful operation
  */
 export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>): CreateUserStatusDefault {
-
   return user(data)
 }
 
@@ -18,11 +17,9 @@ export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>)
  * @description Created user object
  */
 export function createUserData(data?: Partial<CreateUserData>): CreateUserData {
-
   return user(data)
 }
 
 export function createUserResponse(data?: Partial<CreateUserResponse>): CreateUserResponse {
-
   return createUserStatusDefault(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUsersWithListInput.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWithListInputStatus200>): CreateUsersWithListInputStatus200 {
-
   return user(data)
 }
 
@@ -23,7 +22,6 @@ export function createUsersWithListInputStatusDefault() {
 }
 
 export function createUsersWithListInputData(data?: CreateUsersWithListInputData): CreateUsersWithListInputData {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function createUsersWithListInputData(data?: CreateUsersWithListInputData
 }
 
 export function createUsersWithListInputResponse(_data?: CreateUsersWithListInputResponse): CreateUsersWithListInputResponse {
-
   return faker.helpers.arrayElement<any>([createUsersWithListInputStatus200(), createUsersWithListInputStatusDefault()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUsersWithListInput.ts
@@ -19,7 +19,6 @@ export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWith
  * @description successful operation
  */
 export function createUsersWithListInputStatusDefault() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteOrder.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderResponse } from "../types/DeleteOrder.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteOrderPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -26,6 +25,5 @@ export function deleteOrderStatus404() {
 }
 
 export function deleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-
   return faker.helpers.arrayElement<any>([deleteOrderStatus400(), deleteOrderStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteOrder.ts
@@ -15,7 +15,6 @@ export function deleteOrderPathOrderId(data?: number): number {
  * @description Invalid ID supplied
  */
 export function deleteOrderStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteOrderStatus400() {
  * @description Order not found
  */
 export function deleteOrderStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteUser.ts
@@ -15,7 +15,6 @@ export function deleteUserPathUsername(data?: string): string {
  * @description Invalid username supplied
  */
 export function deleteUserStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteUserStatus400() {
  * @description User not found
  */
 export function deleteUserStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/deleteUser.ts
@@ -7,7 +7,6 @@ import type { DeleteUserResponse } from "../types/DeleteUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -26,6 +25,5 @@ export function deleteUserStatus404() {
 }
 
 export function deleteUserResponse(_data?: DeleteUserResponse): DeleteUserResponse {
-
   return faker.helpers.arrayElement<any>([deleteUserStatus400(), deleteUserStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getInventory.ts
@@ -6,13 +6,17 @@
 import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetInventory.ts";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
-  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
+  const defaultFakeData = {}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {
-
   return getInventoryStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getInventory.ts
@@ -8,12 +8,10 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-
-  return {
-    ...{},
-    ...(data || {})
-  }
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
+  const _defaults = {}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
+  return result
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getInventory.ts
@@ -8,10 +8,8 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
-  const _defaults = {}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
-  return result
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getOrderById.ts
@@ -8,7 +8,6 @@ import { order } from "./order.ts";
 import { faker } from "@faker-js/faker";
 
 export function getOrderByIdPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getOrderByIdPathOrderId(data?: number): number {
  * @description successful operation
  */
 export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): GetOrderByIdStatus200 {
-
   return order(data)
 }
 
@@ -35,6 +33,5 @@ export function getOrderByIdStatus404() {
 }
 
 export function getOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-
   return faker.helpers.arrayElement<any>([getOrderByIdStatus200(), getOrderByIdStatus400(), getOrderByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getOrderById.ts
@@ -24,7 +24,6 @@ export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): Ge
  * @description Invalid ID supplied
  */
 export function getOrderByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getOrderByIdStatus400() {
  * @description Order not found
  */
 export function getOrderByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getUserByName.ts
@@ -24,7 +24,6 @@ export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): 
  * @description Invalid username supplied
  */
 export function getUserByNameStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getUserByNameStatus400() {
  * @description User not found
  */
 export function getUserByNameStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/getUserByName.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function getUserByNamePathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -16,7 +15,6 @@ export function getUserByNamePathUsername(data?: string): string {
  * @description successful operation
  */
 export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): GetUserByNameStatus200 {
-
   return user(data)
 }
 
@@ -35,6 +33,5 @@ export function getUserByNameStatus404() {
 }
 
 export function getUserByNameResponse(_data?: GetUserByNameResponse): GetUserByNameResponse {
-
   return faker.helpers.arrayElement<any>([getUserByNameStatus200(), getUserByNameStatus400(), getUserByNameStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/loginUser.ts
@@ -28,7 +28,6 @@ export function loginUserStatus200(data?: string): string {
  * @description Invalid username/password supplied
  */
 export function loginUserStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/loginUser.ts
@@ -7,12 +7,10 @@ import type { LoginUserResponse } from "../types/LoginUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function loginUserQueryUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function loginUserQueryPassword(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -20,7 +18,6 @@ export function loginUserQueryPassword(data?: string): string {
  * @description successful operation
  */
 export function loginUserStatus200(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -32,6 +29,5 @@ export function loginUserStatus400() {
 }
 
 export function loginUserResponse(_data?: LoginUserResponse): LoginUserResponse {
-
   return faker.helpers.arrayElement<any>([loginUserStatus200(), loginUserStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/logoutUser.ts
@@ -7,11 +7,9 @@
  * @description successful operation
  */
 export function logoutUserStatusDefault() {
-
   return undefined
 }
 
 export function logoutUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/pet.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/pet.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/pet.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/placeOrder.ts
@@ -19,7 +19,6 @@ export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceO
  * @description Invalid input
  */
 export function placeOrderStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/placeOrder.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description successful operation
  */
 export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceOrderStatus200 {
-
   return order(data)
 }
 
@@ -23,11 +22,9 @@ export function placeOrderStatus405() {
 }
 
 export function placeOrderData(data?: Partial<PlaceOrderData>): PlaceOrderData {
-
   return order(data)
 }
 
 export function placeOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-
   return faker.helpers.arrayElement<any>([placeOrderStatus200(), placeOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updateUser.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function updateUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -23,7 +22,6 @@ export function updateUserStatusDefault() {
  * @description Update an existent user in the store
  */
 export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
-
   return user(data)
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/updateUser.ts
@@ -16,7 +16,6 @@ export function updateUserPathUsername(data?: string): string {
  * @description successful operation
  */
 export function updateUserStatusDefault() {
-
   return undefined
 }
 
@@ -29,6 +28,5 @@ export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
 }
 
 export function updateUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "./apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/addPet.ts
@@ -20,7 +20,6 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
  * @description Invalid input
  */
 export function addPetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/addPet.ts
@@ -12,7 +12,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus200 {
-
   return pet(data)
 }
 
@@ -27,11 +26,9 @@ export function addPetStatus405() {
  * @description Create a new pet in the store
  */
 export function addPetData(data?: Partial<AddPetData>): AddPetData {
-
   return addPetRequest(data)
 }
 
 export function addPetResponse(_data?: AddPetResponse): AddPetResponse {
-
   return faker.helpers.arrayElement<any>([addPetStatus200(), addPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/deletePet.ts
@@ -19,11 +19,9 @@ export function deletePetPathPetId(data?: number): number {
  * @description Invalid pet value
  */
 export function deletePetStatus400() {
-
   return undefined
 }
 
 export function deletePetResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/deletePet.ts
@@ -6,12 +6,10 @@
 import { faker } from "@faker-js/faker";
 
 export function deletePetHeaderApiKey(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function deletePetPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "../pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "../pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "../pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/petController/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "../apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/deleteOrder.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderResponse } from "../../types/DeleteOrder.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteOrderPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -26,6 +25,5 @@ export function deleteOrderStatus404() {
 }
 
 export function deleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-
   return faker.helpers.arrayElement<any>([deleteOrderStatus400(), deleteOrderStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/deleteOrder.ts
@@ -15,7 +15,6 @@ export function deleteOrderPathOrderId(data?: number): number {
  * @description Invalid ID supplied
  */
 export function deleteOrderStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteOrderStatus400() {
  * @description Order not found
  */
 export function deleteOrderStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/getInventory.ts
@@ -6,17 +6,17 @@
 import type { GetInventoryResponse, GetInventoryStatus200 } from "../../types/GetInventory.ts";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
+  const defaultFakeData = {}
   return {
-    ...{},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {
-
   return getInventoryStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/getOrderById.ts
@@ -24,7 +24,6 @@ export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): Ge
  * @description Invalid ID supplied
  */
 export function getOrderByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getOrderByIdStatus400() {
  * @description Order not found
  */
 export function getOrderByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/getOrderById.ts
@@ -8,7 +8,6 @@ import { order } from "../order.ts";
 import { faker } from "@faker-js/faker";
 
 export function getOrderByIdPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getOrderByIdPathOrderId(data?: number): number {
  * @description successful operation
  */
 export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): GetOrderByIdStatus200 {
-
   return order(data)
 }
 
@@ -35,6 +33,5 @@ export function getOrderByIdStatus404() {
 }
 
 export function getOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-
   return faker.helpers.arrayElement<any>([getOrderByIdStatus200(), getOrderByIdStatus400(), getOrderByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/placeOrder.ts
@@ -19,7 +19,6 @@ export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceO
  * @description Invalid input
  */
 export function placeOrderStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/storeController/placeOrder.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description successful operation
  */
 export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceOrderStatus200 {
-
   return order(data)
 }
 
@@ -23,11 +22,9 @@ export function placeOrderStatus405() {
 }
 
 export function placeOrderData(data?: Partial<PlaceOrderData>): PlaceOrderData {
-
   return order(data)
 }
 
 export function placeOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-
   return faker.helpers.arrayElement<any>([placeOrderStatus200(), placeOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/createUser.ts
@@ -10,7 +10,6 @@ import { user } from "../user.ts";
  * @description successful operation
  */
 export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>): CreateUserStatusDefault {
-
   return user(data)
 }
 
@@ -18,11 +17,9 @@ export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>)
  * @description Created user object
  */
 export function createUserData(data?: Partial<CreateUserData>): CreateUserData {
-
   return user(data)
 }
 
 export function createUserResponse(data?: Partial<CreateUserResponse>): CreateUserResponse {
-
   return createUserStatusDefault(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/createUsersWithListInput.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWithListInputStatus200>): CreateUsersWithListInputStatus200 {
-
   return user(data)
 }
 
@@ -23,7 +22,6 @@ export function createUsersWithListInputStatusDefault() {
 }
 
 export function createUsersWithListInputData(data?: CreateUsersWithListInputData): CreateUsersWithListInputData {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function createUsersWithListInputData(data?: CreateUsersWithListInputData
 }
 
 export function createUsersWithListInputResponse(_data?: CreateUsersWithListInputResponse): CreateUsersWithListInputResponse {
-
   return faker.helpers.arrayElement<any>([createUsersWithListInputStatus200(), createUsersWithListInputStatusDefault()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/createUsersWithListInput.ts
@@ -19,7 +19,6 @@ export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWith
  * @description successful operation
  */
 export function createUsersWithListInputStatusDefault() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/deleteUser.ts
@@ -15,7 +15,6 @@ export function deleteUserPathUsername(data?: string): string {
  * @description Invalid username supplied
  */
 export function deleteUserStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteUserStatus400() {
  * @description User not found
  */
 export function deleteUserStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/deleteUser.ts
@@ -7,7 +7,6 @@ import type { DeleteUserResponse } from "../../types/DeleteUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -26,6 +25,5 @@ export function deleteUserStatus404() {
 }
 
 export function deleteUserResponse(_data?: DeleteUserResponse): DeleteUserResponse {
-
   return faker.helpers.arrayElement<any>([deleteUserStatus400(), deleteUserStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/getUserByName.ts
@@ -8,7 +8,6 @@ import { user } from "../user.ts";
 import { faker } from "@faker-js/faker";
 
 export function getUserByNamePathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -16,7 +15,6 @@ export function getUserByNamePathUsername(data?: string): string {
  * @description successful operation
  */
 export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): GetUserByNameStatus200 {
-
   return user(data)
 }
 
@@ -35,6 +33,5 @@ export function getUserByNameStatus404() {
 }
 
 export function getUserByNameResponse(_data?: GetUserByNameResponse): GetUserByNameResponse {
-
   return faker.helpers.arrayElement<any>([getUserByNameStatus200(), getUserByNameStatus400(), getUserByNameStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/getUserByName.ts
@@ -24,7 +24,6 @@ export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): 
  * @description Invalid username supplied
  */
 export function getUserByNameStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getUserByNameStatus400() {
  * @description User not found
  */
 export function getUserByNameStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/loginUser.ts
@@ -28,7 +28,6 @@ export function loginUserStatus200(data?: string): string {
  * @description Invalid username/password supplied
  */
 export function loginUserStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/loginUser.ts
@@ -7,12 +7,10 @@ import type { LoginUserResponse } from "../../types/LoginUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function loginUserQueryUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function loginUserQueryPassword(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -20,7 +18,6 @@ export function loginUserQueryPassword(data?: string): string {
  * @description successful operation
  */
 export function loginUserStatus200(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -32,6 +29,5 @@ export function loginUserStatus400() {
 }
 
 export function loginUserResponse(_data?: LoginUserResponse): LoginUserResponse {
-
   return faker.helpers.arrayElement<any>([loginUserStatus200(), loginUserStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/logoutUser.ts
@@ -7,11 +7,9 @@
  * @description successful operation
  */
 export function logoutUserStatusDefault() {
-
   return undefined
 }
 
 export function logoutUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/updateUser.ts
@@ -16,7 +16,6 @@ export function updateUserPathUsername(data?: string): string {
  * @description successful operation
  */
 export function updateUserStatusDefault() {
-
   return undefined
 }
 
@@ -29,6 +28,5 @@ export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
 }
 
 export function updateUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/userController/updateUser.ts
@@ -8,7 +8,6 @@ import { user } from "../user.ts";
 import { faker } from "@faker-js/faker";
 
 export function updateUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -23,7 +22,6 @@ export function updateUserStatusDefault() {
  * @description Update an existent user in the store
  */
 export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
-
   return user(data)
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPet.ts
@@ -20,7 +20,6 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
  * @description Invalid input
  */
 export function addPetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPet.ts
@@ -12,7 +12,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus200 {
-
   return pet(data)
 }
 
@@ -27,11 +26,9 @@ export function addPetStatus405() {
  * @description Create a new pet in the store
  */
 export function addPetData(data?: Partial<AddPetData>): AddPetData {
-
   return addPetRequest(data)
 }
 
 export function addPetResponse(_data?: AddPetResponse): AddPetResponse {
-
   return faker.helpers.arrayElement<any>([addPetStatus200(), addPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/deletePet.ts
@@ -19,11 +19,9 @@ export function deletePetPathPetId(data?: number): number {
  * @description Invalid pet value
  */
 export function deletePetStatus400() {
-
   return undefined
 }
 
 export function deletePetResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/deletePet.ts
@@ -6,12 +6,10 @@
 import { faker } from "@faker-js/faker";
 
 export function deletePetHeaderApiKey(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function deletePetPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/pet.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/pet.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/pet.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "./apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPet.ts
@@ -20,7 +20,6 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
  * @description Invalid input
  */
 export function addPetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPet.ts
@@ -12,7 +12,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus200 {
-
   return pet(data)
 }
 
@@ -27,11 +26,9 @@ export function addPetStatus405() {
  * @description Create a new pet in the store
  */
 export function addPetData(data?: Partial<AddPetData>): AddPetData {
-
   return addPetRequest(data)
 }
 
 export function addPetResponse(_data?: AddPetResponse): AddPetResponse {
-
   return faker.helpers.arrayElement<any>([addPetStatus200(), addPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createUser.ts
@@ -10,7 +10,6 @@ import { user } from "./user.ts";
  * @description successful operation
  */
 export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>): CreateUserStatusDefault {
-
   return user(data)
 }
 
@@ -18,11 +17,9 @@ export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>)
  * @description Created user object
  */
 export function createUserData(data?: Partial<CreateUserData>): CreateUserData {
-
   return user(data)
 }
 
 export function createUserResponse(data?: Partial<CreateUserResponse>): CreateUserResponse {
-
   return createUserStatusDefault(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createUsersWithListInput.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWithListInputStatus200>): CreateUsersWithListInputStatus200 {
-
   return user(data)
 }
 
@@ -23,7 +22,6 @@ export function createUsersWithListInputStatusDefault() {
 }
 
 export function createUsersWithListInputData(data?: CreateUsersWithListInputData): CreateUsersWithListInputData {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function createUsersWithListInputData(data?: CreateUsersWithListInputData
 }
 
 export function createUsersWithListInputResponse(_data?: CreateUsersWithListInputResponse): CreateUsersWithListInputResponse {
-
   return faker.helpers.arrayElement<any>([createUsersWithListInputStatus200(), createUsersWithListInputStatusDefault()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createUsersWithListInput.ts
@@ -19,7 +19,6 @@ export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWith
  * @description successful operation
  */
 export function createUsersWithListInputStatusDefault() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteOrder.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderResponse } from "../types/DeleteOrder.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteOrderPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -26,6 +25,5 @@ export function deleteOrderStatus404() {
 }
 
 export function deleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-
   return faker.helpers.arrayElement<any>([deleteOrderStatus400(), deleteOrderStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteOrder.ts
@@ -15,7 +15,6 @@ export function deleteOrderPathOrderId(data?: number): number {
  * @description Invalid ID supplied
  */
 export function deleteOrderStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteOrderStatus400() {
  * @description Order not found
  */
 export function deleteOrderStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deletePet.ts
@@ -19,11 +19,9 @@ export function deletePetPathPetId(data?: number): number {
  * @description Invalid pet value
  */
 export function deletePetStatus400() {
-
   return undefined
 }
 
 export function deletePetResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deletePet.ts
@@ -6,12 +6,10 @@
 import { faker } from "@faker-js/faker";
 
 export function deletePetHeaderApiKey(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function deletePetPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteUser.ts
@@ -15,7 +15,6 @@ export function deleteUserPathUsername(data?: string): string {
  * @description Invalid username supplied
  */
 export function deleteUserStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteUserStatus400() {
  * @description User not found
  */
 export function deleteUserStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/deleteUser.ts
@@ -7,7 +7,6 @@ import type { DeleteUserResponse } from "../types/DeleteUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -26,6 +25,5 @@ export function deleteUserStatus404() {
 }
 
 export function deleteUserResponse(_data?: DeleteUserResponse): DeleteUserResponse {
-
   return faker.helpers.arrayElement<any>([deleteUserStatus400(), deleteUserStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getInventory.ts
@@ -6,13 +6,17 @@
 import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetInventory.ts";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
-  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
+  const defaultFakeData = {}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {
-
   return getInventoryStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getInventory.ts
@@ -8,12 +8,10 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-
-  return {
-    ...{},
-    ...(data || {})
-  }
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
+  const _defaults = {}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
+  return result
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getInventory.ts
@@ -8,10 +8,8 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
-  const _defaults = {}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
-  return result
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getOrderById.ts
@@ -8,7 +8,6 @@ import { order } from "./order.ts";
 import { faker } from "@faker-js/faker";
 
 export function getOrderByIdPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getOrderByIdPathOrderId(data?: number): number {
  * @description successful operation
  */
 export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): GetOrderByIdStatus200 {
-
   return order(data)
 }
 
@@ -35,6 +33,5 @@ export function getOrderByIdStatus404() {
 }
 
 export function getOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-
   return faker.helpers.arrayElement<any>([getOrderByIdStatus200(), getOrderByIdStatus400(), getOrderByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getOrderById.ts
@@ -24,7 +24,6 @@ export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): Ge
  * @description Invalid ID supplied
  */
 export function getOrderByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getOrderByIdStatus400() {
  * @description Order not found
  */
 export function getOrderByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getUserByName.ts
@@ -24,7 +24,6 @@ export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): 
  * @description Invalid username supplied
  */
 export function getUserByNameStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getUserByNameStatus400() {
  * @description User not found
  */
 export function getUserByNameStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/getUserByName.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function getUserByNamePathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -16,7 +15,6 @@ export function getUserByNamePathUsername(data?: string): string {
  * @description successful operation
  */
 export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): GetUserByNameStatus200 {
-
   return user(data)
 }
 
@@ -35,6 +33,5 @@ export function getUserByNameStatus404() {
 }
 
 export function getUserByNameResponse(_data?: GetUserByNameResponse): GetUserByNameResponse {
-
   return faker.helpers.arrayElement<any>([getUserByNameStatus200(), getUserByNameStatus400(), getUserByNameStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/loginUser.ts
@@ -28,7 +28,6 @@ export function loginUserStatus200(data?: string): string {
  * @description Invalid username/password supplied
  */
 export function loginUserStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/loginUser.ts
@@ -7,12 +7,10 @@ import type { LoginUserResponse } from "../types/LoginUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function loginUserQueryUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function loginUserQueryPassword(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -20,7 +18,6 @@ export function loginUserQueryPassword(data?: string): string {
  * @description successful operation
  */
 export function loginUserStatus200(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -32,6 +29,5 @@ export function loginUserStatus400() {
 }
 
 export function loginUserResponse(_data?: LoginUserResponse): LoginUserResponse {
-
   return faker.helpers.arrayElement<any>([loginUserStatus200(), loginUserStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/logoutUser.ts
@@ -7,11 +7,9 @@
  * @description successful operation
  */
 export function logoutUserStatusDefault() {
-
   return undefined
 }
 
 export function logoutUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": 'active',"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": 'active',"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": 'active',"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": 'active',"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": 'active',"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": 'active',"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/pet.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/pet.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/pet.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": 'active'}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/placeOrder.ts
@@ -19,7 +19,6 @@ export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceO
  * @description Invalid input
  */
 export function placeOrderStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/placeOrder.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description successful operation
  */
 export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceOrderStatus200 {
-
   return order(data)
 }
 
@@ -23,11 +22,9 @@ export function placeOrderStatus405() {
 }
 
 export function placeOrderData(data?: Partial<PlaceOrderData>): PlaceOrderData {
-
   return order(data)
 }
 
 export function placeOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-
   return faker.helpers.arrayElement<any>([placeOrderStatus200(), placeOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updateUser.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function updateUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -23,7 +22,6 @@ export function updateUserStatusDefault() {
  * @description Update an existent user in the store
  */
 export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
-
   return user(data)
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/updateUser.ts
@@ -16,7 +16,6 @@ export function updateUserPathUsername(data?: string): string {
  * @description successful operation
  */
 export function updateUserStatusDefault() {
-
   return undefined
 }
 
@@ -29,6 +28,5 @@ export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
 }
 
 export function updateUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "./apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/pet.ts
@@ -6,8 +6,6 @@
 import type { Pet } from "../types/Pet.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.string.alpha(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.string.alpha(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/pet.ts
@@ -6,10 +6,8 @@
 import type { Pet } from "../types/Pet.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.string.alpha(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.string.alpha(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/pet.ts
@@ -6,6 +6,11 @@
 import type { Pet } from "../types/Pet.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.string.alpha(),"name": faker.string.alpha()}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.string.alpha(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/petUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/petUpdate.ts
@@ -6,10 +6,8 @@
 import type { PetUpdate } from "../types/PetUpdate.ts";
 import { faker } from "@faker-js/faker";
 
-export function petUpdate(data?: Partial<PetUpdate>): PetUpdate {
-
-  return {
-    ...{"name": faker.string.alpha(),"description": faker.string.alpha()},
-    ...(data || {})
-  }
+export function petUpdate(data?: Partial<PetUpdate>): typeof _defaults & Omit<PetUpdate, keyof typeof _defaults> {
+  const _defaults = {"name": faker.string.alpha(),"description": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<PetUpdate, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/petUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/petUpdate.ts
@@ -6,8 +6,6 @@
 import type { PetUpdate } from "../types/PetUpdate.ts";
 import { faker } from "@faker-js/faker";
 
-export function petUpdate(data?: Partial<PetUpdate>): typeof _defaults & Omit<PetUpdate, keyof typeof _defaults> {
-  const _defaults = {"name": faker.string.alpha(),"description": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<PetUpdate, keyof typeof _defaults>
-  return result
+export function petUpdate(data?: Partial<PetUpdate>): Required<PetUpdate> {
+  return Object.assign({} as Required<PetUpdate>, {"name": faker.string.alpha(),"description": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/petUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/petUpdate.ts
@@ -6,6 +6,11 @@
 import type { PetUpdate } from "../types/PetUpdate.ts";
 import { faker } from "@faker-js/faker";
 
-export function petUpdate(data?: Partial<PetUpdate>): Required<PetUpdate> {
-  return Object.assign({} as Required<PetUpdate>, {"name": faker.string.alpha(),"description": faker.string.alpha()}, data)
+export function petUpdate(data?: Partial<PetUpdate>): Required<PetUpdate>
+{
+  const defaultFakeData = {"name": faker.string.alpha(),"description": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<PetUpdate>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/updatePet.ts
@@ -9,17 +9,14 @@ import { petUpdate } from "./petUpdate.ts";
 import { faker } from "@faker-js/faker";
 
 export function updatePetPathPetId(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetQueryIncludeDeleted(data?: boolean): boolean {
-
   return data ?? faker.datatype.boolean()
 }
 
 export function updatePetQueryRequestSource(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -27,16 +24,13 @@ export function updatePetQueryRequestSource(data?: string): string {
  * @description Success
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return petUpdate(data)
 }
 
 export function updatePetResponse(data?: Partial<UpdatePetResponse>): UpdatePetResponse {
-
   return updatePetStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPet.ts
@@ -20,7 +20,6 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
  * @description Invalid input
  */
 export function addPetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPet.ts
@@ -12,7 +12,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus200 {
-
   return pet(data)
 }
 
@@ -27,11 +26,9 @@ export function addPetStatus405() {
  * @description Create a new pet in the store
  */
 export function addPetData(data?: Partial<AddPetData>): AddPetData {
-
   return addPetRequest(data)
 }
 
 export function addPetResponse(_data?: AddPetResponse): AddPetResponse {
-
   return faker.helpers.arrayElement<any>([addPetStatus200(), addPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUser.ts
@@ -10,7 +10,6 @@ import { user } from "./user.ts";
  * @description successful operation
  */
 export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>): CreateUserStatusDefault {
-
   return user(data)
 }
 
@@ -18,11 +17,9 @@ export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>)
  * @description Created user object
  */
 export function createUserData(data?: Partial<CreateUserData>): CreateUserData {
-
   return user(data)
 }
 
 export function createUserResponse(data?: Partial<CreateUserResponse>): CreateUserResponse {
-
   return createUserStatusDefault(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUsersWithListInput.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWithListInputStatus200>): CreateUsersWithListInputStatus200 {
-
   return user(data)
 }
 
@@ -23,7 +22,6 @@ export function createUsersWithListInputStatusDefault() {
 }
 
 export function createUsersWithListInputData(data?: CreateUsersWithListInputData): CreateUsersWithListInputData {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function createUsersWithListInputData(data?: CreateUsersWithListInputData
 }
 
 export function createUsersWithListInputResponse(_data?: CreateUsersWithListInputResponse): CreateUsersWithListInputResponse {
-
   return faker.helpers.arrayElement<any>([createUsersWithListInputStatus200(), createUsersWithListInputStatusDefault()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUsersWithListInput.ts
@@ -19,7 +19,6 @@ export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWith
  * @description successful operation
  */
 export function createUsersWithListInputStatusDefault() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteOrder.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderResponse } from "../types/DeleteOrder.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteOrderPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -26,6 +25,5 @@ export function deleteOrderStatus404() {
 }
 
 export function deleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-
   return faker.helpers.arrayElement<any>([deleteOrderStatus400(), deleteOrderStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteOrder.ts
@@ -15,7 +15,6 @@ export function deleteOrderPathOrderId(data?: number): number {
  * @description Invalid ID supplied
  */
 export function deleteOrderStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteOrderStatus400() {
  * @description Order not found
  */
 export function deleteOrderStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deletePet.ts
@@ -19,11 +19,9 @@ export function deletePetPathPetId(data?: number): number {
  * @description Invalid pet value
  */
 export function deletePetStatus400() {
-
   return undefined
 }
 
 export function deletePetResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deletePet.ts
@@ -6,12 +6,10 @@
 import { faker } from "@faker-js/faker";
 
 export function deletePetHeaderApiKey(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function deletePetPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteUser.ts
@@ -15,7 +15,6 @@ export function deleteUserPathUsername(data?: string): string {
  * @description Invalid username supplied
  */
 export function deleteUserStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteUserStatus400() {
  * @description User not found
  */
 export function deleteUserStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/deleteUser.ts
@@ -7,7 +7,6 @@ import type { DeleteUserResponse } from "../types/DeleteUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -26,6 +25,5 @@ export function deleteUserStatus404() {
 }
 
 export function deleteUserResponse(_data?: DeleteUserResponse): DeleteUserResponse {
-
   return faker.helpers.arrayElement<any>([deleteUserStatus400(), deleteUserStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getInventory.ts
@@ -6,13 +6,17 @@
 import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetInventory.ts";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
-  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
+  const defaultFakeData = {}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {
-
   return getInventoryStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getInventory.ts
@@ -8,12 +8,10 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-
-  return {
-    ...{},
-    ...(data || {})
-  }
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
+  const _defaults = {}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
+  return result
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getInventory.ts
@@ -8,10 +8,8 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
-  const _defaults = {}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
-  return result
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getOrderById.ts
@@ -8,7 +8,6 @@ import { order } from "./order.ts";
 import { faker } from "@faker-js/faker";
 
 export function getOrderByIdPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getOrderByIdPathOrderId(data?: number): number {
  * @description successful operation
  */
 export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): GetOrderByIdStatus200 {
-
   return order(data)
 }
 
@@ -35,6 +33,5 @@ export function getOrderByIdStatus404() {
 }
 
 export function getOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-
   return faker.helpers.arrayElement<any>([getOrderByIdStatus200(), getOrderByIdStatus400(), getOrderByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getOrderById.ts
@@ -24,7 +24,6 @@ export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): Ge
  * @description Invalid ID supplied
  */
 export function getOrderByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getOrderByIdStatus400() {
  * @description Order not found
  */
 export function getOrderByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getUserByName.ts
@@ -24,7 +24,6 @@ export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): 
  * @description Invalid username supplied
  */
 export function getUserByNameStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getUserByNameStatus400() {
  * @description User not found
  */
 export function getUserByNameStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/getUserByName.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function getUserByNamePathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -16,7 +15,6 @@ export function getUserByNamePathUsername(data?: string): string {
  * @description successful operation
  */
 export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): GetUserByNameStatus200 {
-
   return user(data)
 }
 
@@ -35,6 +33,5 @@ export function getUserByNameStatus404() {
 }
 
 export function getUserByNameResponse(_data?: GetUserByNameResponse): GetUserByNameResponse {
-
   return faker.helpers.arrayElement<any>([getUserByNameStatus200(), getUserByNameStatus400(), getUserByNameStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/loginUser.ts
@@ -28,7 +28,6 @@ export function loginUserStatus200(data?: string): string {
  * @description Invalid username/password supplied
  */
 export function loginUserStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/loginUser.ts
@@ -7,12 +7,10 @@ import type { LoginUserResponse } from "../types/LoginUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function loginUserQueryUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function loginUserQueryPassword(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -20,7 +18,6 @@ export function loginUserQueryPassword(data?: string): string {
  * @description successful operation
  */
 export function loginUserStatus200(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -32,6 +29,5 @@ export function loginUserStatus400() {
 }
 
 export function loginUserResponse(_data?: LoginUserResponse): LoginUserResponse {
-
   return faker.helpers.arrayElement<any>([loginUserStatus200(), loginUserStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/logoutUser.ts
@@ -7,11 +7,9 @@
  * @description successful operation
  */
 export function logoutUserStatusDefault() {
-
   return undefined
 }
 
 export function logoutUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/pet.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/pet.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/pet.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/placeOrder.ts
@@ -19,7 +19,6 @@ export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceO
  * @description Invalid input
  */
 export function placeOrderStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/placeOrder.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description successful operation
  */
 export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceOrderStatus200 {
-
   return order(data)
 }
 
@@ -23,11 +22,9 @@ export function placeOrderStatus405() {
 }
 
 export function placeOrderData(data?: Partial<PlaceOrderData>): PlaceOrderData {
-
   return order(data)
 }
 
 export function placeOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-
   return faker.helpers.arrayElement<any>([placeOrderStatus200(), placeOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updateUser.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function updateUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -23,7 +22,6 @@ export function updateUserStatusDefault() {
  * @description Update an existent user in the store
  */
 export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
-
   return user(data)
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/updateUser.ts
@@ -16,7 +16,6 @@ export function updateUserPathUsername(data?: string): string {
  * @description successful operation
  */
 export function updateUserStatusDefault() {
-
   return undefined
 }
 
@@ -29,6 +28,5 @@ export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
 }
 
 export function updateUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "./apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPet.ts
@@ -20,7 +20,6 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
  * @description Invalid input
  */
 export function addPetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPet.ts
@@ -12,7 +12,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus200 {
-
   return pet(data)
 }
 
@@ -27,11 +26,9 @@ export function addPetStatus405() {
  * @description Create a new pet in the store
  */
 export function addPetData(data?: Partial<AddPetData>): AddPetData {
-
   return addPetRequest(data)
 }
 
 export function addPetResponse(_data?: AddPetResponse): AddPetResponse {
-
   return faker.helpers.arrayElement<any>([addPetStatus200(), addPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUser.ts
@@ -10,7 +10,6 @@ import { user } from "./user.ts";
  * @description successful operation
  */
 export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>): CreateUserStatusDefault {
-
   return user(data)
 }
 
@@ -18,11 +17,9 @@ export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>)
  * @description Created user object
  */
 export function createUserData(data?: Partial<CreateUserData>): CreateUserData {
-
   return user(data)
 }
 
 export function createUserResponse(data?: Partial<CreateUserResponse>): CreateUserResponse {
-
   return createUserStatusDefault(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUsersWithListInput.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWithListInputStatus200>): CreateUsersWithListInputStatus200 {
-
   return user(data)
 }
 
@@ -23,7 +22,6 @@ export function createUsersWithListInputStatusDefault() {
 }
 
 export function createUsersWithListInputData(data?: CreateUsersWithListInputData): CreateUsersWithListInputData {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function createUsersWithListInputData(data?: CreateUsersWithListInputData
 }
 
 export function createUsersWithListInputResponse(_data?: CreateUsersWithListInputResponse): CreateUsersWithListInputResponse {
-
   return faker.helpers.arrayElement<any>([createUsersWithListInputStatus200(), createUsersWithListInputStatusDefault()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUsersWithListInput.ts
@@ -19,7 +19,6 @@ export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWith
  * @description successful operation
  */
 export function createUsersWithListInputStatusDefault() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteOrder.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderResponse } from "../types/DeleteOrder.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteOrderPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -26,6 +25,5 @@ export function deleteOrderStatus404() {
 }
 
 export function deleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-
   return faker.helpers.arrayElement<any>([deleteOrderStatus400(), deleteOrderStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteOrder.ts
@@ -15,7 +15,6 @@ export function deleteOrderPathOrderId(data?: number): number {
  * @description Invalid ID supplied
  */
 export function deleteOrderStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteOrderStatus400() {
  * @description Order not found
  */
 export function deleteOrderStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deletePet.ts
@@ -19,11 +19,9 @@ export function deletePetPathPetId(data?: number): number {
  * @description Invalid pet value
  */
 export function deletePetStatus400() {
-
   return undefined
 }
 
 export function deletePetResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deletePet.ts
@@ -6,12 +6,10 @@
 import { faker } from "@faker-js/faker";
 
 export function deletePetHeaderApiKey(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function deletePetPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteUser.ts
@@ -15,7 +15,6 @@ export function deleteUserPathUsername(data?: string): string {
  * @description Invalid username supplied
  */
 export function deleteUserStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteUserStatus400() {
  * @description User not found
  */
 export function deleteUserStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/deleteUser.ts
@@ -7,7 +7,6 @@ import type { DeleteUserResponse } from "../types/DeleteUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -26,6 +25,5 @@ export function deleteUserStatus404() {
 }
 
 export function deleteUserResponse(_data?: DeleteUserResponse): DeleteUserResponse {
-
   return faker.helpers.arrayElement<any>([deleteUserStatus400(), deleteUserStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getInventory.ts
@@ -6,13 +6,17 @@
 import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetInventory.ts";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
-  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
+  const defaultFakeData = {}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {
-
   return getInventoryStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getInventory.ts
@@ -8,12 +8,10 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-
-  return {
-    ...{},
-    ...(data || {})
-  }
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
+  const _defaults = {}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
+  return result
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getInventory.ts
@@ -8,10 +8,8 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
-  const _defaults = {}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
-  return result
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getOrderById.ts
@@ -8,7 +8,6 @@ import { order } from "./order.ts";
 import { faker } from "@faker-js/faker";
 
 export function getOrderByIdPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getOrderByIdPathOrderId(data?: number): number {
  * @description successful operation
  */
 export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): GetOrderByIdStatus200 {
-
   return order(data)
 }
 
@@ -35,6 +33,5 @@ export function getOrderByIdStatus404() {
 }
 
 export function getOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-
   return faker.helpers.arrayElement<any>([getOrderByIdStatus200(), getOrderByIdStatus400(), getOrderByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getOrderById.ts
@@ -24,7 +24,6 @@ export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): Ge
  * @description Invalid ID supplied
  */
 export function getOrderByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getOrderByIdStatus400() {
  * @description Order not found
  */
 export function getOrderByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getUserByName.ts
@@ -24,7 +24,6 @@ export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): 
  * @description Invalid username supplied
  */
 export function getUserByNameStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getUserByNameStatus400() {
  * @description User not found
  */
 export function getUserByNameStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/getUserByName.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function getUserByNamePathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -16,7 +15,6 @@ export function getUserByNamePathUsername(data?: string): string {
  * @description successful operation
  */
 export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): GetUserByNameStatus200 {
-
   return user(data)
 }
 
@@ -35,6 +33,5 @@ export function getUserByNameStatus404() {
 }
 
 export function getUserByNameResponse(_data?: GetUserByNameResponse): GetUserByNameResponse {
-
   return faker.helpers.arrayElement<any>([getUserByNameStatus200(), getUserByNameStatus400(), getUserByNameStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/loginUser.ts
@@ -28,7 +28,6 @@ export function loginUserStatus200(data?: string): string {
  * @description Invalid username/password supplied
  */
 export function loginUserStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/loginUser.ts
@@ -7,12 +7,10 @@ import type { LoginUserResponse } from "../types/LoginUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function loginUserQueryUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function loginUserQueryPassword(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -20,7 +18,6 @@ export function loginUserQueryPassword(data?: string): string {
  * @description successful operation
  */
 export function loginUserStatus200(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -32,6 +29,5 @@ export function loginUserStatus400() {
 }
 
 export function loginUserResponse(_data?: LoginUserResponse): LoginUserResponse {
-
   return faker.helpers.arrayElement<any>([loginUserStatus200(), loginUserStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/logoutUser.ts
@@ -7,11 +7,9 @@
  * @description successful operation
  */
 export function logoutUserStatusDefault() {
-
   return undefined
 }
 
 export function logoutUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/pet.ts
@@ -9,10 +9,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": new RandExp("^[A-Za-z0-9()\\[\\]'\"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]'\"]$").gen(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": new RandExp("^[A-Za-z0-9()\\[\\]'\"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]'\"]$").gen(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/pet.ts
@@ -9,8 +9,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": new RandExp("^[A-Za-z0-9()\\[\\]'\"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]'\"]$").gen(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": new RandExp("^[A-Za-z0-9()\\[\\]'\"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]'\"]$").gen(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/pet.ts
@@ -9,6 +9,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": new RandExp("^[A-Za-z0-9()\\[\\]'\"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]'\"]$").gen(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": new RandExp("^[A-Za-z0-9()\\[\\]'\"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]'\"]$").gen(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/placeOrder.ts
@@ -19,7 +19,6 @@ export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceO
  * @description Invalid input
  */
 export function placeOrderStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/placeOrder.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description successful operation
  */
 export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceOrderStatus200 {
-
   return order(data)
 }
 
@@ -23,11 +22,9 @@ export function placeOrderStatus405() {
 }
 
 export function placeOrderData(data?: Partial<PlaceOrderData>): PlaceOrderData {
-
   return order(data)
 }
 
 export function placeOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-
   return faker.helpers.arrayElement<any>([placeOrderStatus200(), placeOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updateUser.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function updateUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -23,7 +22,6 @@ export function updateUserStatusDefault() {
  * @description Update an existent user in the store
  */
 export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
-
   return user(data)
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/updateUser.ts
@@ -16,7 +16,6 @@ export function updateUserPathUsername(data?: string): string {
  * @description successful operation
  */
 export function updateUserStatusDefault() {
-
   return undefined
 }
 
@@ -29,6 +28,5 @@ export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
 }
 
 export function updateUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "./apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/addPetRequest.ts
@@ -8,11 +8,12 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
   return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/address.ts
@@ -6,11 +6,12 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
+export function address(data?: Partial<Address>): Required<Address>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
   return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/apiResponse.ts
@@ -6,11 +6,12 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
   return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/category.ts
@@ -6,11 +6,12 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
+export function category(data?: Partial<Category>): Required<Category>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
   return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/customer.ts
@@ -7,11 +7,12 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
   return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/getInventory.ts
@@ -7,15 +7,16 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 import { faker } from "@faker-js/faker";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
   faker.seed([42])
-
+  const defaultFakeData = {}
   return {
-    ...{},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/order.ts
@@ -6,11 +6,12 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
+export function order(data?: Partial<Order>): Required<Order>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
   return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/pet.ts
@@ -8,11 +8,12 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
   return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/tag.ts
@@ -6,11 +6,12 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
   return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/user.ts
@@ -6,11 +6,12 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
+export function user(data?: Partial<User>): Required<User>
+{
   faker.seed([42])
-
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
   return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPet.ts
@@ -20,7 +20,6 @@ export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus20
  * @description Invalid input
  */
 export function addPetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPet.ts
@@ -12,7 +12,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function addPetStatus200(data?: Partial<AddPetStatus200>): AddPetStatus200 {
-
   return pet(data)
 }
 
@@ -27,11 +26,9 @@ export function addPetStatus405() {
  * @description Create a new pet in the store
  */
 export function addPetData(data?: Partial<AddPetData>): AddPetData {
-
   return addPetRequest(data)
 }
 
 export function addPetResponse(_data?: AddPetResponse): AddPetResponse {
-
   return faker.helpers.arrayElement<any>([addPetStatus200(), addPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPetRequest.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): AddPetRequest {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPetRequest.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<AddPetRequest, keyof typeof _defaults>
-  return result
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
+  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/addPetRequest.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest> {
-  return Object.assign({} as Required<AddPetRequest>, {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}, data)
+export function addPetRequest(data?: Partial<AddPetRequest>): Required<AddPetRequest>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<AddPetRequest>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<AddPetRequest>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/address.ts
@@ -6,8 +6,6 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
-  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
-  return result
+export function address(data?: Partial<Address>): Required<Address> {
+  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/address.ts
@@ -6,10 +6,8 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Address {
-
-  return {
-    ...{"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()},
-    ...(data || {})
-  }
+export function address(data?: Partial<Address>): typeof _defaults & Omit<Address, keyof typeof _defaults> {
+  const _defaults = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Address, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/address.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/address.ts
@@ -6,6 +6,11 @@
 import type { Address } from "../types/Address.ts";
 import { faker } from "@faker-js/faker";
 
-export function address(data?: Partial<Address>): Required<Address> {
-  return Object.assign({} as Required<Address>, {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}, data)
+export function address(data?: Partial<Address>): Required<Address>
+{
+  const defaultFakeData = {"street": faker.string.alpha(),"city": faker.string.alpha(),"state": faker.string.alpha(),"zip": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Address>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/apiResponse.ts
@@ -6,6 +6,11 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
-  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse>
+{
+  const defaultFakeData = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<ApiResponse>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/apiResponse.ts
@@ -6,10 +6,8 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): ApiResponse {
-
-  return {
-    ...{"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()},
-    ...(data || {})
-  }
+export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
+  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/apiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/apiResponse.ts
@@ -6,8 +6,6 @@
 import type { ApiResponse } from "../types/ApiResponse.ts";
 import { faker } from "@faker-js/faker";
 
-export function apiResponse(data?: Partial<ApiResponse>): typeof _defaults & Omit<ApiResponse, keyof typeof _defaults> {
-  const _defaults = {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<ApiResponse, keyof typeof _defaults>
-  return result
+export function apiResponse(data?: Partial<ApiResponse>): Required<ApiResponse> {
+  return Object.assign({} as Required<ApiResponse>, {"code": faker.number.int(),"type": faker.string.alpha(),"message": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/category.ts
@@ -6,8 +6,6 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
-  return result
+export function category(data?: Partial<Category>): Required<Category> {
+  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/category.ts
@@ -6,10 +6,8 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Category {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function category(data?: Partial<Category>): typeof _defaults & Omit<Category, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Category, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/category.ts
@@ -6,6 +6,11 @@
 import type { Category } from "../types/Category.ts";
 import { faker } from "@faker-js/faker";
 
-export function category(data?: Partial<Category>): Required<Category> {
-  return Object.assign({} as Required<Category>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function category(data?: Partial<Category>): Required<Category>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Category>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUser.ts
@@ -10,7 +10,6 @@ import { user } from "./user.ts";
  * @description successful operation
  */
 export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>): CreateUserStatusDefault {
-
   return user(data)
 }
 
@@ -18,11 +17,9 @@ export function createUserStatusDefault(data?: Partial<CreateUserStatusDefault>)
  * @description Created user object
  */
 export function createUserData(data?: Partial<CreateUserData>): CreateUserData {
-
   return user(data)
 }
 
 export function createUserResponse(data?: Partial<CreateUserResponse>): CreateUserResponse {
-
   return createUserStatusDefault(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUsersWithListInput.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWithListInputStatus200>): CreateUsersWithListInputStatus200 {
-
   return user(data)
 }
 
@@ -23,7 +22,6 @@ export function createUsersWithListInputStatusDefault() {
 }
 
 export function createUsersWithListInputData(data?: CreateUsersWithListInputData): CreateUsersWithListInputData {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function createUsersWithListInputData(data?: CreateUsersWithListInputData
 }
 
 export function createUsersWithListInputResponse(_data?: CreateUsersWithListInputResponse): CreateUsersWithListInputResponse {
-
   return faker.helpers.arrayElement<any>([createUsersWithListInputStatus200(), createUsersWithListInputStatusDefault()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUsersWithListInput.ts
@@ -19,7 +19,6 @@ export function createUsersWithListInputStatus200(data?: Partial<CreateUsersWith
  * @description successful operation
  */
 export function createUsersWithListInputStatusDefault() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/customer.ts
@@ -7,10 +7,8 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Customer {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))},
-    ...(data || {})
-  }
+export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/customer.ts
@@ -7,8 +7,6 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): typeof _defaults & Omit<Customer, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Customer, keyof typeof _defaults>
-  return result
+export function customer(data?: Partial<Customer>): Required<Customer> {
+  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/customer.ts
@@ -7,6 +7,11 @@ import type { Customer } from "../types/Customer.ts";
 import { address } from "./address.ts";
 import { faker } from "@faker-js/faker";
 
-export function customer(data?: Partial<Customer>): Required<Customer> {
-  return Object.assign({} as Required<Customer>, {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}, data)
+export function customer(data?: Partial<Customer>): Required<Customer>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"address": faker.helpers.multiple(() => (address()))}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Customer>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteOrder.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderResponse } from "../types/DeleteOrder.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteOrderPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -26,6 +25,5 @@ export function deleteOrderStatus404() {
 }
 
 export function deleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-
   return faker.helpers.arrayElement<any>([deleteOrderStatus400(), deleteOrderStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteOrder.ts
@@ -15,7 +15,6 @@ export function deleteOrderPathOrderId(data?: number): number {
  * @description Invalid ID supplied
  */
 export function deleteOrderStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteOrderStatus400() {
  * @description Order not found
  */
 export function deleteOrderStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deletePet.ts
@@ -19,11 +19,9 @@ export function deletePetPathPetId(data?: number): number {
  * @description Invalid pet value
  */
 export function deletePetStatus400() {
-
   return undefined
 }
 
 export function deletePetResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deletePet.ts
@@ -6,12 +6,10 @@
 import { faker } from "@faker-js/faker";
 
 export function deletePetHeaderApiKey(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function deletePetPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteUser.ts
@@ -15,7 +15,6 @@ export function deleteUserPathUsername(data?: string): string {
  * @description Invalid username supplied
  */
 export function deleteUserStatus400() {
-
   return undefined
 }
 
@@ -23,7 +22,6 @@ export function deleteUserStatus400() {
  * @description User not found
  */
 export function deleteUserStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/deleteUser.ts
@@ -7,7 +7,6 @@ import type { DeleteUserResponse } from "../types/DeleteUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function deleteUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -26,6 +25,5 @@ export function deleteUserStatus404() {
 }
 
 export function deleteUserResponse(_data?: DeleteUserResponse): DeleteUserResponse {
-
   return faker.helpers.arrayElement<any>([deleteUserStatus400(), deleteUserStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByStatus.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus): FindPetsByStatusQueryStatus {
-
   return data ?? faker.helpers.arrayElement<FindPetsByStatusQueryStatus>(["available", "pending", "sold"])
 }
 
@@ -16,7 +15,6 @@ export function findPetsByStatusQueryStatus(data?: FindPetsByStatusQueryStatus):
  * @description successful operation
  */
 export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -31,6 +29,5 @@ export function findPetsByStatusStatus400() {
 }
 
 export function findPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByStatusStatus200(), findPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByStatus.ts
@@ -27,7 +27,6 @@ export function findPetsByStatusStatus200(data?: FindPetsByStatusStatus200): Fin
  * @description Invalid status value
  */
 export function findPetsByStatusStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByTags.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPetsByTagsQueryTags {
-
   return [
     ...faker.helpers.multiple(() => (faker.string.alpha())),
     ...(data || [])
@@ -19,7 +18,6 @@ export function findPetsByTagsQueryTags(data?: FindPetsByTagsQueryTags): FindPet
  * @description successful operation
  */
 export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-
   return [
     ...faker.helpers.multiple(() => (pet())),
     ...(data || [])
@@ -34,6 +32,5 @@ export function findPetsByTagsStatus400() {
 }
 
 export function findPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-
   return faker.helpers.arrayElement<any>([findPetsByTagsStatus200(), findPetsByTagsStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/findPetsByTags.ts
@@ -30,7 +30,6 @@ export function findPetsByTagsStatus200(data?: FindPetsByTagsStatus200): FindPet
  * @description Invalid tag value
  */
 export function findPetsByTagsStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getInventory.ts
@@ -6,13 +6,17 @@
 import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetInventory.ts";
 
 /**
- * @description successful operation
- */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
-  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
+   * @description successful operation
+   */
+  export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200>
+{
+  const defaultFakeData = {}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<GetInventoryStatus200>
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {
-
   return getInventoryStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getInventory.ts
@@ -8,12 +8,10 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): GetInventoryStatus200 {
-
-  return {
-    ...{},
-    ...(data || {})
-  }
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
+  const _defaults = {}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
+  return result
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getInventory.ts
@@ -8,10 +8,8 @@ import type { GetInventoryResponse, GetInventoryStatus200 } from "../types/GetIn
 /**
  * @description successful operation
  */
-export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults> {
-  const _defaults = {}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<GetInventoryStatus200, keyof typeof _defaults>
-  return result
+export function getInventoryStatus200(data?: Partial<GetInventoryStatus200>): Required<GetInventoryStatus200> {
+  return Object.assign({} as Required<GetInventoryStatus200>, {}, data)
 }
 
 export function getInventoryResponse(data?: Partial<GetInventoryResponse>): GetInventoryResponse {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getOrderById.ts
@@ -8,7 +8,6 @@ import { order } from "./order.ts";
 import { faker } from "@faker-js/faker";
 
 export function getOrderByIdPathOrderId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getOrderByIdPathOrderId(data?: number): number {
  * @description successful operation
  */
 export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): GetOrderByIdStatus200 {
-
   return order(data)
 }
 
@@ -35,6 +33,5 @@ export function getOrderByIdStatus404() {
 }
 
 export function getOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-
   return faker.helpers.arrayElement<any>([getOrderByIdStatus200(), getOrderByIdStatus400(), getOrderByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getOrderById.ts
@@ -24,7 +24,6 @@ export function getOrderByIdStatus200(data?: Partial<GetOrderByIdStatus200>): Ge
  * @description Invalid ID supplied
  */
 export function getOrderByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getOrderByIdStatus400() {
  * @description Order not found
  */
 export function getOrderByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getPetById.ts
@@ -24,7 +24,6 @@ export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPet
  * @description Invalid ID supplied
  */
 export function getPetByIdStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getPetByIdStatus400() {
  * @description Pet not found
  */
 export function getPetByIdStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getPetById.ts
@@ -8,7 +8,6 @@ import { pet } from "./pet.ts";
 import { faker } from "@faker-js/faker";
 
 export function getPetByIdPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
@@ -16,7 +15,6 @@ export function getPetByIdPathPetId(data?: number): number {
  * @description successful operation
  */
 export function getPetByIdStatus200(data?: Partial<GetPetByIdStatus200>): GetPetByIdStatus200 {
-
   return pet(data)
 }
 
@@ -35,6 +33,5 @@ export function getPetByIdStatus404() {
 }
 
 export function getPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-
   return faker.helpers.arrayElement<any>([getPetByIdStatus200(), getPetByIdStatus400(), getPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getUserByName.ts
@@ -24,7 +24,6 @@ export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): 
  * @description Invalid username supplied
  */
 export function getUserByNameStatus400() {
-
   return undefined
 }
 
@@ -32,7 +31,6 @@ export function getUserByNameStatus400() {
  * @description User not found
  */
 export function getUserByNameStatus404() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/getUserByName.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function getUserByNamePathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -16,7 +15,6 @@ export function getUserByNamePathUsername(data?: string): string {
  * @description successful operation
  */
 export function getUserByNameStatus200(data?: Partial<GetUserByNameStatus200>): GetUserByNameStatus200 {
-
   return user(data)
 }
 
@@ -35,6 +33,5 @@ export function getUserByNameStatus404() {
 }
 
 export function getUserByNameResponse(_data?: GetUserByNameResponse): GetUserByNameResponse {
-
   return faker.helpers.arrayElement<any>([getUserByNameStatus200(), getUserByNameStatus400(), getUserByNameStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/loginUser.ts
@@ -28,7 +28,6 @@ export function loginUserStatus200(data?: string): string {
  * @description Invalid username/password supplied
  */
 export function loginUserStatus400() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/loginUser.ts
@@ -7,12 +7,10 @@ import type { LoginUserResponse } from "../types/LoginUser.ts";
 import { faker } from "@faker-js/faker";
 
 export function loginUserQueryUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function loginUserQueryPassword(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -20,7 +18,6 @@ export function loginUserQueryPassword(data?: string): string {
  * @description successful operation
  */
 export function loginUserStatus200(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -32,6 +29,5 @@ export function loginUserStatus400() {
 }
 
 export function loginUserResponse(_data?: LoginUserResponse): LoginUserResponse {
-
   return faker.helpers.arrayElement<any>([loginUserStatus200(), loginUserStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/logoutUser.ts
@@ -7,11 +7,9 @@
  * @description successful operation
  */
 export function logoutUserStatusDefault() {
-
   return undefined
 }
 
 export function logoutUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/order.ts
@@ -6,8 +6,6 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
-  return result
+export function order(data?: Partial<Order>): Required<Order> {
+  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/order.ts
@@ -6,10 +6,8 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Order {
-
-  return {
-    ...{"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()},
-    ...(data || {})
-  }
+export function order(data?: Partial<Order>): typeof _defaults & Omit<Order, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Order, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/order.ts
@@ -6,6 +6,11 @@
 import type { Order } from "../types/Order.ts";
 import { faker } from "@faker-js/faker";
 
-export function order(data?: Partial<Order>): Required<Order> {
-  return Object.assign({} as Required<Order>, {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}, data)
+export function order(data?: Partial<Order>): Required<Order>
+{
+  const defaultFakeData = {"id": faker.number.int(),"petId": faker.number.int(),"quantity": faker.number.int(),"shipDate": faker.date.anytime().toISOString(),"status": faker.helpers.arrayElement<NonNullable<Order>["status"]>(["placed", "approved", "delivered"]),"complete": faker.datatype.boolean()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Order>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/pet.ts
@@ -8,10 +8,8 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Pet {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])},
-    ...(data || {})
-  }
+export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/pet.ts
@@ -8,6 +8,11 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): Required<Pet> {
-  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
+export function pet(data?: Partial<Pet>): Required<Pet>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Pet>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/pet.ts
@@ -8,8 +8,6 @@ import { category } from "./category.ts";
 import { tag } from "./tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function pet(data?: Partial<Pet>): typeof _defaults & Omit<Pet, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Pet, keyof typeof _defaults>
-  return result
+export function pet(data?: Partial<Pet>): Required<Pet> {
+  return Object.assign({} as Required<Pet>, {"id": faker.number.int(),"name": faker.string.alpha(),"log": faker.helpers.fromRegExp("^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$"),"category": category(),"photoUrls": faker.helpers.multiple(() => (faker.string.alpha())),"tags": faker.helpers.multiple(() => (tag())),"status": faker.helpers.arrayElement<NonNullable<Pet>["status"]>(["available", "pending", "sold"])}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/placeOrder.ts
@@ -19,7 +19,6 @@ export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceO
  * @description Invalid input
  */
 export function placeOrderStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/placeOrder.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description successful operation
  */
 export function placeOrderStatus200(data?: Partial<PlaceOrderStatus200>): PlaceOrderStatus200 {
-
   return order(data)
 }
 
@@ -23,11 +22,9 @@ export function placeOrderStatus405() {
 }
 
 export function placeOrderData(data?: Partial<PlaceOrderData>): PlaceOrderData {
-
   return order(data)
 }
 
 export function placeOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-
   return faker.helpers.arrayElement<any>([placeOrderStatus200(), placeOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/tag.ts
@@ -6,8 +6,6 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
-  return result
+export function tag(data?: Partial<Tag>): Required<Tag> {
+  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/tag.ts
@@ -6,6 +6,11 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Required<Tag> {
-  return Object.assign({} as Required<Tag>, {"id": faker.number.int(),"name": faker.string.alpha()}, data)
+export function tag(data?: Partial<Tag>): Required<Tag>
+{
+  const defaultFakeData = {"id": faker.number.int(),"name": faker.string.alpha()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<Tag>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/tag.ts
@@ -6,10 +6,8 @@
 import type { Tag } from "../types/Tag.ts";
 import { faker } from "@faker-js/faker";
 
-export function tag(data?: Partial<Tag>): Tag {
-
-  return {
-    ...{"id": faker.number.int(),"name": faker.string.alpha()},
-    ...(data || {})
-  }
+export function tag(data?: Partial<Tag>): typeof _defaults & Omit<Tag, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"name": faker.string.alpha()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<Tag, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePet.ts
@@ -11,7 +11,6 @@ import { faker } from "@faker-js/faker";
  * @description Successful operation
  */
 export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePetStatus200 {
-
   return pet(data)
 }
 
@@ -40,11 +39,9 @@ export function updatePetStatus405() {
  * @description Update an existent pet in the store
  */
 export function updatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-
   return pet(data)
 }
 
 export function updatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-
   return faker.helpers.arrayElement<any>([updatePetStatus200(), updatePetStatus400(), updatePetStatus404(), updatePetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePet.ts
@@ -19,7 +19,6 @@ export function updatePetStatus200(data?: Partial<UpdatePetStatus200>): UpdatePe
  * @description Invalid ID supplied
  */
 export function updatePetStatus400() {
-
   return undefined
 }
 
@@ -27,7 +26,6 @@ export function updatePetStatus400() {
  * @description Pet not found
  */
 export function updatePetStatus404() {
-
   return undefined
 }
 
@@ -35,7 +33,6 @@ export function updatePetStatus404() {
  * @description Validation exception
  */
 export function updatePetStatus405() {
-
   return undefined
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePetWithForm.ts
@@ -6,17 +6,14 @@
 import { faker } from "@faker-js/faker";
 
 export function updatePetWithFormPathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function updatePetWithFormQueryName(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
 export function updatePetWithFormQueryStatus(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updatePetWithForm.ts
@@ -24,11 +24,9 @@ export function updatePetWithFormQueryStatus(data?: string): string {
  * @description Invalid input
  */
 export function updatePetWithFormStatus405() {
-
   return undefined
 }
 
 export function updatePetWithFormResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updateUser.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function updateUserPathUsername(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -23,7 +22,6 @@ export function updateUserStatusDefault() {
  * @description Update an existent user in the store
  */
 export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
-
   return user(data)
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/updateUser.ts
@@ -16,7 +16,6 @@ export function updateUserPathUsername(data?: string): string {
  * @description successful operation
  */
 export function updateUserStatusDefault() {
-
   return undefined
 }
 
@@ -29,6 +28,5 @@ export function updateUserData(data?: Partial<UpdateUserData>): UpdateUserData {
 }
 
 export function updateUserResponse() {
-
   return undefined
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/uploadFile.ts
@@ -8,12 +8,10 @@ import { apiResponse } from "./apiResponse.ts";
 import { faker } from "@faker-js/faker";
 
 export function uploadFilePathPetId(data?: number): number {
-
   return data ?? faker.number.int()
 }
 
 export function uploadFileQueryAdditionalMetadata(data?: string): string {
-
   return data ?? faker.string.alpha()
 }
 
@@ -21,16 +19,13 @@ export function uploadFileQueryAdditionalMetadata(data?: string): string {
  * @description successful operation
  */
 export function uploadFileStatus200(data?: Partial<UploadFileStatus200>): UploadFileStatus200 {
-
   return apiResponse(data)
 }
 
 export function uploadFileData(data?: Blob): Blob {
-
   return data ?? faker.image.url() as unknown as Blob
 }
 
 export function uploadFileResponse(data?: Partial<UploadFileResponse>): UploadFileResponse {
-
   return uploadFileStatus200(data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/user.ts
@@ -6,8 +6,6 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
-  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
-  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
-  return result
+export function user(data?: Partial<User>): Required<User> {
+  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/user.ts
@@ -6,6 +6,11 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): Required<User> {
-  return Object.assign({} as Required<User>, {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}, data)
+export function user(data?: Partial<User>): Required<User>
+{
+  const defaultFakeData = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  return {
+    ...defaultFakeData,
+    ...(data || {}),
+  } as Required<User>
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/user.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/user.ts
@@ -6,10 +6,8 @@
 import type { User } from "../types/User.ts";
 import { faker } from "@faker-js/faker";
 
-export function user(data?: Partial<User>): User {
-
-  return {
-    ...{"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()},
-    ...(data || {})
-  }
+export function user(data?: Partial<User>): typeof _defaults & Omit<User, keyof typeof _defaults> {
+  const _defaults = {"id": faker.number.int(),"username": faker.string.alpha(),"firstName": faker.string.alpha(),"lastName": faker.string.alpha(),"email": faker.string.alpha(),"password": faker.string.alpha(),"phone": faker.string.alpha(),"userStatus": faker.number.int()}
+  const result = { ..._defaults, ...(data || {}) } as typeof _defaults & Omit<User, keyof typeof _defaults>
+  return result
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/userArray.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/userArray.ts
@@ -8,7 +8,6 @@ import { user } from "./user.ts";
 import { faker } from "@faker-js/faker";
 
 export function userArray(data?: UserArray): UserArray {
-
   return [
     ...faker.helpers.multiple(() => (user())),
     ...(data || [])

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
@@ -8,7 +8,6 @@ import { addPetResponse } from "../faker/addPet.ts";
 import { http } from "msw";
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function addPetHandlerResponse200(data: AddPetResponse) {
 }
 
 export function addPetHandlerResponse405(data?: AddPetStatus405) {
-
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
@@ -8,6 +8,7 @@ import { addPetResponse } from "../faker/addPet.ts";
 import { http } from "msw";
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function addPetHandlerResponse200(data: AddPetResponse) {
 }
 
 export function addPetHandlerResponse405(data?: AddPetStatus405) {
+
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUsersWithListInputHandler.ts
@@ -8,7 +8,6 @@ import { createUsersWithListInputResponse } from "../faker/createUsersWithListIn
 import { http } from "msw";
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUsersWithListInputHandler.ts
@@ -8,6 +8,7 @@ import { createUsersWithListInputResponse } from "../faker/createUsersWithListIn
 import { http } from "msw";
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteOrderHandler.ts
@@ -7,6 +7,7 @@ import type { DeleteOrderStatus400, DeleteOrderStatus404 } from "../types/Delete
 import { http } from "msw";
 
 export function deleteOrderHandlerResponse400(data?: DeleteOrderStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -14,6 +15,7 @@ export function deleteOrderHandlerResponse400(data?: DeleteOrderStatus400) {
 }
 
 export function deleteOrderHandlerResponse404(data?: DeleteOrderStatus404) {
+
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteOrderHandler.ts
@@ -7,7 +7,6 @@ import type { DeleteOrderStatus400, DeleteOrderStatus404 } from "../types/Delete
 import { http } from "msw";
 
 export function deleteOrderHandlerResponse400(data?: DeleteOrderStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -15,7 +14,6 @@ export function deleteOrderHandlerResponse400(data?: DeleteOrderStatus400) {
 }
 
 export function deleteOrderHandlerResponse404(data?: DeleteOrderStatus404) {
-
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deletePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deletePetHandler.ts
@@ -7,7 +7,6 @@ import type { DeletePetStatus400 } from "../types/DeletePet.ts";
 import { http } from "msw";
 
 export function deletePetHandlerResponse400(data?: DeletePetStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deletePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deletePetHandler.ts
@@ -7,6 +7,7 @@ import type { DeletePetStatus400 } from "../types/DeletePet.ts";
 import { http } from "msw";
 
 export function deletePetHandlerResponse400(data?: DeletePetStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteUserHandler.ts
@@ -7,7 +7,6 @@ import type { DeleteUserStatus400, DeleteUserStatus404 } from "../types/DeleteUs
 import { http } from "msw";
 
 export function deleteUserHandlerResponse400(data?: DeleteUserStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -15,7 +14,6 @@ export function deleteUserHandlerResponse400(data?: DeleteUserStatus400) {
 }
 
 export function deleteUserHandlerResponse404(data?: DeleteUserStatus404) {
-
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/deleteUserHandler.ts
@@ -7,6 +7,7 @@ import type { DeleteUserStatus400, DeleteUserStatus404 } from "../types/DeleteUs
 import { http } from "msw";
 
 export function deleteUserHandlerResponse400(data?: DeleteUserStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -14,6 +15,7 @@ export function deleteUserHandlerResponse400(data?: DeleteUserStatus400) {
 }
 
 export function deleteUserHandlerResponse404(data?: DeleteUserStatus404) {
+
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByStatusHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByStatusHandler.ts
@@ -8,7 +8,6 @@ import { findPetsByStatusResponse } from "../faker/findPetsByStatus.ts";
 import { http } from "msw";
 
 export function findPetsByStatusHandlerResponse200(data: FindPetsByStatusResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function findPetsByStatusHandlerResponse200(data: FindPetsByStatusRespons
 }
 
 export function findPetsByStatusHandlerResponse400(data?: FindPetsByStatusStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByStatusHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByStatusHandler.ts
@@ -8,6 +8,7 @@ import { findPetsByStatusResponse } from "../faker/findPetsByStatus.ts";
 import { http } from "msw";
 
 export function findPetsByStatusHandlerResponse200(data: FindPetsByStatusResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function findPetsByStatusHandlerResponse200(data: FindPetsByStatusRespons
 }
 
 export function findPetsByStatusHandlerResponse400(data?: FindPetsByStatusStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByTagsHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByTagsHandler.ts
@@ -8,6 +8,7 @@ import { findPetsByTagsResponse } from "../faker/findPetsByTags.ts";
 import { http } from "msw";
 
 export function findPetsByTagsHandlerResponse200(data: FindPetsByTagsResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function findPetsByTagsHandlerResponse200(data: FindPetsByTagsResponse) {
 }
 
 export function findPetsByTagsHandlerResponse400(data?: FindPetsByTagsStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByTagsHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/findPetsByTagsHandler.ts
@@ -8,7 +8,6 @@ import { findPetsByTagsResponse } from "../faker/findPetsByTags.ts";
 import { http } from "msw";
 
 export function findPetsByTagsHandlerResponse200(data: FindPetsByTagsResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function findPetsByTagsHandlerResponse200(data: FindPetsByTagsResponse) {
 }
 
 export function findPetsByTagsHandlerResponse400(data?: FindPetsByTagsStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getInventoryHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getInventoryHandler.ts
@@ -8,6 +8,7 @@ import { getInventoryResponse } from "../faker/getInventory.ts";
 import { http } from "msw";
 
 export function getInventoryHandlerResponse200(data: GetInventoryResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getInventoryHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getInventoryHandler.ts
@@ -8,7 +8,6 @@ import { getInventoryResponse } from "../faker/getInventory.ts";
 import { http } from "msw";
 
 export function getInventoryHandlerResponse200(data: GetInventoryResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getOrderByIdHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getOrderByIdHandler.ts
@@ -8,7 +8,6 @@ import { getOrderByIdResponse } from "../faker/getOrderById.ts";
 import { http } from "msw";
 
 export function getOrderByIdHandlerResponse200(data: GetOrderByIdResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function getOrderByIdHandlerResponse200(data: GetOrderByIdResponse) {
 }
 
 export function getOrderByIdHandlerResponse400(data?: GetOrderByIdStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -26,7 +24,6 @@ export function getOrderByIdHandlerResponse400(data?: GetOrderByIdStatus400) {
 }
 
 export function getOrderByIdHandlerResponse404(data?: GetOrderByIdStatus404) {
-
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getOrderByIdHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getOrderByIdHandler.ts
@@ -8,6 +8,7 @@ import { getOrderByIdResponse } from "../faker/getOrderById.ts";
 import { http } from "msw";
 
 export function getOrderByIdHandlerResponse200(data: GetOrderByIdResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function getOrderByIdHandlerResponse200(data: GetOrderByIdResponse) {
 }
 
 export function getOrderByIdHandlerResponse400(data?: GetOrderByIdStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -24,6 +26,7 @@ export function getOrderByIdHandlerResponse400(data?: GetOrderByIdStatus400) {
 }
 
 export function getOrderByIdHandlerResponse404(data?: GetOrderByIdStatus404) {
+
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getPetByIdHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getPetByIdHandler.ts
@@ -8,6 +8,7 @@ import { getPetByIdResponse } from "../faker/getPetById.ts";
 import { http } from "msw";
 
 export function getPetByIdHandlerResponse200(data: GetPetByIdResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function getPetByIdHandlerResponse200(data: GetPetByIdResponse) {
 }
 
 export function getPetByIdHandlerResponse400(data?: GetPetByIdStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -24,6 +26,7 @@ export function getPetByIdHandlerResponse400(data?: GetPetByIdStatus400) {
 }
 
 export function getPetByIdHandlerResponse404(data?: GetPetByIdStatus404) {
+
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getPetByIdHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getPetByIdHandler.ts
@@ -8,7 +8,6 @@ import { getPetByIdResponse } from "../faker/getPetById.ts";
 import { http } from "msw";
 
 export function getPetByIdHandlerResponse200(data: GetPetByIdResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function getPetByIdHandlerResponse200(data: GetPetByIdResponse) {
 }
 
 export function getPetByIdHandlerResponse400(data?: GetPetByIdStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -26,7 +24,6 @@ export function getPetByIdHandlerResponse400(data?: GetPetByIdStatus400) {
 }
 
 export function getPetByIdHandlerResponse404(data?: GetPetByIdStatus404) {
-
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getUserByNameHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getUserByNameHandler.ts
@@ -8,7 +8,6 @@ import { getUserByNameResponse } from "../faker/getUserByName.ts";
 import { http } from "msw";
 
 export function getUserByNameHandlerResponse200(data: GetUserByNameResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function getUserByNameHandlerResponse200(data: GetUserByNameResponse) {
 }
 
 export function getUserByNameHandlerResponse400(data?: GetUserByNameStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -26,7 +24,6 @@ export function getUserByNameHandlerResponse400(data?: GetUserByNameStatus400) {
 }
 
 export function getUserByNameHandlerResponse404(data?: GetUserByNameStatus404) {
-
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getUserByNameHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/getUserByNameHandler.ts
@@ -8,6 +8,7 @@ import { getUserByNameResponse } from "../faker/getUserByName.ts";
 import { http } from "msw";
 
 export function getUserByNameHandlerResponse200(data: GetUserByNameResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function getUserByNameHandlerResponse200(data: GetUserByNameResponse) {
 }
 
 export function getUserByNameHandlerResponse400(data?: GetUserByNameStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -24,6 +26,7 @@ export function getUserByNameHandlerResponse400(data?: GetUserByNameStatus400) {
 }
 
 export function getUserByNameHandlerResponse404(data?: GetUserByNameStatus404) {
+
       return new Response(JSON.stringify(data), {
         status: 404,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/loginUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/loginUserHandler.ts
@@ -8,6 +8,7 @@ import { loginUserResponse } from "../faker/loginUser.ts";
 import { http } from "msw";
 
 export function loginUserHandlerResponse200(data: LoginUserResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function loginUserHandlerResponse200(data: LoginUserResponse) {
 }
 
 export function loginUserHandlerResponse400(data?: LoginUserStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/loginUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/loginUserHandler.ts
@@ -8,7 +8,6 @@ import { loginUserResponse } from "../faker/loginUser.ts";
 import { http } from "msw";
 
 export function loginUserHandlerResponse200(data: LoginUserResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function loginUserHandlerResponse200(data: LoginUserResponse) {
 }
 
 export function loginUserHandlerResponse400(data?: LoginUserStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
@@ -8,7 +8,6 @@ import { placeOrderResponse } from "../faker/placeOrder.ts";
 import { http } from "msw";
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
 }
 
 export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
-
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
@@ -8,6 +8,7 @@ import { placeOrderResponse } from "../faker/placeOrder.ts";
 import { http } from "msw";
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
 }
 
 export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
+
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetHandler.ts
@@ -8,7 +8,6 @@ import { updatePetResponse } from "../faker/updatePet.ts";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -18,7 +17,6 @@ export function updatePetHandlerResponse200(data: UpdatePetResponse) {
 }
 
 export function updatePetHandlerResponse400(data?: UpdatePetStatus400) {
-
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -26,7 +24,6 @@ export function updatePetHandlerResponse400(data?: UpdatePetStatus400) {
 }
 
 export function updatePetHandlerResponse404(data?: UpdatePetStatus404) {
-
       return new Response(JSON.stringify(data), {
         status: 404,
 
@@ -34,7 +31,6 @@ export function updatePetHandlerResponse404(data?: UpdatePetStatus404) {
 }
 
 export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
-
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetHandler.ts
@@ -8,6 +8,7 @@ import { updatePetResponse } from "../faker/updatePet.ts";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {
@@ -17,6 +18,7 @@ export function updatePetHandlerResponse200(data: UpdatePetResponse) {
 }
 
 export function updatePetHandlerResponse400(data?: UpdatePetStatus400) {
+
       return new Response(JSON.stringify(data), {
         status: 400,
 
@@ -24,6 +26,7 @@ export function updatePetHandlerResponse400(data?: UpdatePetStatus400) {
 }
 
 export function updatePetHandlerResponse404(data?: UpdatePetStatus404) {
+
       return new Response(JSON.stringify(data), {
         status: 404,
 
@@ -31,6 +34,7 @@ export function updatePetHandlerResponse404(data?: UpdatePetStatus404) {
 }
 
 export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
+
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetWithFormHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetWithFormHandler.ts
@@ -7,7 +7,6 @@ import type { UpdatePetWithFormStatus405 } from "../types/UpdatePetWithForm.ts";
 import { http } from "msw";
 
 export function updatePetWithFormHandlerResponse405(data?: UpdatePetWithFormStatus405) {
-
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetWithFormHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetWithFormHandler.ts
@@ -7,6 +7,7 @@ import type { UpdatePetWithFormStatus405 } from "../types/UpdatePetWithForm.ts";
 import { http } from "msw";
 
 export function updatePetWithFormHandlerResponse405(data?: UpdatePetWithFormStatus405) {
+
       return new Response(JSON.stringify(data), {
         status: 405,
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
@@ -8,6 +8,7 @@ import { uploadFileResponse } from "../faker/uploadFile.ts";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
+
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
@@ -8,7 +8,6 @@ import { uploadFileResponse } from "../faker/uploadFile.ts";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
-
       return new Response(JSON.stringify(data), {
         status: 200,
           headers: {


### PR DESCRIPTION
Resolve issue kubb-labs/kubb#69: @kubb/plugin-faker types are now more precise when dealing with nullish API types.

The faker functions now use a more accurate return type that marks generated properties as required, even if the underlying API type marks them as optional. This prevents TypeScript from inferring that properties might be undefined when they're actually always generated.

For object types without circular references, the generated code now uses:
- Extract defaults into a variable: `const _defaults = {...}`
- Return with precise type: `typeof _defaults & Omit<Type, keyof typeof _defaults>`

This ensures:
1. All generated properties are marked as required (not optional)
2. Nullable properties remain nullable (if the schema allows null)
3. Type safety is maintained for user overrides via the `data` parameter