### PR TITLE
fix(plugin-msw): type request body in generated handler callbacks

### DIFF
--- a/.changeset/plugin-msw-typed-request-body.md
+++ b/.changeset/plugin-msw-typed-request-body.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-msw": patch
+---
+
+Fix typed request body in generated MSW handler callbacks. When an operation has a request body, the generated handler now passes the request body type as a generic to `http.<method>`, so `info.request.json()` returns the typed payload without requiring a manual cast.

--- a/examples/msw/src/gen/msw/pet/Handlers/addPetHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/addPetHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { AddPetResponse, AddPetStatus405 } from '../../../models/AddPet.ts'
+import type { AddPetData, AddPetResponse, AddPetStatus405 } from '../../../models/AddPet.ts'
 import { http } from 'msw'
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
@@ -24,8 +24,8 @@ export function addPetHandlerResponse405(data: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, AddPetData, any>>[1]>[0]) => Response | Promise<Response>)) {
+  return http.post<Record<string, string>, AddPetData, any>(`http://localhost:3000/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/pet/Handlers/addPetHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/addPetHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { AddPetData, AddPetResponse, AddPetStatus405 } from '../../../models/AddPet.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
@@ -24,7 +25,7 @@ export function addPetHandlerResponse405(data: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, AddPetData, any>>[1]>[0]) => Response | Promise<Response>)) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
   return http.post<Record<string, string>, AddPetData, any>(`http://localhost:3000/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/pet/Handlers/updatePetHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/updatePetHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from '../../../models/UpdatePet.ts'
+import type { UpdatePetData, UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from '../../../models/UpdatePet.ts'
 import { http } from 'msw'
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -33,8 +33,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
   })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`http://localhost:3000/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<(typeof http)['put']<Record<string, string>, UpdatePetData, any>>[1]>[0]) => Response | Promise<Response>)) {
+  return http.put<Record<string, string>, UpdatePetData, any>(`http://localhost:3000/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/pet/Handlers/updatePetHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/updatePetHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { UpdatePetData, UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from '../../../models/UpdatePet.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -33,7 +34,7 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
   })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<(typeof http)['put']<Record<string, string>, UpdatePetData, any>>[1]>[0]) => Response | Promise<Response>)) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
   return http.put<Record<string, string>, UpdatePetData, any>(`http://localhost:3000/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/pet/Handlers/uploadFileHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/uploadFileHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { UploadFileResponse } from '../../../models/UploadFile.ts'
+import type { UploadFileData, UploadFileResponse } from '../../../models/UploadFile.ts'
 import { http } from 'msw'
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -15,8 +15,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, UploadFileData, any>>[1]>[0]) => Response | Promise<Response>)) {
+  return http.post<Record<string, string>, UploadFileData, any>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/pet/Handlers/uploadFileHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/uploadFileHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { UploadFileData, UploadFileResponse } from '../../../models/UploadFile.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -15,7 +16,7 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, UploadFileData, any>>[1]>[0]) => Response | Promise<Response>)) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
   return http.post<Record<string, string>, UploadFileData, any>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/store/Handlers/placeOrderHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/placeOrderHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405 } from '../../../models/PlaceOrder.ts'
+import type { PlaceOrderData, PlaceOrderResponse, PlaceOrderStatus405 } from '../../../models/PlaceOrder.ts'
 import { http } from 'msw'
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
@@ -21,8 +21,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, PlaceOrderData, any>>[1]>[0]) => Response | Promise<Response>)) {
+  return http.post<Record<string, string>, PlaceOrderData, any>(`http://localhost:3000/store/order`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/store/Handlers/placeOrderHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/placeOrderHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { PlaceOrderData, PlaceOrderResponse, PlaceOrderStatus405 } from '../../../models/PlaceOrder.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
@@ -21,7 +22,7 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, PlaceOrderData, any>>[1]>[0]) => Response | Promise<Response>)) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
   return http.post<Record<string, string>, PlaceOrderData, any>(`http://localhost:3000/store/order`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/store/Handlers/placeOrderPatchHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/placeOrderPatchHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { PlaceOrderPatchResponse, PlaceOrderPatchStatus405 } from '../../../models/PlaceOrderPatch.ts'
+import type { PlaceOrderPatchData, PlaceOrderPatchResponse, PlaceOrderPatchStatus405 } from '../../../models/PlaceOrderPatch.ts'
 import { http } from 'msw'
 
 export function placeOrderPatchHandlerResponse200(data: PlaceOrderPatchResponse) {
@@ -22,9 +22,9 @@ export function placeOrderPatchHandlerResponse405(data?: PlaceOrderPatchStatus40
 }
 
 export function placeOrderPatchHandler(
-  data?: PlaceOrderPatchResponse | ((info: Parameters<Parameters<typeof http.patch>[1]>[0]) => Response | Promise<Response>),
+  data?: PlaceOrderPatchResponse | ((info: Parameters<Parameters<(typeof http)['patch']<Record<string, string>, PlaceOrderPatchData, any>>[1]>[0]) => Response | Promise<Response>),
 ) {
-  return http.patch(`http://localhost:3000/store/order`, function handler(info) {
+  return http.patch<Record<string, string>, PlaceOrderPatchData, any>(`http://localhost:3000/store/order`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/store/Handlers/placeOrderPatchHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/placeOrderPatchHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { PlaceOrderPatchData, PlaceOrderPatchResponse, PlaceOrderPatchStatus405 } from '../../../models/PlaceOrderPatch.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
 export function placeOrderPatchHandlerResponse200(data: PlaceOrderPatchResponse) {
@@ -21,9 +22,7 @@ export function placeOrderPatchHandlerResponse405(data?: PlaceOrderPatchStatus40
   })
 }
 
-export function placeOrderPatchHandler(
-  data?: PlaceOrderPatchResponse | ((info: Parameters<Parameters<(typeof http)['patch']<Record<string, string>, PlaceOrderPatchData, any>>[1]>[0]) => Response | Promise<Response>),
-) {
+export function placeOrderPatchHandler(data?: PlaceOrderPatchResponse | HttpResponseResolver<Record<string, string>, PlaceOrderPatchData, any>) {
   return http.patch<Record<string, string>, PlaceOrderPatchData, any>(`http://localhost:3000/store/order`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/user/Handlers/createUserHandler.ts
+++ b/examples/msw/src/gen/msw/user/Handlers/createUserHandler.ts
@@ -3,12 +3,13 @@
  * Do not edit manually.
  */
 
+import type { CreateUserData } from '../../../models/CreateUser.ts'
 import { http } from 'msw'
 
 export function createUserHandler(
-  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>),
+  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreateUserData, any>>[1]>[0]) => Response | Promise<Response>),
 ) {
-  return http.post(`http://localhost:3000/user`, function handler(info) {
+  return http.post<Record<string, string>, CreateUserData, any>(`http://localhost:3000/user`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/user/Handlers/createUserHandler.ts
+++ b/examples/msw/src/gen/msw/user/Handlers/createUserHandler.ts
@@ -4,11 +4,10 @@
  */
 
 import type { CreateUserData } from '../../../models/CreateUser.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
-export function createUserHandler(
-  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreateUserData, any>>[1]>[0]) => Response | Promise<Response>),
-) {
+export function createUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreateUserData, any>) {
   return http.post<Record<string, string>, CreateUserData, any>(`http://localhost:3000/user`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/user/Handlers/createUsersWithListInputHandler.ts
+++ b/examples/msw/src/gen/msw/user/Handlers/createUsersWithListInputHandler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CreateUsersWithListInputData, CreateUsersWithListInputResponse } from '../../../models/CreateUsersWithListInput.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
@@ -15,9 +16,7 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
   })
 }
 
-export function createUsersWithListInputHandler(
-  data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreateUsersWithListInputData, any>>[1]>[0]) => Response | Promise<Response>),
-) {
+export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
   return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`http://localhost:3000/user/createWithList`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/user/Handlers/createUsersWithListInputHandler.ts
+++ b/examples/msw/src/gen/msw/user/Handlers/createUsersWithListInputHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { CreateUsersWithListInputResponse } from '../../../models/CreateUsersWithListInput.ts'
+import type { CreateUsersWithListInputData, CreateUsersWithListInputResponse } from '../../../models/CreateUsersWithListInput.ts'
 import { http } from 'msw'
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
@@ -16,9 +16,9 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
 }
 
 export function createUsersWithListInputHandler(
-  data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>),
+  data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreateUsersWithListInputData, any>>[1]>[0]) => Response | Promise<Response>),
 ) {
-  return http.post(`http://localhost:3000/user/createWithList`, function handler(info) {
+  return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`http://localhost:3000/user/createWithList`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/user/Handlers/createUsersWithListInputHandler.ts
+++ b/examples/msw/src/gen/msw/user/Handlers/createUsersWithListInputHandler.ts
@@ -16,7 +16,9 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
   })
 }
 
-export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
+export function createUsersWithListInputHandler(
+  data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>,
+) {
   return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`http://localhost:3000/user/createWithList`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/examples/msw/src/gen/msw/user/Handlers/updateUserHandler.ts
+++ b/examples/msw/src/gen/msw/user/Handlers/updateUserHandler.ts
@@ -3,12 +3,13 @@
  * Do not edit manually.
  */
 
+import type { UpdateUserData } from '../../../models/UpdateUser.ts'
 import { http } from 'msw'
 
 export function updateUserHandler(
-  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>),
+  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<(typeof http)['put']<Record<string, string>, UpdateUserData, any>>[1]>[0]) => Response | Promise<Response>),
 ) {
-  return http.put(`http://localhost:3000/user/:username`, function handler(info) {
+  return http.put<Record<string, string>, UpdateUserData, any>(`http://localhost:3000/user/:username`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/user/Handlers/updateUserHandler.ts
+++ b/examples/msw/src/gen/msw/user/Handlers/updateUserHandler.ts
@@ -4,11 +4,10 @@
  */
 
 import type { UpdateUserData } from '../../../models/UpdateUser.ts'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
-export function updateUserHandler(
-  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<(typeof http)['put']<Record<string, string>, UpdateUserData, any>>[1]>[0]) => Response | Promise<Response>),
-) {
+export function updateUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, UpdateUserData, any>) {
   return http.put<Record<string, string>, UpdateUserData, any>(`http://localhost:3000/user/:username`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/packages/plugin-msw/src/components/Mock.tsx
+++ b/packages/plugin-msw/src/components/Mock.tsx
@@ -26,9 +26,9 @@ export function Mock({ baseURL = '', name, typeName, requestTypeName, node }: Pr
   const responseHasSchema = hasResponseSchema(successResponse)
   const dataType = responseHasSchema ? typeName : 'string | number | boolean | null | object'
 
-  const infoType = requestTypeName
-    ? `Parameters<Parameters<(typeof http)['${method}']<Record<string, string>, ${requestTypeName}, any>>[1]>[0]`
-    : `Parameters<Parameters<typeof http.${method}>[1]>[0]`
+  const callbackType = requestTypeName
+    ? `HttpResponseResolver<Record<string, string>, ${requestTypeName}, any>`
+    : `((info: Parameters<Parameters<typeof http.${method}>[1]>[0]) => Response | Promise<Response>)`
 
   const params = declarationPrinter.print(
     ast.createFunctionParameters({
@@ -37,7 +37,7 @@ export function Mock({ baseURL = '', name, typeName, requestTypeName, node }: Pr
           name: 'data',
           type: ast.createParamsType({
             variant: 'reference',
-            name: `${dataType} | ((info: ${infoType}) => Response | Promise<Response>)`,
+            name: `${dataType} | ${callbackType}`,
           }),
           optional: true,
         }),

--- a/packages/plugin-msw/src/components/Mock.tsx
+++ b/packages/plugin-msw/src/components/Mock.tsx
@@ -8,13 +8,14 @@ import { getContentType, getMswMethod, getMswUrl, getPrimarySuccessResponse, has
 type Props = {
   name: string
   typeName: string
+  requestTypeName?: string
   baseURL: string | undefined
   node: ast.OperationNode
 }
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
-export function Mock({ baseURL = '', name, typeName, node }: Props): KubbReactNode {
+export function Mock({ baseURL = '', name, typeName, requestTypeName, node }: Props): KubbReactNode {
   const method = getMswMethod(node)
   const successResponse = getPrimarySuccessResponse(node)
   const statusCode = successResponse ? Number(successResponse.statusCode) : 200
@@ -25,6 +26,10 @@ export function Mock({ baseURL = '', name, typeName, node }: Props): KubbReactNo
   const responseHasSchema = hasResponseSchema(successResponse)
   const dataType = responseHasSchema ? typeName : 'string | number | boolean | null | object'
 
+  const infoType = requestTypeName
+    ? `Parameters<Parameters<(typeof http)['${method}']<Record<string, string>, ${requestTypeName}, any>>[1]>[0]`
+    : `Parameters<Parameters<typeof http.${method}>[1]>[0]`
+
   const params = declarationPrinter.print(
     ast.createFunctionParameters({
       params: [
@@ -32,7 +37,7 @@ export function Mock({ baseURL = '', name, typeName, node }: Props): KubbReactNo
           name: 'data',
           type: ast.createParamsType({
             variant: 'reference',
-            name: `${dataType} | ((info: Parameters<Parameters<typeof http.${method}>[1]>[0]) => Response | Promise<Response>)`,
+            name: `${dataType} | ((info: ${infoType}) => Response | Promise<Response>)`,
           }),
           optional: true,
         }),
@@ -40,10 +45,14 @@ export function Mock({ baseURL = '', name, typeName, node }: Props): KubbReactNo
     }),
   )
 
+  const httpCall = requestTypeName
+    ? `http.${method}<Record<string, string>, ${requestTypeName}, any>`
+    : `http.${method}`
+
   return (
     <File.Source name={name} isIndexable isExportable>
       <Function name={name} export params={params ?? ''}>
-        {`return http.${method}(\`${baseURL}${url.replace(/([^/]):/g, '$1\\\\:')}\`, function handler(info) {
+        {`return ${httpCall}(\`${baseURL}${url.replace(/([^/]):/g, '$1\\\\:')}\`, function handler(info) {
     if(typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/packages/plugin-msw/src/components/Mock.tsx
+++ b/packages/plugin-msw/src/components/Mock.tsx
@@ -45,9 +45,7 @@ export function Mock({ baseURL = '', name, typeName, requestTypeName, node }: Pr
     }),
   )
 
-  const httpCall = requestTypeName
-    ? `http.${method}<Record<string, string>, ${requestTypeName}, any>`
-    : `http.${method}`
+  const httpCall = requestTypeName ? `http.${method}<Record<string, string>, ${requestTypeName}, any>` : `http.${method}`
 
   return (
     <File.Source name={name} isIndexable isExportable>

--- a/packages/plugin-msw/src/components/MockWithFaker.tsx
+++ b/packages/plugin-msw/src/components/MockWithFaker.tsx
@@ -8,6 +8,7 @@ import { getContentType, getMswMethod, getMswUrl, getPrimarySuccessResponse } fr
 type Props = {
   name: string
   typeName: string
+  requestTypeName?: string
   fakerName: string
   baseURL: string | undefined
   node: ast.OperationNode
@@ -15,7 +16,7 @@ type Props = {
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
-export function MockWithFaker({ baseURL = '', name, fakerName, typeName, node }: Props): KubbReactNode {
+export function MockWithFaker({ baseURL = '', name, fakerName, typeName, requestTypeName, node }: Props): KubbReactNode {
   const method = getMswMethod(node)
   const successResponse = getPrimarySuccessResponse(node)
   const statusCode = successResponse ? Number(successResponse.statusCode) : 200
@@ -24,6 +25,10 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, node }:
 
   const headers = [contentType ? `'Content-Type': '${contentType}'` : undefined].filter(Boolean)
 
+  const infoType = requestTypeName
+    ? `Parameters<Parameters<(typeof http)['${method}']<Record<string, string>, ${requestTypeName}, any>>[1]>[0]`
+    : `Parameters<Parameters<typeof http.${method}>[1]>[0]`
+
   const params = declarationPrinter.print(
     ast.createFunctionParameters({
       params: [
@@ -31,7 +36,7 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, node }:
           name: 'data',
           type: ast.createParamsType({
             variant: 'reference',
-            name: `${typeName} | ((info: Parameters<Parameters<typeof http.${method}>[1]>[0]) => Response | Promise<Response>)`,
+            name: `${typeName} | ((info: ${infoType}) => Response | Promise<Response>)`,
           }),
           optional: true,
         }),
@@ -39,10 +44,14 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, node }:
     }),
   )
 
+  const httpCall = requestTypeName
+    ? `http.${method}<Record<string, string>, ${requestTypeName}, any>`
+    : `http.${method}`
+
   return (
     <File.Source name={name} isIndexable isExportable>
       <Function name={name} export params={params ?? ''}>
-        {`return http.${method}('${baseURL}${url.replace(/([^/]):/g, '$1\\\\:')}', function handler(info) {
+        {`return ${httpCall}('${baseURL}${url.replace(/([^/]):/g, '$1\\\\:')}', function handler(info) {
     if(typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data || ${fakerName}(data)), {

--- a/packages/plugin-msw/src/components/MockWithFaker.tsx
+++ b/packages/plugin-msw/src/components/MockWithFaker.tsx
@@ -25,9 +25,9 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, request
 
   const headers = [contentType ? `'Content-Type': '${contentType}'` : undefined].filter(Boolean)
 
-  const infoType = requestTypeName
-    ? `Parameters<Parameters<(typeof http)['${method}']<Record<string, string>, ${requestTypeName}, any>>[1]>[0]`
-    : `Parameters<Parameters<typeof http.${method}>[1]>[0]`
+  const callbackType = requestTypeName
+    ? `HttpResponseResolver<Record<string, string>, ${requestTypeName}, any>`
+    : `((info: Parameters<Parameters<typeof http.${method}>[1]>[0]) => Response | Promise<Response>)`
 
   const params = declarationPrinter.print(
     ast.createFunctionParameters({
@@ -36,7 +36,7 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, request
           name: 'data',
           type: ast.createParamsType({
             variant: 'reference',
-            name: `${typeName} | ((info: ${infoType}) => Response | Promise<Response>)`,
+            name: `${typeName} | ${callbackType}`,
           }),
           optional: true,
         }),

--- a/packages/plugin-msw/src/components/MockWithFaker.tsx
+++ b/packages/plugin-msw/src/components/MockWithFaker.tsx
@@ -44,9 +44,7 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, request
     }),
   )
 
-  const httpCall = requestTypeName
-    ? `http.${method}<Record<string, string>, ${requestTypeName}, any>`
-    : `http.${method}`
+  const httpCall = requestTypeName ? `http.${method}<Record<string, string>, ${requestTypeName}, any>` : `http.${method}`
 
   return (
     <File.Source name={name} isIndexable isExportable>

--- a/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
@@ -3,7 +3,8 @@
  * Do not edit manually.
  */
 
-import type { CreatePetsData, CreatePetsResponse } from './CreatePets'
+import type { CreatePetsResponse, CreatePetsData } from './CreatePets'
+import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
 export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
@@ -12,9 +13,7 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
   })
 }
 
-export function createPetsHandler(
-  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreatePetsData, any>>[1]>[0]) => Response | Promise<Response>),
-) {
+export function createPetsHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreatePetsData, any>) {
   return http.post<Record<string, string>, CreatePetsData, any>(`/pets`, function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { CreatePetsResponse } from './CreatePets'
+import type { CreatePetsData, CreatePetsResponse } from './CreatePets'
 import { http } from 'msw'
 
 export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
@@ -13,9 +13,9 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
 }
 
 export function createPetsHandler(
-  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>),
+  data?: string | number | boolean | null | object | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreatePetsData, any>>[1]>[0]) => Response | Promise<Response>),
 ) {
-  return http.post(`/pets`, function handler(info) {
+  return http.post<Record<string, string>, CreatePetsData, any>(`/pets`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
@@ -3,7 +3,8 @@
  * Do not edit manually.
  */
 
-import type { CreatePetsData, CreatePetsResponse } from './CreatePets'
+import type { CreatePetsResponse, CreatePetsData } from './CreatePets'
+import type { HttpResponseResolver } from 'msw'
 import { createPetsResponse } from './createPets'
 import { http } from 'msw'
 
@@ -13,7 +14,7 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
   })
 }
 
-export function createPetsHandler(data?: CreatePetsResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreatePetsData, any>>[1]>[0]) => Response | Promise<Response>)) {
+export function createPetsHandler(data?: CreatePetsResponse | HttpResponseResolver<Record<string, string>, CreatePetsData, any>) {
   return http.post<Record<string, string>, CreatePetsData, any>('/pets', function handler(info) {
     if (typeof data === 'function') return data(info)
 

--- a/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { CreatePetsResponse } from './CreatePets'
+import type { CreatePetsData, CreatePetsResponse } from './CreatePets'
 import { createPetsResponse } from './createPets'
 import { http } from 'msw'
 
@@ -13,8 +13,8 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
   })
 }
 
-export function createPetsHandler(data?: CreatePetsResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post('/pets', function handler(info) {
+export function createPetsHandler(data?: CreatePetsResponse | ((info: Parameters<Parameters<(typeof http)['post']<Record<string, string>, CreatePetsData, any>>[1]>[0]) => Response | Promise<Response>)) {
+  return http.post<Record<string, string>, CreatePetsData, any>('/pets', function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data || createPetsResponse(data)), {

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -46,6 +46,8 @@ export const mswGenerator = defineGenerator<PluginMsw>({
     const successResponses = getSuccessResponses(node)
     const hasSuccessSchema = successResponses.some((response) => !!response.schema)
 
+    const requestName = node.requestBody?.content?.[0]?.schema ? tsResolver.resolveDataName(node) : undefined
+
     return (
       <File
         baseName={mock.file.baseName}
@@ -56,7 +58,7 @@ export const mswGenerator = defineGenerator<PluginMsw>({
       >
         <File.Import name={['http']} path="msw" />
         <File.Import name={['ResponseResolver']} isTypeOnly path="msw" />
-        <File.Import name={Array.from(new Set([type.responseName, ...types.map((t) => t[1])]))} path={type.file.path} root={mock.file.path} isTypeOnly />
+        <File.Import name={Array.from(new Set([type.responseName, ...types.map((t) => t[1]), ...(requestName ? [requestName] : [])]))} path={type.file.path} root={mock.file.path} isTypeOnly />
         {parser === 'faker' && faker && <File.Import name={[faker.name]} root={mock.file.path} path={faker.file.path} />}
 
         {types
@@ -68,9 +70,9 @@ export const mswGenerator = defineGenerator<PluginMsw>({
           })}
 
         {parser === 'faker' && faker && hasSuccessSchema ? (
-          <MockWithFaker name={mock.name} typeName={type.responseName} fakerName={faker.name} node={node} baseURL={baseURL} />
+          <MockWithFaker name={mock.name} typeName={type.responseName} requestTypeName={requestName} fakerName={faker.name} node={node} baseURL={baseURL} />
         ) : (
-          <Mock name={mock.name} typeName={type.responseName} node={node} baseURL={baseURL} />
+          <Mock name={mock.name} typeName={type.responseName} requestTypeName={requestName} node={node} baseURL={baseURL} />
         )}
       </File>
     )

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -57,7 +57,7 @@ export const mswGenerator = defineGenerator<PluginMsw>({
         footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
       >
         <File.Import name={['http']} path="msw" />
-        <File.Import name={['ResponseResolver']} isTypeOnly path="msw" />
+        <File.Import name={['HttpResponseResolver']} isTypeOnly path="msw" />
         <File.Import name={Array.from(new Set([type.responseName, ...types.map((t) => t[1]), ...(requestName ? [requestName] : [])]))} path={type.file.path} root={mock.file.path} isTypeOnly />
         {parser === 'faker' && faker && <File.Import name={[faker.name]} root={mock.file.path} path={faker.file.path} />}
 

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -58,7 +58,12 @@ export const mswGenerator = defineGenerator<PluginMsw>({
       >
         <File.Import name={['http']} path="msw" />
         <File.Import name={['HttpResponseResolver']} isTypeOnly path="msw" />
-        <File.Import name={Array.from(new Set([type.responseName, ...types.map((t) => t[1]), ...(requestName ? [requestName] : [])]))} path={type.file.path} root={mock.file.path} isTypeOnly />
+        <File.Import
+          name={Array.from(new Set([type.responseName, ...types.map((t) => t[1]), ...(requestName ? [requestName] : [])]))}
+          path={type.file.path}
+          root={mock.file.path}
+          isTypeOnly
+        />
         {parser === 'faker' && faker && <File.Import name={[faker.name]} root={mock.file.path} path={faker.file.path} />}
 
         {types

--- a/packages/plugin-msw/vitest.config.ts
+++ b/packages/plugin-msw/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/addPetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405 } from "../types/AddPet.ts";
+import type { AddPetResponse, AddPetStatus405, AddPetData } from "../types/AddPet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
@@ -24,8 +25,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
       })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
+  return http.post<Record<string, string>, AddPetData, any>(`http://localhost:3000/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/createUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/createUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { CreateUserData } from "../types/CreateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function createUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/user`, function handler(info) {
+export function createUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreateUserData, any>) {
+  return http.post<Record<string, string>, CreateUserData, any>(`http://localhost:3000/user`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/createUsersWithListInputHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { CreateUsersWithListInputResponse } from "../types/CreateUsersWithListInput.ts";
+import type { CreateUsersWithListInputResponse, CreateUsersWithListInputData } from "../types/CreateUsersWithListInput.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
@@ -16,8 +17,8 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
       })
 }
 
-export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/user/createWithList`, function handler(info) {
+export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
+  return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`http://localhost:3000/user/createWithList`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/placeOrderHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405 } from "../types/PlaceOrder.ts";
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from "../types/PlaceOrder.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
@@ -24,8 +25,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
       })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
+  return http.post<Record<string, string>, PlaceOrderData, any>(`http://localhost:3000/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/updatePetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from "../types/UpdatePet.ts";
+import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405, UpdatePetData } from "../types/UpdatePet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -40,8 +41,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
       })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`http://localhost:3000/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
+  return http.put<Record<string, string>, UpdatePetData, any>(`http://localhost:3000/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/updateUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/updateUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { UpdateUserData } from "../types/UpdateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function updateUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`http://localhost:3000/user/:username`, function handler(info) {
+export function updateUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, UpdateUserData, any>) {
+  return http.put<Record<string, string>, UpdateUserData, any>(`http://localhost:3000/user/:username`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/uploadFileHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse } from "../types/UploadFile.ts";
+import type { UploadFileResponse, UploadFileData } from "../types/UploadFile.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -16,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
       })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
+  return http.post<Record<string, string>, UploadFileData, any>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/createUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/createUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { CreateUserData } from "../types/CreateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function createUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user`, function handler(info) {
+export function createUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreateUserData, any>) {
+  return http.post<Record<string, string>, CreateUserData, any>(`/user`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/createUsersWithListInputHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { CreateUsersWithListInputResponse } from "../types/CreateUsersWithListInput.ts";
+import type { CreateUsersWithListInputResponse, CreateUsersWithListInputData } from "../types/CreateUsersWithListInput.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
@@ -16,8 +17,8 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
       })
 }
 
-export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user/createWithList`, function handler(info) {
+export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
+  return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`/user/createWithList`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/placeOrderHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405 } from "../types/PlaceOrder.ts";
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from "../types/PlaceOrder.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
@@ -24,8 +25,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
       })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
+  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/updatePetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from "../types/UpdatePet.ts";
+import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405, UpdatePetData } from "../types/UpdatePet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -40,8 +41,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
       })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
+  return http.put<Record<string, string>, UpdatePetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/updateUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/updateUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { UpdateUserData } from "../types/UpdateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function updateUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/user/:username`, function handler(info) {
+export function updateUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, UpdateUserData, any>) {
+  return http.put<Record<string, string>, UpdateUserData, any>(`/user/:username`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/uploadFileHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse } from "../types/UploadFile.ts";
+import type { UploadFileResponse, UploadFileData } from "../types/UploadFile.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -16,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
       })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
+  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/petController/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/petController/addPetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405 } from "../../types/AddPet.ts";
+import type { AddPetResponse, AddPetStatus405, AddPetData } from "../../types/AddPet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
@@ -24,8 +25,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
       })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
+  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/petController/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/petController/updatePetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from "../../types/UpdatePet.ts";
+import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405, UpdatePetData } from "../../types/UpdatePet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -40,8 +41,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
       })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
+  return http.put<Record<string, string>, UpdatePetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/petController/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/petController/uploadFileHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse } from "../../types/UploadFile.ts";
+import type { UploadFileResponse, UploadFileData } from "../../types/UploadFile.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -16,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
       })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
+  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/storeController/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/storeController/placeOrderHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405 } from "../../types/PlaceOrder.ts";
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from "../../types/PlaceOrder.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
@@ -24,8 +25,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
       })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
+  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/userController/createUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/userController/createUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { CreateUserData } from "../../types/CreateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function createUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user`, function handler(info) {
+export function createUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreateUserData, any>) {
+  return http.post<Record<string, string>, CreateUserData, any>(`/user`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/userController/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/userController/createUsersWithListInputHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { CreateUsersWithListInputResponse } from "../../types/CreateUsersWithListInput.ts";
+import type { CreateUsersWithListInputResponse, CreateUsersWithListInputData } from "../../types/CreateUsersWithListInput.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
@@ -16,8 +17,8 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
       })
 }
 
-export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user/createWithList`, function handler(info) {
+export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
+  return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`/user/createWithList`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/userController/updateUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/userController/updateUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { UpdateUserData } from "../../types/UpdateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function updateUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/user/:username`, function handler(info) {
+export function updateUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, UpdateUserData, any>) {
+  return http.put<Record<string, string>, UpdateUserData, any>(`/user/:username`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/addPetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405 } from "../types/AddPet.ts";
+import type { AddPetResponse, AddPetStatus405, AddPetData } from "../types/AddPet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
@@ -24,8 +25,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
       })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
+  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/createUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/createUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { CreateUserData } from "../types/CreateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function createUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user`, function handler(info) {
+export function createUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreateUserData, any>) {
+  return http.post<Record<string, string>, CreateUserData, any>(`/user`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/createUsersWithListInputHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { CreateUsersWithListInputResponse } from "../types/CreateUsersWithListInput.ts";
+import type { CreateUsersWithListInputResponse, CreateUsersWithListInputData } from "../types/CreateUsersWithListInput.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
@@ -16,8 +17,8 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
       })
 }
 
-export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user/createWithList`, function handler(info) {
+export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
+  return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`/user/createWithList`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/placeOrderHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405 } from "../types/PlaceOrder.ts";
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from "../types/PlaceOrder.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
@@ -24,8 +25,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
       })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
+  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/updatePetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from "../types/UpdatePet.ts";
+import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405, UpdatePetData } from "../types/UpdatePet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -40,8 +41,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
       })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
+  return http.put<Record<string, string>, UpdatePetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/updateUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/updateUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { UpdateUserData } from "../types/UpdateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function updateUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/user/:username`, function handler(info) {
+export function updateUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, UpdateUserData, any>) {
+  return http.put<Record<string, string>, UpdateUserData, any>(`/user/:username`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/uploadFileHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse } from "../types/UploadFile.ts";
+import type { UploadFileResponse, UploadFileData } from "../types/UploadFile.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -16,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
       })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
+  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/addPetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405 } from "../types/AddPet.ts";
+import type { AddPetResponse, AddPetStatus405, AddPetData } from "../types/AddPet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
@@ -24,8 +25,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
       })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
+  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/updatePetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from "../types/UpdatePet.ts";
+import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405, UpdatePetData } from "../types/UpdatePet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -40,8 +41,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
       })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
+  return http.put<Record<string, string>, UpdatePetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/uploadFileHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse } from "../types/UploadFile.ts";
+import type { UploadFileResponse, UploadFileData } from "../types/UploadFile.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -16,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
       })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
+  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405 } from "../types/AddPet.ts";
+import type { AddPetResponse, AddPetStatus405, AddPetData } from "../types/AddPet.ts";
+import type { HttpResponseResolver } from "msw";
 import { addPetResponse } from "../faker/addPet.ts";
 import { http } from "msw";
 
@@ -25,8 +26,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
       })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post('/pet', function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
+  return http.post<Record<string, string>, AddPetData, any>('/pet', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || addPetResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { CreateUserData } from "../types/CreateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function createUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user`, function handler(info) {
+export function createUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreateUserData, any>) {
+  return http.post<Record<string, string>, CreateUserData, any>(`/user`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/createUsersWithListInputHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { CreateUsersWithListInputResponse } from "../types/CreateUsersWithListInput.ts";
+import type { CreateUsersWithListInputResponse, CreateUsersWithListInputData } from "../types/CreateUsersWithListInput.ts";
+import type { HttpResponseResolver } from "msw";
 import { createUsersWithListInputResponse } from "../faker/createUsersWithListInput.ts";
 import { http } from "msw";
 
@@ -17,8 +18,8 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
       })
 }
 
-export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post('/user/createWithList', function handler(info) {
+export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
+  return http.post<Record<string, string>, CreateUsersWithListInputData, any>('/user/createWithList', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || createUsersWithListInputResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405 } from "../types/PlaceOrder.ts";
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from "../types/PlaceOrder.ts";
+import type { HttpResponseResolver } from "msw";
 import { placeOrderResponse } from "../faker/placeOrder.ts";
 import { http } from "msw";
 
@@ -25,8 +26,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
       })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post('/store/order', function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
+  return http.post<Record<string, string>, PlaceOrderData, any>('/store/order', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || placeOrderResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updatePetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from "../types/UpdatePet.ts";
+import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405, UpdatePetData } from "../types/UpdatePet.ts";
+import type { HttpResponseResolver } from "msw";
 import { updatePetResponse } from "../faker/updatePet.ts";
 import { http } from "msw";
 
@@ -41,8 +42,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
       })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put('/pet', function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
+  return http.put<Record<string, string>, UpdatePetData, any>('/pet', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || updatePetResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updateUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/updateUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { UpdateUserData } from "../types/UpdateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function updateUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/user/:username`, function handler(info) {
+export function updateUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, UpdateUserData, any>) {
+  return http.put<Record<string, string>, UpdateUserData, any>(`/user/:username`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse } from "../types/UploadFile.ts";
+import type { UploadFileResponse, UploadFileData } from "../types/UploadFile.ts";
+import type { HttpResponseResolver } from "msw";
 import { uploadFileResponse } from "../faker/uploadFile.ts";
 import { http } from "msw";
 
@@ -17,8 +18,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
       })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post('/pet/:petId/uploadImage', function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
+  return http.post<Record<string, string>, UploadFileData, any>('/pet/:petId/uploadImage', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || uploadFileResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/addPetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405 } from "../types/AddPet.ts";
+import type { AddPetResponse, AddPetStatus405, AddPetData } from "../types/AddPet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function addPetHandlerResponse200(data: AddPetResponse) {
@@ -24,8 +25,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
       })
 }
 
-export function addPetHandler(data?: AddPetResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
+  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/createUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/createUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { CreateUserData } from "../types/CreateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function createUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user`, function handler(info) {
+export function createUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreateUserData, any>) {
+  return http.post<Record<string, string>, CreateUserData, any>(`/user`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/createUsersWithListInputHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/createUsersWithListInputHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { CreateUsersWithListInputResponse } from "../types/CreateUsersWithListInput.ts";
+import type { CreateUsersWithListInputResponse, CreateUsersWithListInputData } from "../types/CreateUsersWithListInput.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function createUsersWithListInputHandlerResponse200(data: CreateUsersWithListInputResponse) {
@@ -16,8 +17,8 @@ export function createUsersWithListInputHandlerResponse200(data: CreateUsersWith
       })
 }
 
-export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/user/createWithList`, function handler(info) {
+export function createUsersWithListInputHandler(data?: CreateUsersWithListInputResponse | HttpResponseResolver<Record<string, string>, CreateUsersWithListInputData, any>) {
+  return http.post<Record<string, string>, CreateUsersWithListInputData, any>(`/user/createWithList`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/placeOrderHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405 } from "../types/PlaceOrder.ts";
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from "../types/PlaceOrder.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
@@ -24,8 +25,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
       })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
+  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/updatePetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/updatePetHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405 } from "../types/UpdatePet.ts";
+import type { UpdatePetResponse, UpdatePetStatus400, UpdatePetStatus404, UpdatePetStatus405, UpdatePetData } from "../types/UpdatePet.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function updatePetHandlerResponse200(data: UpdatePetResponse) {
@@ -40,8 +41,8 @@ export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
       })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
+  return http.put<Record<string, string>, UpdatePetData, any>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/updateUserHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/updateUserHandler.ts
@@ -3,10 +3,12 @@
 * Do not edit manually.
 */
 
+import type { UpdateUserData } from "../types/UpdateUser.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
-export function updateUserHandler(data?: string | number | boolean | null | object | ((info: Parameters<Parameters<typeof http.put>[1]>[0]) => Response | Promise<Response>)) {
-  return http.put(`/user/:username`, function handler(info) {
+export function updateUserHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, UpdateUserData, any>) {
+  return http.put<Record<string, string>, UpdateUserData, any>(`/user/:username`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/uploadFileHandler.ts
@@ -3,7 +3,8 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse } from "../types/UploadFile.ts";
+import type { UploadFileResponse, UploadFileData } from "../types/UploadFile.ts";
+import type { HttpResponseResolver } from "msw";
 import { http } from "msw";
 
 export function uploadFileHandlerResponse200(data: UploadFileResponse) {
@@ -16,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
       })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | ((info: Parameters<Parameters<typeof http.post>[1]>[0]) => Response | Promise<Response>)) {
-  return http.post(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
+  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {


### PR DESCRIPTION
When an operation has a request body, the generated MSW handler now passes
the request body type as a generic to `http.<method>`, so `info.request.json()`
returns the typed payload without requiring a manual cast.

Fixes #12

https://claude.ai/code/session_012uZAv7aK9aXaE7SjXQX8eD