### PR TITLE
Update kubb core packages to 5.0.0-alpha.71

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,23 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     '@kubb/agent':
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     '@kubb/core':
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     '@kubb/middleware-barrel':
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     '@kubb/parser-ts':
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     '@kubb/renderer-jsx':
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     '@size-limit/file':
       specifier: ^12.1.0
       version: 12.1.0
@@ -34,8 +34,8 @@ catalogs:
       specifier: ^19.2.14
       version: 19.2.14
     kubb:
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     remeda:
       specifier: ^2.33.7
       version: 2.33.7
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     unplugin-kubb:
-      specifier: 5.0.0-alpha.70
-      version: 5.0.0-alpha.70
+      specifier: 5.0.0-alpha.71
+      version: 5.0.0-alpha.71
     vitest:
       specifier: ^4.1.5
       version: 4.1.5
@@ -67,16 +67,16 @@ importers:
         version: 2.31.0(@types/node@22.19.17)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/middleware-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70))
+        version: 5.0.0-alpha.71(@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71))
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -209,16 +209,16 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/agent':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -227,13 +227,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -242,13 +242,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
       axios:
         specifier: ^1.15.2
         version: 1.15.2
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -270,7 +270,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -289,7 +289,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -304,7 +304,7 @@ importers:
         version: 1.11.20
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -317,7 +317,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -326,7 +326,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
     devDependencies:
       react:
         specifier: ^19.2.5
@@ -339,13 +339,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -354,13 +354,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
       axios:
         specifier: ^1.15.2
         version: 1.15.2
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -376,7 +376,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-mcp':
         specifier: workspace:*
         version: link:../../packages/plugin-mcp
@@ -394,7 +394,7 @@ importers:
         version: 1.15.2
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -410,7 +410,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -428,7 +428,7 @@ importers:
         version: 0.10.3(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       msw:
         specifier: ^2.13.6
         version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
@@ -447,7 +447,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -468,7 +468,7 @@ importers:
         version: 1.15.2
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -477,7 +477,7 @@ importers:
         version: 19.2.5(react@19.2.5)
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70))(@kubb/renderer-jsx@5.0.0-alpha.70)(esbuild@0.27.7)(rolldown@1.0.0-rc.17)(rollup@4.60.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+        version: 5.0.0-alpha.71(@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71))(@kubb/renderer-jsx@5.0.0-alpha.71)(esbuild@0.27.7)(rolldown@1.0.0-rc.17)(rollup@4.60.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -502,7 +502,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -511,7 +511,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -521,7 +521,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -545,7 +545,7 @@ importers:
         version: 1.15.2
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -560,7 +560,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -569,7 +569,7 @@ importers:
         version: 1.15.2
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -579,7 +579,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -600,7 +600,7 @@ importers:
         version: 1.15.2
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70))(@kubb/renderer-jsx@5.0.0-alpha.70)(esbuild@0.27.7)(rolldown@1.0.0-rc.17)(rollup@4.60.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
+        version: 5.0.0-alpha.71(@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71))(@kubb/renderer-jsx@5.0.0-alpha.71)(esbuild@0.27.7)(rolldown@1.0.0-rc.17)(rollup@4.60.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       vue:
         specifier: ^3.5.33
         version: 3.5.33(typescript@6.0.3)
@@ -634,7 +634,7 @@ importers:
         version: 1.15.2
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -652,13 +652,13 @@ importers:
         version: link:../utils
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -674,7 +674,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
@@ -683,7 +683,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -696,13 +696,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -712,13 +712,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -728,7 +728,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -740,7 +740,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -750,7 +750,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../plugin-faker
@@ -759,7 +759,7 @@ importers:
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -769,7 +769,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -781,7 +781,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
       remeda:
         specifier: 'catalog:'
         version: 2.33.7
@@ -797,10 +797,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -813,13 +813,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
       remeda:
         specifier: 'catalog:'
         version: 2.33.7
@@ -835,7 +835,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -847,7 +847,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
       remeda:
         specifier: 'catalog:'
         version: 2.33.7
@@ -863,10 +863,10 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70
+        version: 5.0.0-alpha.71
       remeda:
         specifier: 'catalog:'
         version: 2.33.7
@@ -882,13 +882,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -934,7 +934,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -970,7 +970,7 @@ importers:
         version: 15.14.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
       msw:
         specifier: ^2.13.6
         version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
@@ -1001,10 +1001,10 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1019,7 +1019,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
+        version: 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1656,48 +1656,48 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@kubb/adapter-oas@5.0.0-alpha.70':
-    resolution: {integrity: sha512-4f9xgyLHWjyB1+M+qq0ZLa/nZ4Urv3beUfUM3NWdpll6TRhFYOe3AWJQ09cK5svYZWcOsKdqHt+RHwlij7uYGA==}
+  '@kubb/adapter-oas@5.0.0-alpha.71':
+    resolution: {integrity: sha512-Z5TGTHwbayHlQqIx7IHNT6BHtp6MX4BLuVJJX1nRU7JTAVVeS44fnxq03JlcIhNwBPtt6reY/ArJ9m10bf+eNQ==}
     engines: {node: '>=22'}
 
-  '@kubb/agent@5.0.0-alpha.70':
-    resolution: {integrity: sha512-6bYOQRAwb174QxGmxefVTPuBQHZa1J/oaO2YU1ekp/yPriKd6q42sjHhsyHVd3+KO49l6p/omdzoB1ZCA8QnRQ==}
+  '@kubb/agent@5.0.0-alpha.71':
+    resolution: {integrity: sha512-UPr1+FyoSPSwMx5KmLuEbY69sxzbWXyO5Kjo6ejG20j9Nsg7NI4cP69LMcQBv3Zy1tLujY9fMSnpGNTeN/9DiA==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-alpha.70':
-    resolution: {integrity: sha512-5ShVQ9IuHYS4jGb3RmAtCAe+ygVJspgZSkenxaq56uhPxMdOarn5ghhsmA6E0tmjnYv0bg/xsRrz3LKPuccFEQ==}
+  '@kubb/ast@5.0.0-alpha.71':
+    resolution: {integrity: sha512-Ef9XhoUnFDcq5YBQ2X4reQibSjqxO0IYZHuCVOv87vuioSekqHQUPHiUcXsczbiHi9dJX/zP5dczfS3ERdSHHg==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-alpha.70':
-    resolution: {integrity: sha512-azavaizsHTkfveIB3YXoJHw+jVX/bPKXGaWC6mpW5s4op5KEI2A+/NVI3wmONjxM+vB77tuPG/wjEfqYuhRGTg==}
-    engines: {node: '>=22'}
-    hasBin: true
-
-  '@kubb/core@5.0.0-alpha.70':
-    resolution: {integrity: sha512-9QsGHl2515uNL1rcCh73pyadgM1nC10orcl3wAWhdIrIbHnTSCSbeAsLeqCoz04c0GMIiPSGqHDYy3lPF50MjA==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-alpha.70
-
-  '@kubb/mcp@5.0.0-alpha.70':
-    resolution: {integrity: sha512-5bPJEgeyzgW9AJGK6AR4AJcK9wpGI8V4BFPpihPkPypbELecjUE5S9c6M0ib6okkqkxh3h+wFGvHjYJcTrtyTA==}
+  '@kubb/cli@5.0.0-alpha.71':
+    resolution: {integrity: sha512-ZRbubElVZYiofnvQJKzPAoZ55XzpnNgOd+xZwGL19exbbC6HvOw94BeXbeFVh9zxkPdmd2uGQcBJuQxUdST/+w==}
     engines: {node: '>=22'}
     hasBin: true
-    peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-alpha.70
 
-  '@kubb/middleware-barrel@5.0.0-alpha.70':
-    resolution: {integrity: sha512-DiptwZkVKKoy+tBb/R5Gyzc0kHXhyfvF5i4hu9UAuWBMyT97pmkesywQB2RUAq5ObjjlJzXnvfTdpD/2OsW14Q==}
+  '@kubb/core@5.0.0-alpha.71':
+    resolution: {integrity: sha512-sAsJHwNXeTInuaalFI35IEyUNdAfmtHSrwNicuDsZ/9Cdi4d5VgOb4xDSo4q8/W7WxunHScFcDbhlznzLl3X+A==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-alpha.70
+      '@kubb/renderer-jsx': 5.0.0-alpha.71
 
-  '@kubb/parser-ts@5.0.0-alpha.70':
-    resolution: {integrity: sha512-P7wHeZTtLoH0hWRSyTl4Q1VT29dt9Ru5bvMO/WBbPD6MF17VEnzRcZozxZ/4RFYiP1PAlMlSho7LRui0LaCG7Q==}
+  '@kubb/mcp@5.0.0-alpha.71':
+    resolution: {integrity: sha512-dyCrk14C8nO3Mo3cnC4bmIpm29JNWDqFxLVApkkAOalTmSAIObgILc5lbzvGCbg9m1ym36QibB0Nq+qSYoq5RQ==}
+    engines: {node: '>=22'}
+    hasBin: true
+    peerDependencies:
+      '@kubb/renderer-jsx': 5.0.0-alpha.71
+
+  '@kubb/middleware-barrel@5.0.0-alpha.71':
+    resolution: {integrity: sha512-uHUyZO9iT3Lqm1Y7RM3/M16fjqw/RBgZylpyjy1VlkKsTljTB7bxTPivGDRTnCwHnc4NV0MDxSXiWCOvut0KsA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@kubb/core': 5.0.0-alpha.71
+
+  '@kubb/parser-ts@5.0.0-alpha.71':
+    resolution: {integrity: sha512-F5t2uXQKJyErM2iXKVCUk1E9GxmYXyouzByf/VVrIH1G50UCGF/4UzoWJk+gEZVKdi2QE5y1M9j/K7wd0hldVA==}
     engines: {node: '>=22'}
 
-  '@kubb/renderer-jsx@5.0.0-alpha.70':
-    resolution: {integrity: sha512-wh+uira1ittmZlnhHmWNtipvhcP2nUvc+qxEESNGq7+4vc6IklJCUlNAy7ADIAiCJxer/sVKQkuazwcxh/6IWA==}
+  '@kubb/renderer-jsx@5.0.0-alpha.71':
+    resolution: {integrity: sha512-1FGjMTaR8p+e0Gy820/BcJ04G+LkyNZRIXRtz8Axp6CfmvSiRgRmlcJa17zeKN/HCRcIBfhZYfFQmCWWureo4w==}
     engines: {node: '>=22'}
 
   '@logtail/core@0.5.8':
@@ -3717,8 +3717,8 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-alpha.70:
-    resolution: {integrity: sha512-RWF7vXBJ+KQBWH3XTX/h9opO3f39LG+ufVXn5rGuTKi3Oi2NSBxY148a/Nx/M9kEnuviLSoYbHV/E91V1WNilw==}
+  kubb@5.0.0-alpha.71:
+    resolution: {integrity: sha512-J22wJulQCYxgJgTmu7iu/JV1uvcZXrqioiL8xmd2kwJ40nKlOC6lOd14xPt1FZlvTlh4aM1eqlWfdiny4qP3YA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4808,8 +4808,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-alpha.70:
-    resolution: {integrity: sha512-blXD9VbWFgKw2ufLIzW2j5BLMFnRxpTxNjHvgR9S/gaa+qfvw5bSWk9vYu64OxlHZXeku3JAAZQdWRMsc6ls8g==}
+  unplugin-kubb@5.0.0-alpha.71:
+    resolution: {integrity: sha512-eOAJF9cwZDeuaI7iV+uZHfjxCvmJbdGqH2qsdKYmLGTwBcUHxUAujOb3+b4m0CR43LXrrCzYYNXunueRVNkCNw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -5831,9 +5831,9 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kubb/adapter-oas@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)':
+  '@kubb/adapter-oas@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)':
     dependencies:
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@redocly/openapi-core': 2.30.0
       oas: 32.1.17
       oas-normalize: 16.0.4
@@ -5842,15 +5842,15 @@ snapshots:
       - '@kubb/renderer-jsx'
       - encoding
 
-  '@kubb/agent@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)':
+  '@kubb/agent@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)':
     dependencies:
-      '@kubb/ast': 5.0.0-alpha.70
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/ast': 5.0.0-alpha.71
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       '@logtail/node': 0.5.8
       consola: 3.4.2
-      jiti: 2.6.1
       remeda: 2.33.7
       tinyexec: 1.1.1
+      unrun: 0.2.37
       unstorage: 1.17.5
       ws: 8.20.0
     transitivePeerDependencies:
@@ -5874,23 +5874,24 @@ snapshots:
       - db0
       - idb-keyval
       - ioredis
+      - synckit
       - uploadthing
       - utf-8-validate
 
-  '@kubb/ast@5.0.0-alpha.70': {}
+  '@kubb/ast@5.0.0-alpha.71': {}
 
-  '@kubb/cli@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)':
+  '@kubb/cli@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)':
     dependencies:
       '@clack/prompts': 1.2.0
-      '@kubb/adapter-oas': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/adapter-oas': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       chokidar: 5.0.0
       cosmiconfig: 9.0.1(typescript@6.0.3)
-      jiti: 2.6.1
       tinyexec: 1.1.1
+      unrun: 0.2.37
     optionalDependencies:
-      '@kubb/agent': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/mcp': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/agent': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/mcp': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5915,42 +5916,44 @@ snapshots:
       - idb-keyval
       - ioredis
       - supports-color
+      - synckit
       - typescript
       - uploadthing
       - utf-8-validate
 
-  '@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)':
+  '@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)':
     dependencies:
-      '@kubb/ast': 5.0.0-alpha.70
-      '@kubb/renderer-jsx': 5.0.0-alpha.70
+      '@kubb/ast': 5.0.0-alpha.71
+      '@kubb/renderer-jsx': 5.0.0-alpha.71
       fflate: 0.8.2
       tinyexec: 1.1.1
 
-  '@kubb/mcp@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)':
+  '@kubb/mcp@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)':
     dependencies:
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/renderer-jsx': 5.0.0-alpha.70
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/renderer-jsx': 5.0.0-alpha.71
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
-      jiti: 2.6.1
+      unrun: 0.2.37
       zod: 4.3.6
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
+      - synckit
 
-  '@kubb/middleware-barrel@5.0.0-alpha.70(@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70))':
+  '@kubb/middleware-barrel@5.0.0-alpha.71(@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71))':
     dependencies:
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
 
-  '@kubb/parser-ts@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)':
+  '@kubb/parser-ts@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)':
     dependencies:
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/renderer-jsx@5.0.0-alpha.70':
+  '@kubb/renderer-jsx@5.0.0-alpha.71':
     dependencies:
-      '@kubb/ast': 5.0.0-alpha.70
+      '@kubb/ast': 5.0.0-alpha.71
 
   '@logtail/core@0.5.8':
     dependencies:
@@ -7914,15 +7917,15 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3):
+  kubb@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/agent': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/cli': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)(typescript@6.0.3)
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/mcp': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/middleware-barrel': 5.0.0-alpha.70(@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70))
-      '@kubb/parser-ts': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/adapter-oas': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/agent': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/cli': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)(typescript@6.0.3)
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/mcp': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/middleware-barrel': 5.0.0-alpha.71(@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71))
+      '@kubb/parser-ts': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7947,6 +7950,7 @@ snapshots:
       - idb-keyval
       - ioredis
       - supports-color
+      - synckit
       - typescript
       - uploadthing
       - utf-8-validate
@@ -9099,12 +9103,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-alpha.70(@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70))(@kubb/renderer-jsx@5.0.0-alpha.70)(esbuild@0.27.7)(rolldown@1.0.0-rc.17)(rollup@4.60.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)):
+  unplugin-kubb@5.0.0-alpha.71(@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71))(@kubb/renderer-jsx@5.0.0-alpha.71)(esbuild@0.27.7)(rolldown@1.0.0-rc.17)(rollup@4.60.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/core': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
-      '@kubb/middleware-barrel': 5.0.0-alpha.70(@kubb/core@5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70))
-      '@kubb/parser-ts': 5.0.0-alpha.70(@kubb/renderer-jsx@5.0.0-alpha.70)
+      '@kubb/adapter-oas': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/core': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
+      '@kubb/middleware-barrel': 5.0.0-alpha.71(@kubb/core@5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71))
+      '@kubb/parser-ts': 5.0.0-alpha.71(@kubb/renderer-jsx@5.0.0-alpha.71)
       unplugin: 3.0.0
     optionalDependencies:
       esbuild: 0.27.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,14 +5,14 @@ packages:
   - tests/**
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-alpha.70
-  '@kubb/agent': 5.0.0-alpha.70
-  '@kubb/core': 5.0.0-alpha.70
-  '@kubb/middleware-barrel': 5.0.0-alpha.70
-  '@kubb/parser-ts': 5.0.0-alpha.70
-  '@kubb/renderer-jsx': 5.0.0-alpha.70
-  kubb: 5.0.0-alpha.70
-  unplugin-kubb: 5.0.0-alpha.70
+  '@kubb/adapter-oas': 5.0.0-alpha.71
+  '@kubb/agent': 5.0.0-alpha.71
+  '@kubb/core': 5.0.0-alpha.71
+  '@kubb/middleware-barrel': 5.0.0-alpha.71
+  '@kubb/parser-ts': 5.0.0-alpha.71
+  '@kubb/renderer-jsx': 5.0.0-alpha.71
+  kubb: 5.0.0-alpha.71
+  unplugin-kubb: 5.0.0-alpha.71
   '@types/node': ^22.19.17
   '@types/react': ^19.2.14
   '@size-limit/file': ^12.1.0


### PR DESCRIPTION
## Summary

Updates all kubb core packages from 5.0.0-alpha.70 to 5.0.0-alpha.71:
- @kubb/adapter-oas
- @kubb/agent
- @kubb/core
- @kubb/middleware-barrel
- @kubb/parser-ts
- @kubb/renderer-jsx
- kubb
- unplugin-kubb

## Changes

Updated the catalog versions in `pnpm-workspace.yaml` to reflect the new alpha version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWvjhUszXh2XDHb8odojy7)_