### PR TITLE
fix: Expand plugin resolvers with dedicated naming methods for generated helpers, hooks, keys, handlers, and paths.

### DIFF
--- a/.changeset/plugin-resolver-naming.md
+++ b/.changeset/plugin-resolver-naming.md
@@ -1,0 +1,13 @@
+---
+"@kubb/plugin-client": minor
+"@kubb/plugin-cypress": minor
+"@kubb/plugin-faker": minor
+"@kubb/plugin-mcp": minor
+"@kubb/plugin-msw": major
+"@kubb/plugin-react-query": major
+"@kubb/plugin-vue-query": major
+---
+
+Expand plugin resolvers with dedicated naming methods for generated helpers, hooks, keys, handlers, client classes, handler collections, custom hook option helpers, and paths.
+
+**Breaking:** `@kubb/plugin-react-query`, `@kubb/plugin-vue-query`, and `@kubb/plugin-msw` no longer support the `transformers.name` naming option. Use the plugin `resolver` option instead to customize generated names.

--- a/examples/react-query/kubb.config.ts
+++ b/examples/react-query/kubb.config.ts
@@ -4,6 +4,14 @@ import { QueryKey } from '@kubb/plugin-react-query/components'
 import { pluginTs } from '@kubb/plugin-ts'
 import { defineConfig } from 'kubb'
 
+function capitalize(name: string): string {
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`
+}
+
+function hookName(name: string): string {
+  return `${name}Hook`
+}
+
 /** @type {import('@kubb/core').UserConfig} */
 export const config = {
   root: '.',
@@ -36,12 +44,48 @@ export const config = {
       client: {
         bundle: true,
       },
-      transformers: {
-        name: (name, type) => {
-          if (type === 'file' || type === 'function') {
-            return `${name}Hook`
-          }
-          return name
+      resolver: {
+        resolveQueryName(node) {
+          return hookName(`use${capitalize(this.resolveName(node.operationId))}`)
+        },
+        resolveSuspenseQueryName(node) {
+          return hookName(`use${capitalize(this.resolveName(node.operationId))}Suspense`)
+        },
+        resolveInfiniteQueryName(node) {
+          return hookName(`use${capitalize(this.resolveName(node.operationId))}Infinite`)
+        },
+        resolveSuspenseInfiniteQueryName(node) {
+          return hookName(`use${capitalize(this.resolveName(node.operationId))}SuspenseInfinite`)
+        },
+        resolveMutationName(node) {
+          return hookName(`use${capitalize(this.resolveName(node.operationId))}`)
+        },
+        resolveQueryOptionsName(node) {
+          return hookName(`${this.resolveName(node.operationId)}QueryOptions`)
+        },
+        resolveSuspenseQueryOptionsName(node) {
+          return hookName(`${this.resolveName(node.operationId)}SuspenseQueryOptions`)
+        },
+        resolveInfiniteQueryOptionsName(node) {
+          return hookName(`${this.resolveName(node.operationId)}InfiniteQueryOptions`)
+        },
+        resolveSuspenseInfiniteQueryOptionsName(node) {
+          return hookName(`${this.resolveName(node.operationId)}SuspenseInfiniteQueryOptions`)
+        },
+        resolveMutationOptionsName(node) {
+          return hookName(`${this.resolveName(node.operationId)}MutationOptions`)
+        },
+        resolveClientName(node) {
+          return hookName(this.resolveName(node.operationId))
+        },
+        resolveSuspenseClientName(node) {
+          return hookName(`${this.resolveName(node.operationId)}Suspense`)
+        },
+        resolveInfiniteClientName(node) {
+          return hookName(`${this.resolveName(node.operationId)}Infinite`)
+        },
+        resolveSuspenseInfiniteClientName(node) {
+          return hookName(`${this.resolveName(node.operationId)}SuspenseInfinite`)
         },
       },
       output: {

--- a/packages/plugin-client/src/components/WrapperClient.tsx
+++ b/packages/plugin-client/src/components/WrapperClient.tsx
@@ -1,17 +1,21 @@
-import { camelCase } from '@internals/utils'
 import { File } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 
+type ClientController = {
+  className: string
+  propertyName: string
+}
+
 type Props = {
   name: string
-  classNames: Array<string>
+  controllers: Array<ClientController>
   isExportable?: boolean
   isIndexable?: boolean
 }
 
-export function WrapperClient({ name, classNames, isExportable = true, isIndexable = true }: Props): KubbReactNode {
-  const properties = classNames.map((className) => `  readonly ${camelCase(className)}: ${className}`).join('\n')
-  const assignments = classNames.map((className) => `    this.${camelCase(className)} = new ${className}(config)`).join('\n')
+export function WrapperClient({ name, controllers, isExportable = true, isIndexable = true }: Props): KubbReactNode {
+  const properties = controllers.map(({ className, propertyName }) => `  readonly ${propertyName}: ${className}`).join('\n')
+  const assignments = controllers.map(({ className, propertyName }) => `    this.${propertyName} = new ${className}(config)`).join('\n')
 
   const classCode = `export class ${name} {
 ${properties}

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { camelCase, pascalCase } from '@internals/utils'
+import { camelCase } from '@internals/utils'
 import type { ast } from '@kubb/core'
 import { defineGenerator } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
@@ -22,6 +22,7 @@ type OperationData = {
 
 type Controller = {
   name: string
+  propertyName: string
   file: ast.FileNode
   operations: Array<OperationData>
 }
@@ -87,10 +88,10 @@ export const classClientGenerator = defineGenerator<PluginClient>({
 
     const controllers = nodes.reduce((acc, operationNode) => {
       const tag = operationNode.tags[0]
-      const groupName = tag ? (group?.name?.({ group: camelCase(tag) }) ?? pascalCase(tag)) : 'Client'
+      const groupName = tag ? (group?.name?.({ group: camelCase(tag) }) ?? resolver.resolveGroupName(tag)) : resolver.resolveGroupName('Client')
 
       if (!tag && !group) {
-        const name = 'ApiClient'
+        const name = resolver.resolveClassName('ApiClient')
         const file = resolver.resolveFile({ name, extname: '.ts' }, { root, output, group })
         const operationData = buildOperationData(operationNode)
         const previous = acc.find((item) => item.file.path === file.path)
@@ -98,7 +99,7 @@ export const classClientGenerator = defineGenerator<PluginClient>({
         if (previous) {
           previous.operations.push(operationData)
         } else {
-          acc.push({ name, file, operations: [operationData] })
+          acc.push({ name, propertyName: resolver.resolveClientPropertyName(name), file, operations: [operationData] })
         }
       } else if (tag) {
         const name = groupName
@@ -109,7 +110,7 @@ export const classClientGenerator = defineGenerator<PluginClient>({
         if (previous) {
           previous.operations.push(operationData)
         } else {
-          acc.push({ name, file, operations: [operationData] })
+          acc.push({ name, propertyName: resolver.resolveClientPropertyName(name), file, operations: [operationData] })
         }
       }
 
@@ -239,7 +240,7 @@ export const classClientGenerator = defineGenerator<PluginClient>({
             <File.Import key={name} name={[name]} root={sdkFile.path} path={file.path} />
           ))}
 
-          <WrapperClient name={sdk.className} classNames={controllers.map(({ name }) => name)} />
+          <WrapperClient name={sdk.className} controllers={controllers.map(({ name, propertyName }) => ({ className: name, propertyName }))} />
         </File>,
       )
     }

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -49,7 +49,7 @@ export const clientGenerator = defineGenerator<PluginClient>({
 
     const meta = {
       name: resolver.resolveName(node.operationId),
-      urlName: `get${resolver.resolveName(node.operationId).charAt(0).toUpperCase()}${resolver.resolveName(node.operationId).slice(1)}Url`,
+      urlName: resolver.resolveUrlName(node),
       file: resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),
       fileTs: tsResolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { camelCase, pascalCase } from '@internals/utils'
+import { camelCase } from '@internals/utils'
 import type { ast } from '@kubb/core'
 import { defineGenerator } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
@@ -86,10 +86,10 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
 
     const controllers = nodes.reduce((acc, operationNode) => {
       const tag = operationNode.tags[0]
-      const groupName = tag ? (group?.name?.({ group: camelCase(tag) }) ?? pascalCase(tag)) : 'Client'
+      const groupName = tag ? (group?.name?.({ group: camelCase(tag) }) ?? resolver.resolveGroupName(tag)) : resolver.resolveGroupName('Client')
 
       if (!tag && !group) {
-        const name = 'ApiClient'
+        const name = resolver.resolveClassName('ApiClient')
         const file = resolver.resolveFile({ name, extname: '.ts' }, { root, output, group })
         const operationData = buildOperationData(operationNode)
         const previous = acc.find((item) => item.file.path === file.path)

--- a/packages/plugin-client/src/resolvers/resolverClient.ts
+++ b/packages/plugin-client/src/resolvers/resolverClient.ts
@@ -1,4 +1,4 @@
-import { camelCase } from '@internals/utils'
+import { camelCase, pascalCase } from '@internals/utils'
 import { defineResolver } from '@kubb/core'
 import type { PluginClient } from '../types.ts'
 
@@ -18,5 +18,21 @@ export const resolverClient = defineResolver<PluginClient>((ctx) => ({
   },
   resolveName(name) {
     return ctx.default(name, 'function')
+  },
+  resolvePathName(name, type) {
+    return ctx.default(name, type)
+  },
+  resolveClassName(name) {
+    return pascalCase(name)
+  },
+  resolveGroupName(name) {
+    return pascalCase(name)
+  },
+  resolveClientPropertyName(name) {
+    return camelCase(name)
+  },
+  resolveUrlName(node) {
+    const name = ctx.resolveName(node.operationId)
+    return `get${name.charAt(0).toUpperCase()}${name.slice(1)}Url`
   },
 }))

--- a/packages/plugin-client/src/types.ts
+++ b/packages/plugin-client/src/types.ts
@@ -7,10 +7,34 @@ import type { ast, Exclude, Generator, Group, Include, Output, Override, PluginF
 export type ResolverClient = Resolver & {
   /**
    * Resolves the function name for a given raw operation name.
+   *
    * @example Resolving operation names
    * `resolver.resolveName('show pet by id') // -> 'showPetById'`
    */
   resolveName(this: ResolverClient, name: string): string
+  /**
+   * Resolves the output file name for a client module.
+   */
+  resolvePathName(this: ResolverClient, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
+  /**
+   * Resolves the generated class name for class-based clients.
+   */
+  resolveClassName(this: ResolverClient, name: string): string
+  /**
+   * Resolves the generated class name for tag-based client groups.
+   */
+  resolveGroupName(this: ResolverClient, name: string): string
+  /**
+   * Resolves the generated SDK facade property name for a client class.
+   */
+  resolveClientPropertyName(this: ResolverClient, name: string): string
+  /**
+   * Resolves the URL helper function name for an operation.
+   *
+   * @example Resolving URL helper names
+   * `resolver.resolveUrlName(node) // -> 'getShowPetByIdUrl'`
+   */
+  resolveUrlName(this: ResolverClient, node: ast.OperationNode): string
 }
 
 /**

--- a/packages/plugin-cypress/src/resolvers/resolverCypress.ts
+++ b/packages/plugin-cypress/src/resolvers/resolverCypress.ts
@@ -19,4 +19,7 @@ export const resolverCypress = defineResolver<PluginCypress>((ctx) => ({
   resolveName(name) {
     return ctx.default(name, 'function')
   },
+  resolvePathName(name, type) {
+    return ctx.default(name, type)
+  },
 }))

--- a/packages/plugin-cypress/src/types.ts
+++ b/packages/plugin-cypress/src/types.ts
@@ -11,6 +11,10 @@ export type ResolverCypress = Resolver & {
    * `resolver.resolveName('show pet by id') // -> 'showPetById'`
    */
   resolveName(this: ResolverCypress, name: string): string
+  /**
+   * Resolves the output file name for a Cypress request module.
+   */
+  resolvePathName(this: ResolverCypress, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
 }
 
 /**

--- a/packages/plugin-faker/src/resolvers/resolverFaker.ts
+++ b/packages/plugin-faker/src/resolvers/resolverFaker.ts
@@ -79,6 +79,9 @@ export const resolverFaker = defineResolver<PluginFaker>((ctx) => {
     resolveResponseName(node) {
       return ctx.resolveName(`${node.operationId} Response`)
     },
+    resolveResponsesName(node) {
+      return ctx.resolveName(`${node.operationId} Responses`)
+    },
     resolvePathParamsName(node, param) {
       return ctx.resolveParamName(node, param)
     },

--- a/packages/plugin-faker/src/types.ts
+++ b/packages/plugin-faker/src/types.ts
@@ -42,6 +42,13 @@ export type ResolverFaker = Resolver &
      */
     resolveResponseName(this: ResolverFaker, node: ast.OperationNode): string
     /**
+     * Resolves the faker function name for the response collection.
+     *
+     * @example Responses collection names
+     * `resolver.resolveResponsesName(node) // -> 'listPetsResponses'`
+     */
+    resolveResponsesName(this: ResolverFaker, node: ast.OperationNode): string
+    /**
      * Resolves the faker function name for path parameters.
      *
      * @example Path parameters names

--- a/packages/plugin-mcp/src/generators/mcpGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/mcpGenerator.tsx
@@ -36,7 +36,7 @@ export const mcpGenerator = defineGenerator<PluginMcp>({
     ].filter((name): name is string => Boolean(name))
 
     const meta = {
-      name: resolver.resolveName(node.operationId),
+      name: resolver.resolveHandlerName(node),
       file: resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),
       fileTs: tsResolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -73,7 +73,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
           description: node.description || `Make a ${node.method.toUpperCase()} request to ${node.path}`,
         },
         mcp: {
-          name: resolver.resolveName(node.operationId),
+          name: resolver.resolveHandlerName(node),
           file: mcpFile,
         },
         zod: {

--- a/packages/plugin-mcp/src/resolvers/resolverMcp.ts
+++ b/packages/plugin-mcp/src/resolvers/resolverMcp.ts
@@ -22,4 +22,10 @@ export const resolverMcp = defineResolver<PluginMcp>((ctx) => ({
   resolveName(name) {
     return ctx.default(name, 'function')
   },
+  resolvePathName(name, type) {
+    return ctx.default(name, type)
+  },
+  resolveHandlerName(node) {
+    return ctx.resolveName(node.operationId)
+  },
 }))

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -6,12 +6,20 @@ import type { ClientImportPath, PluginClient } from '@kubb/plugin-client'
  */
 export type ResolverMcp = Resolver & {
   /**
-   * Resolves the handler function name for an operation.
+   * Resolves the base handler function name for an operation.
    *
    * @example Resolving handler function names
    * `resolver.resolveName('show pet by id') // -> 'showPetByIdHandler'`
    */
   resolveName(this: ResolverMcp, name: string): string
+  /**
+   * Resolves the output file name for an MCP module.
+   */
+  resolvePathName(this: ResolverMcp, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
+  /**
+   * Resolves the handler function name for an operation.
+   */
+  resolveHandlerName(this: ResolverMcp, node: ast.OperationNode): string
 }
 
 export type Options = {

--- a/packages/plugin-msw/extension.yaml
+++ b/packages/plugin-msw/extension.yaml
@@ -211,19 +211,6 @@ options:
       Define additional generators next to the built-in generators.
 
       See [Generators](https://kubb.dev/docs/5.x/guides/creating-plugins) for more information on how to use generators.
-  - name: transformers
-    type: object
-    required: false
-    description: Customize the generated names based on the type provided by the plugin.
-    properties:
-      - name: name
-        type: '(name: string, type?: ResolveType) => string'
-        required: false
-        description: Customize the names based on the type that is provided by the plugin.
-        codeBlock:
-          lang: typescript
-          code: |
-            type ResolveType = 'file' | 'function' | 'type' | 'const'
 examples:
   - name: kubb.config.ts
     files:

--- a/packages/plugin-msw/src/generators/handlersGenerator.test.tsx
+++ b/packages/plugin-msw/src/generators/handlersGenerator.test.tsx
@@ -18,7 +18,6 @@ const defaultOptions: PluginMsw['resolvedOptions'] = {
   include: undefined,
   override: [],
   handlers: true,
-  transformers: {},
   resolver: resolverMsw,
 }
 

--- a/packages/plugin-msw/src/generators/handlersGenerator.tsx
+++ b/packages/plugin-msw/src/generators/handlersGenerator.tsx
@@ -2,19 +2,19 @@ import { defineGenerator } from '@kubb/core'
 import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { Handlers } from '../components/Handlers.tsx'
 import type { PluginMsw } from '../types'
-import { transformName } from '../utils.ts'
 
 export const handlersGenerator = defineGenerator<PluginMsw>({
   name: 'plugin-msw',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
     const { resolver, config, root, adapter } = ctx
-    const { output, group, transformers } = ctx.options
+    const { output, group } = ctx.options
 
-    const file = resolver.resolveFile({ name: 'handlers', extname: '.ts' }, { root, output, group })
+    const handlersName = resolver.resolveHandlersName()
+    const file = resolver.resolveFile({ name: resolver.resolvePathName(handlersName, 'file'), extname: '.ts' }, { root, output, group })
 
     const imports = nodes.map((node) => {
-      const operationName = transformName(resolver.resolveName(node.operationId), 'function', transformers)
+      const operationName = resolver.resolveHandlerName(node)
       const operationFile = resolver.resolveFile(
         { name: resolver.resolveName(node.operationId), extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
         { root, output, group },
@@ -23,7 +23,7 @@ export const handlersGenerator = defineGenerator<PluginMsw>({
       return <File.Import key={operationFile.path} name={[operationName]} root={file.path} path={operationFile.path} />
     })
 
-    const handlers = nodes.map((node) => `${transformName(resolver.resolveName(node.operationId), 'function', transformers)}()`)
+    const handlers = nodes.map((node) => `${resolver.resolveHandlerName(node)}()`)
 
     return (
       <File
@@ -34,7 +34,7 @@ export const handlersGenerator = defineGenerator<PluginMsw>({
         footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
       >
         {imports}
-        <Handlers name={'handlers'} handlers={handlers} />
+        <Handlers name={handlersName} handlers={handlers} />
       </File>
     )
   },

--- a/packages/plugin-msw/src/generators/mswGenerator.test.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.test.tsx
@@ -22,7 +22,6 @@ const defaultOptions: PluginMsw['resolvedOptions'] = {
   include: undefined,
   override: [],
   handlers: false,
-  transformers: {},
   resolver: resolverMsw,
 }
 

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -4,18 +4,18 @@ import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { Mock, MockWithFaker, Response } from '../components'
 import type { PluginMsw } from '../types'
-import { getResponseTypes, getSuccessResponses, resolveFakerMeta, transformName } from '../utils.ts'
+import { getResponseTypes, getSuccessResponses, resolveFakerMeta } from '../utils.ts'
 
 export const mswGenerator = defineGenerator<PluginMsw>({
   name: 'msw',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { driver, resolver, config, root, adapter } = ctx
-    const { output, parser, baseURL, group, transformers } = ctx.options
+    const { output, parser, baseURL, group } = ctx.options
 
     const fileName = resolver.resolveName(node.operationId)
     const mock = {
-      name: transformName(fileName, 'function', transformers),
+      name: resolver.resolveHandlerName(node),
       file: resolver.resolveFile({ name: fileName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),
     }
 

--- a/packages/plugin-msw/src/plugin.ts
+++ b/packages/plugin-msw/src/plugin.ts
@@ -15,7 +15,6 @@ export const pluginMsw = definePlugin<PluginMsw>((options) => {
     exclude = [],
     include,
     override = [],
-    transformers = {},
     handlers = false,
     parser = 'data',
     baseURL,
@@ -55,7 +54,6 @@ export const pluginMsw = definePlugin<PluginMsw>((options) => {
           include,
           override,
           handlers,
-          transformers,
           resolver,
         })
         ctx.setResolver(resolver)

--- a/packages/plugin-msw/src/resolvers/resolverMsw.ts
+++ b/packages/plugin-msw/src/resolvers/resolverMsw.ts
@@ -7,7 +7,7 @@ import type { PluginMsw } from '../types.ts'
  *
  * Provides default naming helpers using camelCase with a `handler` suffix.
  */
-export const resolverMsw = defineResolver<PluginMsw>((_ctx) => ({
+export const resolverMsw = defineResolver<PluginMsw>((ctx) => ({
   name: 'default',
   pluginName: 'plugin-msw',
   default(name, type) {
@@ -15,5 +15,14 @@ export const resolverMsw = defineResolver<PluginMsw>((_ctx) => ({
   },
   resolveName(name) {
     return camelCase(name, { suffix: 'handler' })
+  },
+  resolvePathName(name, type) {
+    return ctx.default(name, type)
+  },
+  resolveHandlerName(node) {
+    return ctx.resolveName(node.operationId)
+  },
+  resolveHandlersName() {
+    return 'handlers'
   },
 }))

--- a/packages/plugin-msw/src/types.ts
+++ b/packages/plugin-msw/src/types.ts
@@ -1,13 +1,25 @@
-import type { ast, Exclude, Generator, Group, Include, Output, Override, PluginFactoryOptions, ResolveNameParams, Resolver } from '@kubb/core'
+import type { ast, Exclude, Generator, Group, Include, Output, Override, PluginFactoryOptions, Resolver } from '@kubb/core'
 
 /**
  * Resolver for MSW that provides naming methods for handler functions.
  */
 export type ResolverMsw = Resolver & {
   /**
-   * Resolves the handler function name for an operation.
+   * Resolves the base handler function name for an operation.
    */
   resolveName(this: ResolverMsw, name: string): string
+  /**
+   * Resolves the output file name for an MSW handler module.
+   */
+  resolvePathName(this: ResolverMsw, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
+  /**
+   * Resolves the handler function name for an operation.
+   */
+  resolveHandlerName(this: ResolverMsw, node: ast.OperationNode): string
+  /**
+   * Resolves the exported handlers collection name.
+   */
+  resolveHandlersName(this: ResolverMsw): string
 }
 
 export type Options = {
@@ -33,12 +45,6 @@ export type Options = {
    * Override options for specific tags, operations, or paths.
    */
   override?: Array<Override<ResolvedOptions>>
-  transformers?: {
-    /**
-     * Override the default naming for handlers.
-     */
-    name?: (name: ResolveNameParams['name'], type?: ResolveNameParams['type']) => string
-  }
   /**
    * Override naming conventions for function names and types.
    */
@@ -73,7 +79,6 @@ type ResolvedOptions = {
   parser: NonNullable<Options['parser']>
   baseURL: Options['baseURL'] | undefined
   handlers: boolean
-  transformers: NonNullable<Options['transformers']>
   resolver: ResolverMsw
 }
 

--- a/packages/plugin-msw/src/utils.ts
+++ b/packages/plugin-msw/src/utils.ts
@@ -4,13 +4,6 @@ import type { ResolverTs } from '@kubb/plugin-ts'
 import type { PluginMsw } from './types.ts'
 
 /**
- * Applies a name transformer function to a name if configured, otherwise returns it unchanged.
- */
-export function transformName(name: string, type: 'function' | 'type' | 'file' | 'const', transformers?: PluginMsw['resolvedOptions']['transformers']): string {
-  return transformers?.name?.(name, type) || name
-}
-
-/**
  * Filters responses to only those with 2xx status codes.
  */
 export function getSuccessResponses(node: ast.OperationNode): ast.ResponseNode[] {

--- a/packages/plugin-react-query/extension.yaml
+++ b/packages/plugin-react-query/extension.yaml
@@ -801,19 +801,6 @@ options:
       Define additional generators next to the built-in generators.
 
       See [Generators](https://kubb.dev/docs/5.x/guides/creating-plugins) for more information on how to use generators.
-  - name: transformers
-    type: '{ name?: (name: string, type?: ResolveType) => string }'
-    required: false
-    description: Customize the generated names based on the type provided by the plugin.
-    properties:
-      - name: name
-        type: '(name: string, type?: ResolveType) => string'
-        required: false
-        description: Customize the names based on the type that is provided by the plugin.
-        codeBlock:
-          lang: typescript
-          code: |
-            type ResolveType = 'file' | 'function' | 'type' | 'const'
   - name: resolver
     type: Partial<ResolverReactQuery> & ThisType<ResolverReactQuery>
     required: false

--- a/packages/plugin-react-query/src/generators/customHookOptionsFileGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/customHookOptionsFileGenerator.tsx
@@ -4,29 +4,27 @@ import path from 'node:path'
 import { defineGenerator } from '@kubb/core'
 import { File, Function, jsxRenderer } from '@kubb/renderer-jsx'
 import type { PluginReactQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const customHookOptionsFileGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-custom-hook-options-file',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
     const { resolver, config, root } = ctx
-    const { output, customOptions, query, group, transformers } = ctx.options
+    const { output, customOptions, query, group } = ctx.options
 
     if (!customOptions) return null
 
     const override = output.override ?? config.output.override ?? false
     const { importPath, name } = customOptions
+    const hookOptionsName = resolver.resolveHookOptionsName()
+    const customHookOptionsName = resolver.resolveCustomHookOptionsName()
 
     const reactQueryImportPath = query ? query.importPath : '@tanstack/react-query'
-
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
 
     let hookFilePath: string
     const firstNode = nodes[0]
     if (firstNode) {
-      const baseName = resolver.resolveName(firstNode.operationId)
-      const hookName = transformName(`use${capitalize(baseName)}`, 'function', transformers)
+      const hookName = resolver.resolveQueryName(firstNode)
       const hookFile = resolver.resolveFile(
         { name: hookName, extname: '.ts', tag: firstNode.tags[0] ?? 'default', path: firstNode.path },
         { root, output, group },
@@ -55,9 +53,9 @@ export const customHookOptionsFileGenerator = defineGenerator<PluginReactQuery>(
       <File baseName={file.baseName} path={file.path}>
         <File.Import name={['QueryClient']} path={reactQueryImportPath} isTypeOnly />
         <File.Import name={['useQueryClient']} path={reactQueryImportPath} />
-        <File.Import name={['HookOptions']} root={file.path} path={path.resolve(root, './index.ts')} />
+        <File.Import name={[hookOptionsName]} root={file.path} path={path.resolve(root, './index.ts')} />
         <File.Source name={file.name} isExportable isIndexable>
-          <Function name="getCustomHookOptions" params="{ queryClient }: { queryClient: QueryClient }" returnType="Partial<HookOptions>">
+          <Function name={customHookOptionsName} params="{ queryClient }: { queryClient: QueryClient }" returnType={`Partial<${hookOptionsName}>`}>
             {`return {
               // TODO: Define custom hook options here
               // Example:
@@ -70,13 +68,13 @@ export const customHookOptionsFileGenerator = defineGenerator<PluginReactQuery>(
           </Function>
           <Function
             name={name}
-            generics="T extends keyof HookOptions"
+            generics={`T extends keyof ${hookOptionsName}`}
             params="{ hookName, operationId }: { hookName: T, operationId: string }"
-            returnType="HookOptions[T]"
+            returnType={`${hookOptionsName}[T]`}
             export
           >
             {`const queryClient = useQueryClient()
-            const customOptions = getCustomHookOptions({ queryClient })
+            const customOptions = ${customHookOptionsName}({ queryClient })
             return customOptions[hookName] ?? {}`}
           </Function>
         </File.Source>

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -3,7 +3,7 @@ import { File, jsxRenderer, Type } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import { difference } from 'remeda'
 import type { PluginReactQuery } from '../types'
-import { resolveOperationOverrides, transformName } from '../utils.ts'
+import { resolveOperationOverrides } from '../utils.ts'
 
 type QueryOption = PluginReactQuery['resolvedOptions']['query']
 type MutationOption = PluginReactQuery['resolvedOptions']['mutation']
@@ -13,24 +13,22 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
   renderer: jsxRenderer,
   operations(nodes, ctx) {
     const { resolver, config, root, adapter } = ctx
-    const { output, customOptions, query, mutation, suspense, infinite, group, transformers, override } = ctx.options
+    const { output, customOptions, query, mutation, suspense, infinite, group, override } = ctx.options
 
     if (!customOptions) return null
 
-    const resolvedFile = resolver.resolveFile({ name: 'HookOptions', extname: '.ts' }, { root, output, group })
+    const name = resolver.resolveHookOptionsName()
+    const resolvedFile = resolver.resolveFile({ name, extname: '.ts' }, { root, output, group })
     const hookOptionsFile = {
       ...resolvedFile,
-      baseName: 'HookOptions.ts' as const,
-      path: resolvedFile.path.replace(/hookOptions\.ts$/, 'HookOptions.ts'),
+      baseName: `${name}.ts` as const,
+      path: resolvedFile.path.replace(/[^/\\]+\.ts$/, `${name}.ts`),
     }
-
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
 
     const imports: KubbReactNode[] = []
     const hookOptions: Record<string, string> = {}
 
     for (const node of nodes) {
-      const baseName = resolver.resolveName(node.operationId)
       const opOverrides = resolveOperationOverrides(node, override)
       const nodeQuery: QueryOption = 'query' in opOverrides ? (opOverrides.query as QueryOption) : query
       const nodeMutation: MutationOption = 'mutation' in opOverrides ? (opOverrides.mutation as MutationOption) : mutation
@@ -50,8 +48,8 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       const isInfiniteOp = !!nodeInfiniteOptions
 
       if (isQueryOp) {
-        const queryOptionsName = transformName(`${baseName}QueryOptions`, 'function', transformers)
-        const queryHookName = transformName(`use${capitalize(baseName)}`, 'function', transformers)
+        const queryOptionsName = resolver.resolveQueryOptionsName(node)
+        const queryHookName = resolver.resolveQueryName(node)
         const queryHookFile = resolver.resolveFile(
           { name: queryHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
           { root, output, group },
@@ -60,8 +58,8 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
         hookOptions[queryHookName] = `Partial<ReturnType<typeof ${queryOptionsName}>>`
 
         if (isSuspenseOp) {
-          const suspenseOptionsName = transformName(`${baseName}SuspenseQueryOptions`, 'function', transformers)
-          const suspenseHookName = transformName(`use${capitalize(baseName)}Suspense`, 'function', transformers)
+          const suspenseOptionsName = resolver.resolveSuspenseQueryOptionsName(node)
+          const suspenseHookName = resolver.resolveSuspenseQueryName(node)
           const suspenseHookFile = resolver.resolveFile(
             { name: suspenseHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
             { root, output, group },
@@ -77,8 +75,8 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
           const hasQueryParam = nodeInfiniteOptions!.queryParam ? queryParamKeys.some((k) => normalizeKey(k) === nodeInfiniteOptions!.queryParam) : false
 
           if (hasQueryParam) {
-            const infiniteOptionsName = transformName(`${baseName}InfiniteQueryOptions`, 'function', transformers)
-            const infiniteHookName = transformName(`use${capitalize(baseName)}Infinite`, 'function', transformers)
+            const infiniteOptionsName = resolver.resolveInfiniteQueryOptionsName(node)
+            const infiniteHookName = resolver.resolveInfiniteQueryName(node)
             const infiniteHookFile = resolver.resolveFile(
               { name: infiniteHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
               { root, output, group },
@@ -87,8 +85,8 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
             hookOptions[infiniteHookName] = `Partial<ReturnType<typeof ${infiniteOptionsName}>>`
 
             if (isSuspenseOp) {
-              const suspenseInfiniteOptionsName = transformName(`${baseName}SuspenseInfiniteQueryOptions`, 'function', transformers)
-              const suspenseInfiniteHookName = transformName(`use${capitalize(baseName)}SuspenseInfinite`, 'function', transformers)
+              const suspenseInfiniteOptionsName = resolver.resolveSuspenseInfiniteQueryOptionsName(node)
+              const suspenseInfiniteHookName = resolver.resolveSuspenseInfiniteQueryName(node)
               const suspenseInfiniteHookFile = resolver.resolveFile(
                 { name: suspenseInfiniteHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
                 { root, output, group },
@@ -101,8 +99,8 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       }
 
       if (isMutationOp) {
-        const mutationOptionsName = transformName(`${baseName}MutationOptions`, 'function', transformers)
-        const mutationHookName = transformName(`use${capitalize(baseName)}`, 'function', transformers)
+        const mutationOptionsName = resolver.resolveMutationOptionsName(node)
+        const mutationHookName = resolver.resolveMutationName(node)
         const mutationHookFile = resolver.resolveFile(
           { name: mutationHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
           { root, output, group },
@@ -111,8 +109,6 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
         hookOptions[mutationHookName] = `Partial<ReturnType<typeof ${mutationOptionsName}>>`
       }
     }
-
-    const name = 'HookOptions'
 
     return (
       <File

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.test.tsx
@@ -42,7 +42,6 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   output: { path: '.' },
   group: undefined,
   resolver: resolverReactQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -7,27 +7,13 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginReactQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-infinite-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { adapter, config, driver, resolver, root } = ctx
-    const {
-      output,
-      query,
-      mutation,
-      infinite,
-      paramsCasing,
-      paramsType,
-      pathParamsType,
-      parser,
-      client: clientOptions,
-      group,
-      transformers,
-      customOptions,
-    } = ctx.options
+    const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -53,13 +39,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
 
     const importPath = query ? query.importPath : '@tanstack/react-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const queryName = transformName(`use${capitalize(baseName)}Infinite`, 'function', transformers)
-    const queryOptionsName = transformName(`${baseName}InfiniteQueryOptions`, 'function', transformers)
-    const queryKeyName = transformName(`${baseName}InfiniteQueryKey`, 'const', transformers)
-    const queryKeyTypeName = transformName(`${capitalize(baseName)}InfiniteQueryKey`, 'type', transformers)
-    const clientBaseName = transformName(`${baseName}Infinite`, 'function', transformers)
+    const queryName = resolver.resolveInfiniteQueryName(node)
+    const queryOptionsName = resolver.resolveInfiniteQueryOptionsName(node)
+    const queryKeyName = resolver.resolveInfiniteQueryKeyName(node)
+    const queryKeyTypeName = resolver.resolveInfiniteQueryKeyTypeName(node)
+    const clientBaseName = resolver.resolveInfiniteClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
@@ -42,7 +42,6 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   output: { path: '.' },
   group: undefined,
   resolver: resolverReactQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -7,14 +7,13 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { Mutation, MutationKey, MutationOptions } from '../components'
 import type { PluginReactQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const mutationGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-mutation',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { adapter, config, driver, resolver, root } = ctx
-    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, transformers, customOptions } = ctx.options
+    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -30,13 +29,11 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
 
     const importPath = mutation ? mutation.importPath : '@tanstack/react-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const mutationHookName = transformName(`use${capitalize(baseName)}`, 'function', transformers)
-    const mutationTypeName = transformName(`${capitalize(baseName)}`, 'type', transformers)
-    const mutationOptionsName = transformName(`${baseName}MutationOptions`, 'function', transformers)
-    const mutationKeyName = transformName(`${baseName}MutationKey`, 'const', transformers)
-    const clientName = transformName(baseName, 'function', transformers)
+    const mutationHookName = resolver.resolveMutationName(node)
+    const mutationTypeName = resolver.resolveMutationTypeName(node)
+    const mutationOptionsName = resolver.resolveMutationOptionsName(node)
+    const mutationKeyName = resolver.resolveMutationKeyName(node)
+    const clientName = resolver.resolveClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: mutationHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
@@ -44,7 +44,6 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   output: { path: '.' },
   group: undefined,
   resolver: resolverReactQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -7,14 +7,13 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginReactQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const queryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { adapter, config, driver, resolver, root } = ctx
-    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, transformers, customOptions } = ctx.options
+    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -31,13 +30,11 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
 
     const importPath = query ? query.importPath : '@tanstack/react-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const queryName = transformName(`use${capitalize(baseName)}`, 'function', transformers)
-    const queryOptionsName = transformName(`${baseName}QueryOptions`, 'function', transformers)
-    const queryKeyName = transformName(`${baseName}QueryKey`, 'const', transformers)
-    const queryKeyTypeName = transformName(`${capitalize(baseName)}QueryKey`, 'type', transformers)
-    const clientName = transformName(baseName, 'function', transformers)
+    const queryName = resolver.resolveQueryName(node)
+    const queryOptionsName = resolver.resolveQueryOptionsName(node)
+    const queryKeyName = resolver.resolveQueryKeyName(node)
+    const queryKeyTypeName = resolver.resolveQueryKeyTypeName(node)
+    const clientName = resolver.resolveClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.test.tsx
@@ -42,7 +42,6 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   output: { path: '.' },
   group: undefined,
   resolver: resolverReactQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -7,7 +7,6 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { QueryKey, SuspenseInfiniteQuery, SuspenseInfiniteQueryOptions } from '../components'
 import type { PluginReactQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-suspense-infinite-query',
@@ -26,7 +25,6 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
       parser,
       client: clientOptions,
       group,
-      transformers,
       customOptions,
     } = ctx.options
 
@@ -54,13 +52,11 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
 
     const importPath = query ? query.importPath : '@tanstack/react-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const queryName = transformName(`use${capitalize(baseName)}SuspenseInfinite`, 'function', transformers)
-    const queryOptionsName = transformName(`${baseName}SuspenseInfiniteQueryOptions`, 'function', transformers)
-    const queryKeyName = transformName(`${baseName}SuspenseInfiniteQueryKey`, 'const', transformers)
-    const queryKeyTypeName = transformName(`${capitalize(baseName)}SuspenseInfiniteQueryKey`, 'type', transformers)
-    const clientBaseName = transformName(`${baseName}SuspenseInfinite`, 'function', transformers)
+    const queryName = resolver.resolveSuspenseInfiniteQueryName(node)
+    const queryOptionsName = resolver.resolveSuspenseInfiniteQueryOptionsName(node)
+    const queryKeyName = resolver.resolveSuspenseInfiniteQueryKeyName(node)
+    const queryKeyTypeName = resolver.resolveSuspenseInfiniteQueryKeyTypeName(node)
+    const clientBaseName = resolver.resolveSuspenseInfiniteClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.test.tsx
@@ -42,7 +42,6 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   output: { path: '.' },
   group: undefined,
   resolver: resolverReactQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -7,27 +7,13 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { QueryKey, QueryOptions, SuspenseQuery } from '../components'
 import type { PluginReactQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-suspense-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { adapter, config, driver, resolver, root } = ctx
-    const {
-      output,
-      query,
-      mutation,
-      suspense,
-      paramsCasing,
-      paramsType,
-      pathParamsType,
-      parser,
-      client: clientOptions,
-      group,
-      transformers,
-      customOptions,
-    } = ctx.options
+    const { output, query, mutation, suspense, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -45,13 +31,11 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
 
     const importPath = query ? query.importPath : '@tanstack/react-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const queryName = transformName(`use${capitalize(baseName)}Suspense`, 'function', transformers)
-    const queryOptionsName = transformName(`${baseName}SuspenseQueryOptions`, 'function', transformers)
-    const queryKeyName = transformName(`${baseName}SuspenseQueryKey`, 'const', transformers)
-    const queryKeyTypeName = transformName(`${capitalize(baseName)}SuspenseQueryKey`, 'type', transformers)
-    const clientName = transformName(`${baseName}Suspense`, 'function', transformers)
+    const queryName = resolver.resolveSuspenseQueryName(node)
+    const queryOptionsName = resolver.resolveSuspenseQueryOptionsName(node)
+    const queryKeyName = resolver.resolveSuspenseQueryKeyName(node)
+    const queryKeyTypeName = resolver.resolveSuspenseQueryKeyTypeName(node)
+    const clientName = resolver.resolveSuspenseClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-react-query/src/plugin.ts
+++ b/packages/plugin-react-query/src/plugin.ts
@@ -33,7 +33,6 @@ export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
     parser = 'client',
     suspense = {},
     infinite = false,
-    transformers = {},
     paramsType = 'inline',
     pathParamsType = paramsType === 'object' ? 'object' : options.pathParamsType || 'inline',
     mutation = {},
@@ -87,7 +86,6 @@ export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
 
         ctx.setOptions({
           output,
-          transformers,
           client: {
             bundle: client?.bundle,
             baseURL: client?.baseURL,

--- a/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
+++ b/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
@@ -2,6 +2,10 @@ import { camelCase } from '@internals/utils'
 import { defineResolver } from '@kubb/core'
 import type { PluginReactQuery } from '../types.ts'
 
+function capitalize(name: string): string {
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`
+}
+
 /**
  * Naming convention resolver for React Query plugin.
  *
@@ -18,5 +22,86 @@ export const resolverReactQuery = defineResolver<PluginReactQuery>((ctx) => ({
   },
   resolveName(name) {
     return ctx.default(name, 'function')
+  },
+  resolvePathName(name, type) {
+    return ctx.default(name, type)
+  },
+  resolveQueryName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}`
+  },
+  resolveSuspenseQueryName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}Suspense`
+  },
+  resolveInfiniteQueryName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}Infinite`
+  },
+  resolveSuspenseInfiniteQueryName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}SuspenseInfinite`
+  },
+  resolveMutationName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}`
+  },
+  resolveQueryOptionsName(node) {
+    return `${ctx.resolveName(node.operationId)}QueryOptions`
+  },
+  resolveSuspenseQueryOptionsName(node) {
+    return `${ctx.resolveName(node.operationId)}SuspenseQueryOptions`
+  },
+  resolveInfiniteQueryOptionsName(node) {
+    return `${ctx.resolveName(node.operationId)}InfiniteQueryOptions`
+  },
+  resolveSuspenseInfiniteQueryOptionsName(node) {
+    return `${ctx.resolveName(node.operationId)}SuspenseInfiniteQueryOptions`
+  },
+  resolveMutationOptionsName(node) {
+    return `${ctx.resolveName(node.operationId)}MutationOptions`
+  },
+  resolveQueryKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}QueryKey`
+  },
+  resolveSuspenseQueryKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}SuspenseQueryKey`
+  },
+  resolveInfiniteQueryKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}InfiniteQueryKey`
+  },
+  resolveSuspenseInfiniteQueryKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}SuspenseInfiniteQueryKey`
+  },
+  resolveMutationKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}MutationKey`
+  },
+  resolveQueryKeyTypeName(node) {
+    return `${capitalize(ctx.resolveName(node.operationId))}QueryKey`
+  },
+  resolveSuspenseQueryKeyTypeName(node) {
+    return `${capitalize(ctx.resolveName(node.operationId))}SuspenseQueryKey`
+  },
+  resolveInfiniteQueryKeyTypeName(node) {
+    return `${capitalize(ctx.resolveName(node.operationId))}InfiniteQueryKey`
+  },
+  resolveSuspenseInfiniteQueryKeyTypeName(node) {
+    return `${capitalize(ctx.resolveName(node.operationId))}SuspenseInfiniteQueryKey`
+  },
+  resolveMutationTypeName(node) {
+    return capitalize(ctx.resolveName(node.operationId))
+  },
+  resolveClientName(node) {
+    return ctx.resolveName(node.operationId)
+  },
+  resolveSuspenseClientName(node) {
+    return `${ctx.resolveName(node.operationId)}Suspense`
+  },
+  resolveInfiniteClientName(node) {
+    return `${ctx.resolveName(node.operationId)}Infinite`
+  },
+  resolveSuspenseInfiniteClientName(node) {
+    return `${ctx.resolveName(node.operationId)}SuspenseInfinite`
+  },
+  resolveHookOptionsName() {
+    return 'HookOptions'
+  },
+  resolveCustomHookOptionsName() {
+    return 'getCustomHookOptions'
   },
 }))

--- a/packages/plugin-react-query/src/types.ts
+++ b/packages/plugin-react-query/src/types.ts
@@ -9,12 +9,120 @@ export type { Transformer } from '@internals/tanstack-query'
  */
 export type ResolverReactQuery = Resolver & {
   /**
-   * Resolves the hook function name for an operation.
+   * Resolves the base function name for an operation.
    *
-   * @example Resolving hook names
+   * @example Resolving base operation names
    * `resolver.resolveName('show pet by id') // -> 'showPetById'`
    */
   resolveName(this: ResolverReactQuery, name: string): string
+  /**
+   * Resolves the output file name for a hook module.
+   */
+  resolvePathName(this: ResolverReactQuery, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
+  /**
+   * Resolves a query hook function name.
+   */
+  resolveQueryName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves a suspense query hook function name.
+   */
+  resolveSuspenseQueryName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves an infinite query hook function name.
+   */
+  resolveInfiniteQueryName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves a suspense infinite query hook function name.
+   */
+  resolveSuspenseInfiniteQueryName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves a mutation hook function name.
+   */
+  resolveMutationName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the query options helper name.
+   */
+  resolveQueryOptionsName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the suspense query options helper name.
+   */
+  resolveSuspenseQueryOptionsName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the infinite query options helper name.
+   */
+  resolveInfiniteQueryOptionsName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the suspense infinite query options helper name.
+   */
+  resolveSuspenseInfiniteQueryOptionsName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the mutation options helper name.
+   */
+  resolveMutationOptionsName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the query key helper name.
+   */
+  resolveQueryKeyName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the suspense query key helper name.
+   */
+  resolveSuspenseQueryKeyName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the infinite query key helper name.
+   */
+  resolveInfiniteQueryKeyName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the suspense infinite query key helper name.
+   */
+  resolveSuspenseInfiniteQueryKeyName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the mutation key helper name.
+   */
+  resolveMutationKeyName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the query key type name.
+   */
+  resolveQueryKeyTypeName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the suspense query key type name.
+   */
+  resolveSuspenseQueryKeyTypeName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the infinite query key type name.
+   */
+  resolveInfiniteQueryKeyTypeName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the suspense infinite query key type name.
+   */
+  resolveSuspenseInfiniteQueryKeyTypeName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the mutation type name.
+   */
+  resolveMutationTypeName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the client function name generated inline by query hooks.
+   */
+  resolveClientName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the client function name generated inline by suspense query hooks.
+   */
+  resolveSuspenseClientName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the client function name generated inline by infinite query hooks.
+   */
+  resolveInfiniteClientName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the client function name generated inline by suspense infinite query hooks.
+   */
+  resolveSuspenseInfiniteClientName(this: ResolverReactQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the generated custom hook options map type name.
+   */
+  resolveHookOptionsName(this: ResolverReactQuery): string
+  /**
+   * Resolves the helper function name used inside the custom hook options file.
+   */
+  resolveCustomHookOptionsName(this: ResolverReactQuery): string
 }
 
 type Suspense = object
@@ -171,12 +279,6 @@ export type Options = {
    * Parser to use for validating response data.
    */
   parser?: PluginClient['options']['parser']
-  transformers?: {
-    /**
-     * Override the default naming for hooks.
-     */
-    name?: (name: string, type?: string) => string
-  }
   /**
    * Override naming conventions for function names and types.
    */
@@ -213,7 +315,6 @@ type ResolvedOptions = {
   mutation: NonNullable<Required<Mutation>> | false
   customOptions: NonNullable<Required<CustomOptions>> | undefined
   resolver: ResolverReactQuery
-  transformers: NonNullable<Options['transformers']>
 }
 
 export type PluginReactQuery = PluginFactoryOptions<'plugin-react-query', Options, ResolvedOptions, ResolverReactQuery>

--- a/packages/plugin-react-query/src/utils.ts
+++ b/packages/plugin-react-query/src/utils.ts
@@ -11,10 +11,6 @@ export {
 } from '@internals/tanstack-query'
 export { buildOperationComments as getComments, buildRequestConfigType, getContentTypeInfo, resolveErrorNames, resolveStatusCodeNames } from '@internals/shared'
 
-export function transformName(name: string, type: string, transformers?: PluginReactQuery['resolvedOptions']['transformers']): string {
-  return transformers?.name?.(name, type) || name
-}
-
 function matchesPattern(node: ast.OperationNode, ov: { type: string; pattern: string | RegExp }): boolean {
   const { type, pattern } = ov
   const matches = (value: string) => (typeof pattern === 'string' ? value === pattern : pattern.test(value))

--- a/packages/plugin-vue-query/extension.yaml
+++ b/packages/plugin-vue-query/extension.yaml
@@ -691,53 +691,6 @@ options:
       Define additional generators next to the built-in generators.
 
       See [Generators](https://kubb.dev/docs/5.x/guides/creating-plugins) for more information on how to use generators.
-  - name: transformers
-    type: Visitor
-    required: false
-    description: |
-      A single AST visitor applied to every node before code is printed. Each method you provide replaces the corresponding built-in one. When a method returns `null` or `undefined`, the preset transformer's result is used as the fallback — so you only need to supply the methods you want to change.
-
-      Visitor methods receive the node and a context object. Return a modified node to replace it, or return `undefined`/`void` to leave it unchanged.
-    examples:
-      - name: Strip descriptions before printing
-        files:
-          - lang: typescript
-            code: |
-              import { pluginTs } from '@kubb/plugin-ts'
-
-              pluginTs({
-                transformer: {
-                  schema(node) {
-                    return { ...node, description: undefined }
-                  },
-                },
-              })
-            twoslash: false
-      - name: Prefix every operationId
-        files:
-          - lang: typescript
-            code: |
-              import { pluginTs } from '@kubb/plugin-ts'
-
-              pluginTs({
-                transformer: {
-                  operation(node) {
-                    return { ...node, operationId: `api_${node.operationId}` }
-                  },
-                },
-              })
-            twoslash: false
-    tip: |
-      Use `transformer` to rewrite node properties before printing. For output naming customization, use `resolver` instead.
-    properties:
-      - name: name
-        type: '(name: string, type?: ResolveType) => string'
-        required: false
-        description: Customize the names based on the type that is provided by the plugin.
-        codeBlock:
-          lang: typescript
-          code: |
-            type ResolveType = 'file' | 'function' | 'type' | 'const'
   - name: resolver
     type: Partial<ResolverVueQuery>
     required: false

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
@@ -41,7 +41,6 @@ const defaultOptions: PluginVueQuery['resolvedOptions'] = {
   include: undefined,
   override: [],
   resolver: resolverVueQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -7,14 +7,13 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginVueQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-infinite',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { adapter, config, driver, resolver, root } = ctx
-    const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, transformers } = ctx.options
+    const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -40,13 +39,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
 
     const importPath = query ? query.importPath : '@tanstack/vue-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const queryName = transformName(`use${capitalize(baseName)}Infinite`, 'function', transformers)
-    const queryOptionsName = transformName(`${baseName}InfiniteQueryOptions`, 'function', transformers)
-    const queryKeyName = transformName(`${baseName}InfiniteQueryKey`, 'const', transformers)
-    const queryKeyTypeName = transformName(`${capitalize(baseName)}InfiniteQueryKey`, 'type', transformers)
-    const clientBaseName = transformName(`${baseName}Infinite`, 'function', transformers)
+    const queryName = resolver.resolveInfiniteQueryName(node)
+    const queryOptionsName = resolver.resolveInfiniteQueryOptionsName(node)
+    const queryKeyName = resolver.resolveInfiniteQueryKeyName(node)
+    const queryKeyTypeName = resolver.resolveInfiniteQueryKeyTypeName(node)
+    const clientBaseName = resolver.resolveInfiniteClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.test.tsx
@@ -41,7 +41,6 @@ const defaultOptions: PluginVueQuery['resolvedOptions'] = {
   include: undefined,
   override: [],
   resolver: resolverVueQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -7,14 +7,13 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { Mutation, MutationKey } from '../components'
 import type { PluginVueQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const mutationGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-mutation',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { adapter, config, driver, resolver, root } = ctx
-    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, transformers } = ctx.options
+    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -30,12 +29,10 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
 
     const importPath = mutation ? mutation.importPath : '@tanstack/vue-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const mutationHookName = transformName(`use${capitalize(baseName)}`, 'function', transformers)
-    const mutationTypeName = transformName(`${capitalize(baseName)}`, 'type', transformers)
-    const mutationKeyName = transformName(`${baseName}MutationKey`, 'const', transformers)
-    const clientName = transformName(baseName, 'function', transformers)
+    const mutationHookName = resolver.resolveMutationName(node)
+    const mutationTypeName = resolver.resolveMutationTypeName(node)
+    const mutationKeyName = resolver.resolveMutationKeyName(node)
+    const clientName = resolver.resolveClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: mutationHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
@@ -43,7 +43,6 @@ const defaultOptions: PluginVueQuery['resolvedOptions'] = {
   include: undefined,
   override: [],
   resolver: resolverVueQuery,
-  transformers: {},
 }
 
 const mockedTsPlugin = createMockedPlugin<PluginTs>({

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -7,14 +7,13 @@ import { File, jsxRenderer } from '@kubb/renderer-jsx'
 import { difference } from 'remeda'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginVueQuery } from '../types'
-import { transformName } from '../utils.ts'
 
 export const queryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
     const { adapter, config, driver, resolver, root } = ctx
-    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, transformers } = ctx.options
+    const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -30,13 +29,11 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
 
     const importPath = query ? query.importPath : '@tanstack/vue-query'
 
-    const baseName = resolver.resolveName(node.operationId)
-    const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
-    const queryName = transformName(`use${capitalize(baseName)}`, 'function', transformers)
-    const queryOptionsName = transformName(`${baseName}QueryOptions`, 'function', transformers)
-    const queryKeyName = transformName(`${baseName}QueryKey`, 'const', transformers)
-    const queryKeyTypeName = transformName(`${capitalize(baseName)}QueryKey`, 'type', transformers)
-    const clientName = transformName(baseName, 'function', transformers)
+    const queryName = resolver.resolveQueryName(node)
+    const queryOptionsName = resolver.resolveQueryOptionsName(node)
+    const queryKeyName = resolver.resolveQueryKeyName(node)
+    const queryKeyTypeName = resolver.resolveQueryKeyTypeName(node)
+    const clientName = resolver.resolveClientName(node)
 
     const meta = {
       file: resolver.resolveFile({ name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),

--- a/packages/plugin-vue-query/src/plugin.ts
+++ b/packages/plugin-vue-query/src/plugin.ts
@@ -24,7 +24,6 @@ export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
     override = [],
     parser = 'client',
     infinite = false,
-    transformers = {},
     paramsType = 'inline',
     pathParamsType = paramsType === 'object' ? 'object' : options.pathParamsType || 'inline',
     mutation = {},
@@ -69,7 +68,6 @@ export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
 
         ctx.setOptions({
           output,
-          transformers,
           client: {
             bundle: client?.bundle,
             baseURL: client?.baseURL,

--- a/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
+++ b/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
@@ -2,6 +2,10 @@ import { camelCase } from '@internals/utils'
 import { defineResolver } from '@kubb/core'
 import type { PluginVueQuery } from '../types.ts'
 
+function capitalize(name: string): string {
+  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`
+}
+
 /**
  * Naming convention resolver for Vue Query plugin.
  *
@@ -15,5 +19,47 @@ export const resolverVueQuery = defineResolver<PluginVueQuery>((ctx) => ({
   },
   resolveName(name) {
     return ctx.default(name, 'function')
+  },
+  resolvePathName(name, type) {
+    return ctx.default(name, type)
+  },
+  resolveQueryName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}`
+  },
+  resolveInfiniteQueryName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}Infinite`
+  },
+  resolveMutationName(node) {
+    return `use${capitalize(ctx.resolveName(node.operationId))}`
+  },
+  resolveQueryOptionsName(node) {
+    return `${ctx.resolveName(node.operationId)}QueryOptions`
+  },
+  resolveInfiniteQueryOptionsName(node) {
+    return `${ctx.resolveName(node.operationId)}InfiniteQueryOptions`
+  },
+  resolveQueryKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}QueryKey`
+  },
+  resolveInfiniteQueryKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}InfiniteQueryKey`
+  },
+  resolveMutationKeyName(node) {
+    return `${ctx.resolveName(node.operationId)}MutationKey`
+  },
+  resolveQueryKeyTypeName(node) {
+    return `${capitalize(ctx.resolveName(node.operationId))}QueryKey`
+  },
+  resolveInfiniteQueryKeyTypeName(node) {
+    return `${capitalize(ctx.resolveName(node.operationId))}InfiniteQueryKey`
+  },
+  resolveMutationTypeName(node) {
+    return capitalize(ctx.resolveName(node.operationId))
+  },
+  resolveClientName(node) {
+    return ctx.resolveName(node.operationId)
+  },
+  resolveInfiniteClientName(node) {
+    return `${ctx.resolveName(node.operationId)}Infinite`
   },
 }))

--- a/packages/plugin-vue-query/src/types.ts
+++ b/packages/plugin-vue-query/src/types.ts
@@ -8,9 +8,65 @@ export type Transformer = (props: { node: ast.OperationNode; casing: 'camelcase'
  */
 export type ResolverVueQuery = Resolver & {
   /**
-   * Resolves the hook function name for an operation.
+   * Resolves the base function name for an operation.
    */
   resolveName(this: ResolverVueQuery, name: string): string
+  /**
+   * Resolves the output file name for a hook module.
+   */
+  resolvePathName(this: ResolverVueQuery, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
+  /**
+   * Resolves a query hook function name.
+   */
+  resolveQueryName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves an infinite query hook function name.
+   */
+  resolveInfiniteQueryName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves a mutation hook function name.
+   */
+  resolveMutationName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the query options helper name.
+   */
+  resolveQueryOptionsName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the infinite query options helper name.
+   */
+  resolveInfiniteQueryOptionsName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the query key helper name.
+   */
+  resolveQueryKeyName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the infinite query key helper name.
+   */
+  resolveInfiniteQueryKeyName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the mutation key helper name.
+   */
+  resolveMutationKeyName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the query key type name.
+   */
+  resolveQueryKeyTypeName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the infinite query key type name.
+   */
+  resolveInfiniteQueryKeyTypeName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the mutation type name.
+   */
+  resolveMutationTypeName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the client function name generated inline by query hooks.
+   */
+  resolveClientName(this: ResolverVueQuery, node: ast.OperationNode): string
+  /**
+   * Resolves the client function name generated inline by infinite query hooks.
+   */
+  resolveInfiniteClientName(this: ResolverVueQuery, node: ast.OperationNode): string
 }
 
 /**
@@ -142,12 +198,6 @@ export type Options = {
    * Parser to use for validating response data.
    */
   parser?: PluginClient['options']['parser']
-  transformers?: {
-    /**
-     * Override the default naming for hooks.
-     */
-    name?: (name: string, type?: string) => string
-  }
   /**
    * Override naming conventions for function names and types.
    */
@@ -182,7 +232,6 @@ type ResolvedOptions = {
   mutationKey: MutationKey | undefined
   mutation: NonNullable<Required<Mutation>> | false
   resolver: ResolverVueQuery
-  transformers: NonNullable<Options['transformers']>
 }
 
 export type PluginVueQuery = PluginFactoryOptions<'plugin-vue-query', Options, ResolvedOptions, ResolverVueQuery>

--- a/packages/plugin-vue-query/src/utils.ts
+++ b/packages/plugin-vue-query/src/utils.ts
@@ -11,10 +11,6 @@ export {
 } from '@internals/tanstack-query'
 export { buildOperationComments as getComments, buildRequestConfigType, getContentTypeInfo, resolveErrorNames, resolveStatusCodeNames } from '@internals/shared'
 
-export function transformName(name: string, type: string, transformers?: PluginVueQuery['resolvedOptions']['transformers']): string {
-  return transformers?.name?.(name, type) || name
-}
-
 function matchesPattern(node: ast.OperationNode, ov: { type: string; pattern: string | RegExp }): boolean {
   const { type, pattern } = ov
   const matches = (value: string) => (typeof pattern === 'string' ? value === pattern : pattern.test(value))

--- a/plugins/plugin-msw.yaml
+++ b/plugins/plugin-msw.yaml
@@ -89,19 +89,6 @@ options:
   - extends: ./_shared/core/generators.yaml
     type: 'Array<Generator<PluginMsw>>'
 
-  - name: transformers
-    type: object
-    required: false
-    description: Customize the generated names based on the type provided by the plugin.
-    properties:
-      - name: name
-        type: '(name: string, type?: ResolveType) => string'
-        required: false
-        description: Customize the names based on the type that is provided by the plugin.
-        codeBlock:
-          lang: typescript
-          code: |
-            type ResolveType = 'file' | 'function' | 'type' | 'const'
 examples:
   - name: kubb.config.ts
     files:

--- a/plugins/plugin-react-query.yaml
+++ b/plugins/plugin-react-query.yaml
@@ -438,20 +438,6 @@ options:
   - extends: ./_shared/core/generators.yaml
     type: 'Array<Generator<PluginReactQuery>>'
 
-  - name: transformers
-    type: '{ name?: (name: string, type?: ResolveType) => string }'
-    required: false
-    description: Customize the generated names based on the type provided by the plugin.
-    properties:
-      - name: name
-        type: '(name: string, type?: ResolveType) => string'
-        required: false
-        description: Customize the names based on the type that is provided by the plugin.
-        codeBlock:
-          lang: typescript
-          code: |
-            type ResolveType = 'file' | 'function' | 'type' | 'const'
-
   - extends: ./_shared/core/resolver.yaml
     type: 'Partial<ResolverReactQuery> & ThisType<ResolverReactQuery>'
 

--- a/plugins/plugin-vue-query.yaml
+++ b/plugins/plugin-vue-query.yaml
@@ -326,18 +326,6 @@ options:
   - extends: ./_shared/core/generators.yaml
     type: 'Array<Generator<PluginVueQuery>>'
 
-  - extends: ./_shared/core/transformer.yaml
-    name: transformers
-    properties:
-      - name: name
-        type: '(name: string, type?: ResolveType) => string'
-        required: false
-        description: Customize the names based on the type that is provided by the plugin.
-        codeBlock:
-          lang: typescript
-          code: |
-            type ResolveType = 'file' | 'function' | 'type' | 'const'
-
   - name: resolver
     type: 'Partial<ResolverVueQuery>'
     required: false


### PR DESCRIPTION


## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
