### PR TITLE
refactor: replace adapter.inputNode with ctx.inputNode in all generators

### DIFF
--- a/examples/client/src/generators/clientStaticGenerator.tsx
+++ b/examples/client/src/generators/clientStaticGenerator.tsx
@@ -11,9 +11,9 @@ export const clientStaticGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { config, plugin: _plugin, driver, resolver, adapter } = ctx
+    const { config, plugin: _plugin, driver, resolver, adapter, inputNode } = ctx
     const { output, importPath, dataReturnType, pathParamsType, paramsType, paramsCasing, parser } = ctx.options
-    const baseURL = adapter.inputNode?.meta?.baseURL
+    const baseURL = inputNode.meta?.baseURL
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null

--- a/packages/plugin-client/extension.yaml
+++ b/packages/plugin-client/extension.yaml
@@ -42,7 +42,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'clients', barrelType: 'named' }"
+    default: "{ path: 'clients', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -52,13 +52,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'clients'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -72,10 +70,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:
@@ -751,7 +754,7 @@ examples:
               pluginClient({
                 output: {
                   path: './clients/axios',
-                  barrelType: 'named',
+                  barrel: { type: 'named' },
                   banner: '/* eslint-disable no-alert, no-console */',
                   footer: '',
                 },

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -44,7 +44,7 @@ export const classClientGenerator = defineGenerator<PluginClient>({
   name: 'classClient',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, group, dataReturnType, paramsCasing, paramsType, pathParamsType, parser, importPath, sdk } = ctx.options
     const baseURL = ctx.options.baseURL ?? inputNode.meta?.baseURL
 

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -44,9 +44,9 @@ export const classClientGenerator = defineGenerator<PluginClient>({
   name: 'classClient',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, group, dataReturnType, paramsCasing, paramsType, pathParamsType, parser, importPath, sdk } = ctx.options
-    const baseURL = ctx.options.baseURL ?? adapter.inputNode?.meta?.baseURL
+    const baseURL = ctx.options.baseURL ?? inputNode.meta?.baseURL
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -161,8 +161,8 @@ export const classClientGenerator = defineGenerator<PluginClient>({
           baseName={file.baseName}
           path={file.path}
           meta={file.meta}
-          banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-          footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+          banner={resolver.resolveBanner(inputNode, { output, config })}
+          footer={resolver.resolveFooter(inputNode, { output, config })}
         >
           {importPath ? (
             <>
@@ -220,8 +220,8 @@ export const classClientGenerator = defineGenerator<PluginClient>({
           baseName={sdkFile.baseName}
           path={sdkFile.path}
           meta={sdkFile.meta}
-          banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-          footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+          banner={resolver.resolveBanner(inputNode, { output, config })}
+          footer={resolver.resolveFooter(inputNode, { output, config })}
         >
           {importPath ? (
             <File.Import name={['Client', 'RequestConfig']} path={importPath} isTypeOnly />

--- a/packages/plugin-client/src/generators/clientGenerator.test.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.test.tsx
@@ -205,6 +205,7 @@ describe('clientGenerator operation', () => {
     const options: PluginClient['resolvedOptions'] = {
       ...defaultOptions,
       ...props.options,
+      ...('baseURL' in props ? { baseURL: props.baseURL } : {}),
     }
     const plugin = createMockedPlugin<PluginClient>({ name: 'plugin-client', options, resolver: resolverClient })
     const driver = createMockedPluginDriver({
@@ -215,7 +216,6 @@ describe('clientGenerator operation', () => {
     await renderGeneratorOperation(clientGenerator, props.node, {
       config: testConfig,
       adapter: createMockedAdapter(),
-      inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
       driver,
       plugin,
       options,

--- a/packages/plugin-client/src/generators/clientGenerator.test.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.test.tsx
@@ -214,9 +214,8 @@ describe('clientGenerator operation', () => {
 
     await renderGeneratorOperation(clientGenerator, props.node, {
       config: testConfig,
-      adapter: createMockedAdapter({
-        inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
-      }),
+      adapter: createMockedAdapter(),
+      inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
       driver,
       plugin,
       options,

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -12,7 +12,7 @@ export const clientGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, urlType, dataReturnType, paramsCasing, paramsType, pathParamsType, parser, importPath, group } = ctx.options
     const baseURL = ctx.options.baseURL ?? inputNode.meta?.baseURL
 

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -12,9 +12,9 @@ export const clientGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, urlType, dataReturnType, paramsCasing, paramsType, pathParamsType, parser, importPath, group } = ctx.options
-    const baseURL = ctx.options.baseURL ?? adapter.inputNode?.meta?.baseURL
+    const baseURL = ctx.options.baseURL ?? inputNode.meta?.baseURL
 
     const pluginTs = driver.getPlugin(pluginTsName)
 
@@ -68,8 +68,8 @@ export const clientGenerator = defineGenerator<PluginClient>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {importPath ? (
           <>

--- a/packages/plugin-client/src/generators/groupedClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/groupedClientGenerator.tsx
@@ -8,7 +8,7 @@ export const groupedClientGenerator = defineGenerator<PluginClient>({
   name: 'groupedClient',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { config, resolver, adapter, root } = ctx
+    const { config, resolver, adapter, root, inputNode } = ctx
     const { output, group } = ctx.options
 
     const controllers = nodes.reduce(
@@ -55,8 +55,8 @@ export const groupedClientGenerator = defineGenerator<PluginClient>({
               baseName={file.baseName}
               path={file.path}
               meta={file.meta}
-              banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-              footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+              banner={resolver.resolveBanner(inputNode, { output, config })}
+              footer={resolver.resolveFooter(inputNode, { output, config })}
             >
               {clients.map((client) => (
                 <File.Import key={client.name} name={[client.name]} root={file.path} path={client.file.path} />

--- a/packages/plugin-client/src/generators/groupedClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/groupedClientGenerator.tsx
@@ -8,7 +8,7 @@ export const groupedClientGenerator = defineGenerator<PluginClient>({
   name: 'groupedClient',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { config, resolver, adapter, root, inputNode } = ctx
+    const { config, resolver, root, inputNode } = ctx
     const { output, group } = ctx.options
 
     const controllers = nodes.reduce(

--- a/packages/plugin-client/src/generators/operationsGenerator.tsx
+++ b/packages/plugin-client/src/generators/operationsGenerator.tsx
@@ -7,7 +7,7 @@ export const operationsGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { config, resolver, adapter, root, inputNode } = ctx
+    const { config, resolver, root, inputNode } = ctx
     const { output, group } = ctx.options
 
     const name = 'operations'

--- a/packages/plugin-client/src/generators/operationsGenerator.tsx
+++ b/packages/plugin-client/src/generators/operationsGenerator.tsx
@@ -7,7 +7,7 @@ export const operationsGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { config, resolver, adapter, root } = ctx
+    const { config, resolver, adapter, root, inputNode } = ctx
     const { output, group } = ctx.options
 
     const name = 'operations'
@@ -18,8 +18,8 @@ export const operationsGenerator = defineGenerator<PluginClient>({
         baseName={file.baseName}
         path={file.path}
         meta={file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         <Operations name={name} nodes={nodes} />
       </File>

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -42,7 +42,7 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
   name: 'staticClassClient',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, group, dataReturnType, paramsCasing, paramsType, pathParamsType, parser, importPath } = ctx.options
     const baseURL = ctx.options.baseURL ?? inputNode.meta?.baseURL
 

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -42,9 +42,9 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
   name: 'staticClassClient',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, group, dataReturnType, paramsCasing, paramsType, pathParamsType, parser, importPath } = ctx.options
-    const baseURL = ctx.options.baseURL ?? adapter.inputNode?.meta?.baseURL
+    const baseURL = ctx.options.baseURL ?? inputNode.meta?.baseURL
 
     const pluginTs = driver.getPlugin(pluginTsName)
     if (!pluginTs) return null
@@ -161,8 +161,8 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
               baseName={file.baseName}
               path={file.path}
               meta={file.meta}
-              banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-              footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+              banner={resolver.resolveBanner(inputNode, { output, config })}
+              footer={resolver.resolveFooter(inputNode, { output, config })}
             >
               {importPath ? (
                 <>

--- a/packages/plugin-cypress/extension.yaml
+++ b/packages/plugin-cypress/extension.yaml
@@ -40,7 +40,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'cypress', barrelType: 'named' }"
+    default: "{ path: 'cypress', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -50,13 +50,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'cypress'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -70,10 +68,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:
@@ -428,7 +431,7 @@ examples:
               pluginCypress({
                 output: {
                   path: './cypress',
-                  barrelType: 'named',
+                  barrel: { type: 'named' },
                   banner: '/* eslint-disable no-alert, no-console */',
                 },
                 group: {

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -9,7 +9,7 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
   name: 'cypress',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, resolver, driver, root } = ctx
+    const { adapter, config, resolver, driver, root, inputNode } = ctx
     const { output, baseURL, dataReturnType, paramsCasing, paramsType, pathParamsType, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -40,8 +40,8 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {meta.fileTs && importedTypeNames.length > 0 && <File.Import name={importedTypeNames} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />}
         <Request

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -9,7 +9,7 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
   name: 'cypress',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, resolver, driver, root, inputNode } = ctx
+    const { config, resolver, driver, root, inputNode } = ctx
     const { output, baseURL, dataReturnType, paramsCasing, paramsType, pathParamsType, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-faker/extension.yaml
+++ b/packages/plugin-faker/extension.yaml
@@ -41,7 +41,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'mocks', barrelType: 'named' }"
+    default: "{ path: 'mocks', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -51,13 +51,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'mocks'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -71,10 +69,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:
@@ -354,7 +357,7 @@ examples:
               pluginFaker({
                 output: {
                   path: './mocks',
-                  barrelType: 'named',
+                  barrel: { type: 'named' },
                 },
                 seed: [100],
                 paramsCasing: 'camelcase',

--- a/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
@@ -181,13 +181,14 @@ describe('fakerGenerator — schema', () => {
 
     await renderGeneratorSchema(fakerGenerator, node, {
       config: testConfig,
-      adapter: createMockedAdapter(),
-      inputNode: {
-        kind: 'Input',
-        schemas: [categorySchema, emojiSchema, errorSchema, petSchema, treeNodeSchema, petPolySchema, catSchema, dogSchema],
-        operations: [],
-        meta: {},
-      },
+      adapter: createMockedAdapter({
+        inputNode: {
+          kind: 'Input',
+          schemas: [categorySchema, emojiSchema, errorSchema, petSchema, treeNodeSchema, petPolySchema, catSchema, dogSchema],
+          operations: [],
+          meta: {},
+        },
+      }),
       driver,
       plugin,
       options: resolvedOptions,
@@ -204,13 +205,14 @@ describe('fakerGenerator — schema', () => {
 
     await renderGeneratorSchema(fakerGenerator, emojiSchema, {
       config: testConfig,
-      adapter: createMockedAdapter(),
-      inputNode: {
-        kind: 'Input',
-        schemas: [emojiSchema],
-        operations: [],
-        meta: {},
-      },
+      adapter: createMockedAdapter({
+        inputNode: {
+          kind: 'Input',
+          schemas: [emojiSchema],
+          operations: [],
+          meta: {},
+        },
+      }),
       driver,
       plugin,
       options: resolvedOptions,
@@ -302,13 +304,14 @@ describe('fakerGenerator — operation', () => {
 
     await renderGeneratorOperation(fakerGenerator, node, {
       config: testConfig,
-      adapter: createMockedAdapter(),
-      inputNode: {
-        kind: 'Input',
-        schemas: [categorySchema, errorSchema, petSchema, treeNodeSchema],
-        operations: [],
-        meta: {},
-      },
+      adapter: createMockedAdapter({
+        inputNode: {
+          kind: 'Input',
+          schemas: [categorySchema, errorSchema, petSchema, treeNodeSchema],
+          operations: [],
+          meta: {},
+        },
+      }),
       driver,
       plugin,
       options: resolvedOptions,

--- a/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
@@ -181,14 +181,13 @@ describe('fakerGenerator — schema', () => {
 
     await renderGeneratorSchema(fakerGenerator, node, {
       config: testConfig,
-      adapter: createMockedAdapter({
-        inputNode: {
-          kind: 'Input',
-          schemas: [categorySchema, emojiSchema, errorSchema, petSchema, treeNodeSchema, petPolySchema, catSchema, dogSchema],
-          operations: [],
-          meta: {},
-        },
-      }),
+      adapter: createMockedAdapter(),
+      inputNode: {
+        kind: 'Input',
+        schemas: [categorySchema, emojiSchema, errorSchema, petSchema, treeNodeSchema, petPolySchema, catSchema, dogSchema],
+        operations: [],
+        meta: {},
+      },
       driver,
       plugin,
       options: resolvedOptions,
@@ -205,14 +204,13 @@ describe('fakerGenerator — schema', () => {
 
     await renderGeneratorSchema(fakerGenerator, emojiSchema, {
       config: testConfig,
-      adapter: createMockedAdapter({
-        inputNode: {
-          kind: 'Input',
-          schemas: [emojiSchema],
-          operations: [],
-          meta: {},
-        },
-      }),
+      adapter: createMockedAdapter(),
+      inputNode: {
+        kind: 'Input',
+        schemas: [emojiSchema],
+        operations: [],
+        meta: {},
+      },
       driver,
       plugin,
       options: resolvedOptions,
@@ -304,14 +302,13 @@ describe('fakerGenerator — operation', () => {
 
     await renderGeneratorOperation(fakerGenerator, node, {
       config: testConfig,
-      adapter: createMockedAdapter({
-        inputNode: {
-          kind: 'Input',
-          schemas: [categorySchema, errorSchema, petSchema, treeNodeSchema],
-          operations: [],
-          meta: {},
-        },
-      }),
+      adapter: createMockedAdapter(),
+      inputNode: {
+        kind: 'Input',
+        schemas: [categorySchema, errorSchema, petSchema, treeNodeSchema],
+        operations: [],
+        meta: {},
+      },
       driver,
       plugin,
       options: resolvedOptions,

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -28,7 +28,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
 
     const tsResolver = ctx.driver.getResolver(pluginTsName)
 
-    const schemaNode = resolveSchemaRef(node, inputNode.schemas)
+    const schemaNode = resolveSchemaRef(node, adapter.inputNode?.schemas ?? inputNode.schemas)
     const schemaName = schemaNode.name ?? node.name
     const mode = ctx.getMode(output)
     const meta = {
@@ -41,7 +41,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       ),
     } as const
     const canOverride = canOverrideSchema(schemaNode)
-    const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
+    const cyclicSchemas = ast.findCircularSchemas(adapter.inputNode?.schemas ?? inputNode.schemas)
     const printerInstance = printerFaker({
       resolver,
       schemaName,
@@ -180,7 +180,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       }
 
       const canOverride = canOverrideSchema(schema)
-      const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
+      const cyclicSchemas = ast.findCircularSchemas(adapter.inputNode?.schemas ?? inputNode.schemas)
       const printerInstance = printerFaker({
         resolver,
         schemaName: name,

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -18,17 +18,17 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
   name: 'faker',
   renderer: jsxRenderer,
   schema(node, ctx) {
-    const { adapter, config, resolver, root } = ctx
+    const { adapter, config, resolver, root, inputNode } = ctx
     const { output, group, dateParser, regexGenerator, mapper, seed, locale, printer } = ctx.options
     const pluginTs = ctx.driver.getPlugin(pluginTsName)
 
-    if (!node.name || !pluginTs || !adapter.inputNode) {
+    if (!node.name || !pluginTs) {
       return
     }
 
     const tsResolver = ctx.driver.getResolver(pluginTsName)
 
-    const schemaNode = resolveSchemaRef(node, adapter.inputNode.schemas)
+    const schemaNode = resolveSchemaRef(node, inputNode.schemas)
     const schemaName = schemaNode.name ?? node.name
     const mode = ctx.getMode(output)
     const meta = {
@@ -41,7 +41,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       ),
     } as const
     const canOverride = canOverrideSchema(schemaNode)
-    const cyclicSchemas = adapter.inputNode ? ast.findCircularSchemas(adapter.inputNode.schemas) : undefined
+    const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
     const printerInstance = printerFaker({
       resolver,
       schemaName,
@@ -75,8 +75,8 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         <File.Import name={locale ? [{ propertyName: localeToFakerImport(locale), name: 'faker' }] : ['faker']} path="@faker-js/faker" />
         {regexGenerator === 'randexp' && <File.Import name={'RandExp'} path={'randexp'} />}
@@ -97,7 +97,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
     )
   },
   operation(node, ctx) {
-    const { adapter, config, resolver, root } = ctx
+    const { adapter, config, resolver, root, inputNode } = ctx
     const { output, group, paramsCasing, dateParser, regexGenerator, mapper, seed, locale, printer } = ctx.options
     const pluginTs = ctx.driver.getPlugin(pluginTsName)
 
@@ -180,7 +180,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       }
 
       const canOverride = canOverrideSchema(schema)
-      const cyclicSchemas = adapter.inputNode ? ast.findCircularSchemas(adapter.inputNode.schemas) : undefined
+      const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
       const printerInstance = printerFaker({
         resolver,
         schemaName: name,
@@ -228,8 +228,8 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         <File.Import name={locale ? [{ propertyName: localeToFakerImport(locale), name: 'faker' }] : ['faker']} path="@faker-js/faker" />
         {regexGenerator === 'randexp' && <File.Import name={'RandExp'} path={'randexp'} />}

--- a/packages/plugin-mcp/extension.yaml
+++ b/packages/plugin-mcp/extension.yaml
@@ -56,7 +56,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'mcp', barrelType: 'named' }"
+    default: "{ path: 'mcp', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -66,13 +66,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'mcp'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -86,10 +84,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:
@@ -456,7 +459,7 @@ examples:
               pluginClient(),
               pluginZod(),
               pluginMcp({
-                output: { path: 'mcp', barrelType: 'named' },
+                output: { path: 'mcp', barrel: { type: 'named' } },
                 client: {
                   baseURL: 'https://petstore.swagger.io/v2',
                 },

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -17,7 +17,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
   name: 'operations',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { adapter, config, resolver, plugin, driver, root } = ctx
+    const { adapter, config, resolver, plugin, driver, root, inputNode } = ctx
     const { output, paramsCasing, group } = ctx.options
 
     const pluginZod = driver.getPlugin(pluginZodName)
@@ -108,8 +108,8 @@ export const serverGenerator = defineGenerator<PluginMcp>({
           baseName={serverFile.baseName}
           path={serverFile.path}
           meta={serverFile.meta}
-          banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-          footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+          banner={resolver.resolveBanner(inputNode, { output, config })}
+          footer={resolver.resolveFooter(inputNode, { output, config })}
         >
           <File.Import name={['McpServer']} path={'@modelcontextprotocol/sdk/server/mcp'} />
           <File.Import name={['z']} path={'zod'} />
@@ -118,8 +118,8 @@ export const serverGenerator = defineGenerator<PluginMcp>({
           {imports}
           <Server
             name={name}
-            serverName={adapter.inputNode?.meta?.title ?? 'server'}
-            serverVersion={adapter.inputNode?.meta?.version ?? '0.0.0'}
+            serverName={inputNode.meta?.title ?? 'server'}
+            serverVersion={inputNode.meta?.version ?? '0.0.0'}
             paramsCasing={paramsCasing}
             operations={operationsMapped}
           />
@@ -130,7 +130,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
             {`
           {
             "mcpServers": {
-              "${adapter.inputNode?.meta?.title || 'server'}": {
+              "${inputNode.meta?.title || 'server'}": {
                 "type": "stdio",
                 "command": "npx",
                 "args": ["tsx", "${path.relative(path.dirname(jsonFile.path), serverFile.path)}"]

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -17,7 +17,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
   name: 'operations',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { adapter, config, resolver, plugin, driver, root, inputNode } = ctx
+    const { config, resolver, plugin, driver, root, inputNode } = ctx
     const { output, paramsCasing, group } = ctx.options
 
     const pluginZod = driver.getPlugin(pluginZodName)

--- a/packages/plugin-msw/extension.yaml
+++ b/packages/plugin-msw/extension.yaml
@@ -42,7 +42,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'handlers', barrelType: 'named' }"
+    default: "{ path: 'handlers', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -52,13 +52,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'handlers'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -72,10 +70,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:
@@ -232,7 +235,7 @@ examples:
               pluginMsw({
                 output: {
                   path: './mocks',
-                  barrelType: 'named',
+                  barrel: { type: 'named' },
                   banner: '/* eslint-disable no-alert, no-console */',
                   footer: '',
                 },

--- a/packages/plugin-msw/src/generators/handlersGenerator.tsx
+++ b/packages/plugin-msw/src/generators/handlersGenerator.tsx
@@ -7,7 +7,7 @@ export const handlersGenerator = defineGenerator<PluginMsw>({
   name: 'plugin-msw',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { resolver, config, root, adapter, inputNode } = ctx
+    const { resolver, config, root, inputNode } = ctx
     const { output, group } = ctx.options
 
     const handlersName = resolver.resolveHandlersName()

--- a/packages/plugin-msw/src/generators/handlersGenerator.tsx
+++ b/packages/plugin-msw/src/generators/handlersGenerator.tsx
@@ -7,7 +7,7 @@ export const handlersGenerator = defineGenerator<PluginMsw>({
   name: 'plugin-msw',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { resolver, config, root, adapter } = ctx
+    const { resolver, config, root, adapter, inputNode } = ctx
     const { output, group } = ctx.options
 
     const handlersName = resolver.resolveHandlersName()
@@ -30,8 +30,8 @@ export const handlersGenerator = defineGenerator<PluginMsw>({
         baseName={file.baseName}
         path={file.path}
         meta={file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {imports}
         <Handlers name={handlersName} handlers={handlers} />

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -11,7 +11,7 @@ export const mswGenerator = defineGenerator<PluginMsw>({
   name: 'msw',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { driver, resolver, config, root, adapter } = ctx
+    const { driver, resolver, config, root, adapter, inputNode } = ctx
     const { output, parser, baseURL, group } = ctx.options
 
     const fileName = resolver.resolveName(node.operationId)
@@ -54,8 +54,8 @@ export const mswGenerator = defineGenerator<PluginMsw>({
         baseName={mock.file.baseName}
         path={mock.file.path}
         meta={mock.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         <File.Import name={['http']} path="msw" />
         <File.Import name={['HttpResponseResolver']} isTypeOnly path="msw" />

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -11,7 +11,7 @@ export const mswGenerator = defineGenerator<PluginMsw>({
   name: 'msw',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { driver, resolver, config, root, adapter, inputNode } = ctx
+    const { driver, resolver, config, root, inputNode } = ctx
     const { output, parser, baseURL, group } = ctx.options
 
     const fileName = resolver.resolveName(node.operationId)

--- a/packages/plugin-react-query/extension.yaml
+++ b/packages/plugin-react-query/extension.yaml
@@ -42,7 +42,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'hooks', barrelType: 'named' }"
+    default: "{ path: 'hooks', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -52,13 +52,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'hooks'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -72,10 +70,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -116,8 +116,8 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
         baseName={hookOptionsFile.baseName}
         path={hookOptionsFile.path}
         meta={hookOptionsFile.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {imports}
         <File.Source name={name} isExportable isIndexable isTypeOnly>

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -13,7 +13,7 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-hook-options',
   renderer: jsxRenderer,
   operations(nodes, ctx) {
-    const { resolver, config, root, adapter } = ctx
+    const { resolver, config, root, inputNode } = ctx
     const { output, customOptions, query, mutation, suspense, infinite, group, override } = ctx.options
 
     if (!customOptions) return null

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-infinite-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-infinite-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -94,8 +94,8 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -14,7 +14,7 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-mutation',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -14,7 +14,7 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-mutation',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -80,8 +80,8 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
@@ -142,7 +142,6 @@ describe('queryGenerator operation', () => {
     await renderGeneratorOperation(queryGenerator, props.node, {
       config: testConfig,
       adapter: createMockedAdapter(),
-      inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
       driver,
       plugin,
       options,

--- a/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
@@ -141,9 +141,8 @@ describe('queryGenerator operation', () => {
 
     await renderGeneratorOperation(queryGenerator, props.node, {
       config: testConfig,
-      adapter: createMockedAdapter({
-        inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
-      }),
+      adapter: createMockedAdapter(),
+      inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
       driver,
       plugin,
       options,

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -14,7 +14,7 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -85,8 +85,8 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -14,7 +14,7 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
   name: 'react-suspense-infinite-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const {
       output,
       query,
@@ -103,8 +103,8 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
   name: 'react-suspense-infinite-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const {
       output,
       query,

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-suspense-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, suspense, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-suspense-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, suspense, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -86,8 +86,8 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-ts/extension.yaml
+++ b/packages/plugin-ts/extension.yaml
@@ -43,7 +43,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'types', barrelType: 'named' }"
+    default: "{ path: 'types', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -53,13 +53,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'types'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -73,10 +71,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -29,7 +29,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
   renderer: jsxRenderer,
   schema(node, ctx) {
     const { enumType, enumTypeSuffix, enumKeyCasing, syntaxType, optionalType, arrayType, output, group, printer } = ctx.options
-    const { adapter, config, resolver, root } = ctx
+    const { adapter, config, resolver, root, inputNode } = ctx
 
     if (!node.name) {
       return
@@ -37,7 +37,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
     const mode = ctx.getMode(output)
     // Build a set of schema names that are enums so the ref handler and getImports
     // callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
-    const enumSchemaNames = new Set((adapter.inputNode?.schemas ?? []).filter((s) => ast.narrowSchema(s, ast.schemaTypes.enum) && s.name).map((s) => s.name!))
+    const enumSchemaNames = new Set(inputNode.schemas.filter((s) => ast.narrowSchema(s, ast.schemaTypes.enum) && s.name).map((s) => s.name!))
 
     function resolveImportName(schemaName: string): string {
       if (ENUM_TYPES_WITH_KEY_SUFFIX.has(enumType) && enumTypeSuffix && enumSchemaNames.has(schemaName)) {
@@ -76,8 +76,8 @@ export const typeGenerator = defineGenerator<PluginTs>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {mode === 'split' &&
           imports.map((imp) => (
@@ -97,7 +97,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
   },
   operation(node, ctx) {
     const { enumType, enumTypeSuffix, enumKeyCasing, optionalType, arrayType, syntaxType, paramsCasing, group, output, printer } = ctx.options
-    const { adapter, config, resolver, root } = ctx
+    const { adapter, config, resolver, root, inputNode } = ctx
 
     const mode = ctx.getMode(output)
 
@@ -109,7 +109,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
 
     // Build a set of schema names that are enums so the ref handler and getImports
     // callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
-    const enumSchemaNames = new Set((adapter.inputNode?.schemas ?? []).filter((s) => ast.narrowSchema(s, ast.schemaTypes.enum) && s.name).map((s) => s.name!))
+    const enumSchemaNames = new Set(inputNode.schemas.filter((s) => ast.narrowSchema(s, ast.schemaTypes.enum) && s.name).map((s) => s.name!))
 
     function resolveImportName(schemaName: string): string {
       if (ENUM_TYPES_WITH_KEY_SUFFIX.has(enumType) && enumTypeSuffix && enumSchemaNames.has(schemaName)) {
@@ -281,8 +281,8 @@ export const typeGenerator = defineGenerator<PluginTs>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {paramTypes}
         {responseTypes}

--- a/packages/plugin-vue-query/extension.yaml
+++ b/packages/plugin-vue-query/extension.yaml
@@ -42,7 +42,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'hooks', barrelType: 'named' }"
+    default: "{ path: 'hooks', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -52,13 +52,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'hooks'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -72,10 +70,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-infinite',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -94,8 +94,8 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -14,7 +14,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-infinite',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -14,7 +14,7 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-mutation',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -79,8 +79,8 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -14,7 +14,7 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-mutation',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
@@ -140,7 +140,6 @@ describe('queryGenerator operation', () => {
     await renderGeneratorOperation(queryGenerator, props.node, {
       config: testConfig,
       adapter: createMockedAdapter(),
-      inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
       driver,
       plugin,
       options,

--- a/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
@@ -139,9 +139,8 @@ describe('queryGenerator operation', () => {
 
     await renderGeneratorOperation(queryGenerator, props.node, {
       config: testConfig,
-      adapter: createMockedAdapter({
-        inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
-      }),
+      adapter: createMockedAdapter(),
+      inputNode: { kind: 'Input', schemas: [], operations: [], meta: { baseURL: 'baseURL' in props ? props.baseURL : undefined } },
       driver,
       plugin,
       options,

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -14,7 +14,7 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root } = ctx
+    const { adapter, config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)
@@ -84,8 +84,8 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -14,7 +14,7 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query',
   renderer: jsxRenderer,
   operation(node, ctx) {
-    const { adapter, config, driver, resolver, root, inputNode } = ctx
+    const { config, driver, resolver, root, inputNode } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
     const pluginTs = driver.getPlugin(pluginTsName)

--- a/packages/plugin-zod/extension.yaml
+++ b/packages/plugin-zod/extension.yaml
@@ -39,7 +39,7 @@ options:
   - name: output
     type: Output
     required: false
-    default: "{ path: 'zod', barrelType: 'named' }"
+    default: "{ path: 'zod', barrel: { type: 'named' } }"
     description: Specify the export location for the files and define the behavior of the output.
     properties:
       - name: path
@@ -49,13 +49,11 @@ options:
         tip: |
           if `output.path` is a file, `group` cannot be used.
         default: "'zod'"
-      - name: barrelType
-        type: "'all' | 'named' | 'propagate' | false"
+      - name: barrel
+        type: "{ type: 'named' | 'all', nested?: boolean } | false"
         required: false
-        default: "'named'"
-        description: Specify what to export and optionally disable barrel-file generation.
-        tip: |
-          Using `propagate` will prevent a plugin from creating a barrel file, but it will still propagate, allowing [`output.barrelType`](https://kubb.dev/docs/5.x/configuration#output-barreltype) to export the specific function or type.
+        default: "{ type: 'named' }"
+        description: 'Configure barrel file export strategy. Use `type` to control named vs. wildcard exports; set `nested: true` to generate hierarchical barrels in subdirectories.'
         examples:
           - name: all
             files:
@@ -69,10 +67,15 @@ options:
                 code: |
                   export { PetService } from './gen/petService.ts'
                 twoslash: false
-          - name: propagate
+          - name: nested
             files:
-              - lang: typescript
-                code: ''
+              - name: kubb.config.ts
+                lang: typescript
+                code: |
+                  output: {
+                    path: './gen',
+                    barrel: { type: 'named', nested: true },
+                  }
                 twoslash: false
           - name: 'false'
             files:

--- a/packages/plugin-zod/src/generators/zodGenerator.test.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.test.tsx
@@ -306,13 +306,13 @@ describe('zodGenerator — Schema', () => {
       config: testConfig,
       adapter: createMockedAdapter({
         resolvedOptions: { dateType: 'string' },
-        inputNode: {
-          kind: 'Input',
-          schemas: [petPolySchema, catCycleSchema],
-          operations: [],
-          meta: {},
-        },
       }),
+      inputNode: {
+        kind: 'Input',
+        schemas: [petPolySchema, catCycleSchema],
+        operations: [],
+        meta: {},
+      },
       driver,
       plugin,
       options: defaultOptions,

--- a/packages/plugin-zod/src/generators/zodGenerator.test.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.test.tsx
@@ -306,13 +306,13 @@ describe('zodGenerator — Schema', () => {
       config: testConfig,
       adapter: createMockedAdapter({
         resolvedOptions: { dateType: 'string' },
+        inputNode: {
+          kind: 'Input',
+          schemas: [petPolySchema, catCycleSchema],
+          operations: [],
+          meta: {},
+        },
       }),
-      inputNode: {
-        kind: 'Input',
-        schemas: [petPolySchema, catCycleSchema],
-        operations: [],
-        meta: {},
-      },
       driver,
       plugin,
       options: defaultOptions,

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -37,7 +37,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
 
     const inferTypeName = inferred ? resolver.resolveSchemaTypeName(node.name) : undefined
 
-    const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
+    const cyclicSchemas = ast.findCircularSchemas(adapter.inputNode?.schemas ?? inputNode.schemas)
 
     const schemaPrinter = mini
       ? printerZodMini({ guidType, wrapOutput, resolver, cyclicSchemas, nodes: printer?.nodes })
@@ -72,7 +72,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
       file: resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),
     } as const
 
-    const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
+    const cyclicSchemas = ast.findCircularSchemas(adapter.inputNode?.schemas ?? inputNode.schemas)
 
     function renderSchemaEntry({ schema, name, keysToOmit }: { schema: ast.SchemaNode | null; name: string; keysToOmit?: Array<string> }) {
       if (!schema) return null
@@ -171,7 +171,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
     )
   },
   operations(nodes, ctx) {
-    const { adapter, config, resolver, root } = ctx
+    const { config, resolver, root, inputNode } = ctx
     const { output, importPath, group, operations, paramsCasing } = ctx.options
 
     if (!operations) {

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -14,7 +14,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
   name: 'zod',
   renderer: jsxRenderer,
   schema(node, ctx) {
-    const { adapter, config, resolver, root } = ctx
+    const { adapter, config, resolver, root, inputNode } = ctx
     const { output, coercion, guidType, mini, wrapOutput, inferred, importPath, group, printer } = ctx.options
     const dateType = (adapter as Adapter<AdapterOas>).options.dateType
 
@@ -37,7 +37,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
 
     const inferTypeName = inferred ? resolver.resolveSchemaTypeName(node.name) : undefined
 
-    const cyclicSchemas = adapter.inputNode ? ast.findCircularSchemas(adapter.inputNode.schemas) : undefined
+    const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
 
     const schemaPrinter = mini
       ? printerZodMini({ guidType, wrapOutput, resolver, cyclicSchemas, nodes: printer?.nodes })
@@ -48,8 +48,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         <File.Import name={isZodImport ? 'z' : ['z']} path={importPath} isNameSpace={isZodImport} />
         {mode === 'split' && imports.map((imp) => <File.Import key={[node.name, imp.path].join('-')} root={meta.file.path} path={imp.path} name={imp.name} />)}
@@ -59,7 +59,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
     )
   },
   operation(node, ctx) {
-    const { adapter, config, resolver, root } = ctx
+    const { adapter, config, resolver, root, inputNode } = ctx
     const { output, coercion, guidType, mini, wrapOutput, inferred, importPath, group, paramsCasing, printer } = ctx.options
     const dateType = (adapter as Adapter<AdapterOas>).options.dateType
 
@@ -72,7 +72,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
       file: resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output, group }),
     } as const
 
-    const cyclicSchemas = adapter.inputNode ? ast.findCircularSchemas(adapter.inputNode.schemas) : undefined
+    const cyclicSchemas = ast.findCircularSchemas(inputNode.schemas)
 
     function renderSchemaEntry({ schema, name, keysToOmit }: { schema: ast.SchemaNode | null; name: string; keysToOmit?: Array<string> }) {
       if (!schema) return null
@@ -159,8 +159,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         <File.Import name={isZodImport ? 'z' : ['z']} path={importPath} isNameSpace={isZodImport} />
         {paramSchemas}
@@ -204,8 +204,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(adapter.inputNode, { output, config })}
-        footer={resolver.resolveFooter(adapter.inputNode, { output, config })}
+        banner={resolver.resolveBanner(inputNode, { output, config })}
+        footer={resolver.resolveFooter(inputNode, { output, config })}
       >
         <File.Import isTypeOnly name={isZodImport ? 'z' : ['z']} path={importPath} isNameSpace={isZodImport} />
         {imports}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,15 +11,6 @@ allowBuilds:
   msw: true
   vue-demi: true
 
-minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age
-pmOnFail: warn
-resolutionMode: highest
-minimumReleaseAgeExclude:
-  - '@kubb/*'
-  - 'kubb'
-  - 'unplugin-kubb'
-  - '@types/*'
-
 catalog:
   '@kubb/adapter-oas': 5.0.0-beta.11
   '@kubb/agent': 5.0.0-beta.11
@@ -27,18 +18,27 @@ catalog:
   '@kubb/middleware-barrel': 5.0.0-beta.11
   '@kubb/parser-ts': 5.0.0-beta.11
   '@kubb/renderer-jsx': 5.0.0-beta.11
-  kubb: 5.0.0-beta.11
-  unplugin-kubb: 5.0.0-beta.11
-  '@types/node': ^22.19.18
-  prettier: ^3.8.3
-  '@types/react': ^19.2.14
   '@size-limit/file': ^12.1.0
-  'size-limit': ^12.1.0
-  remeda: ^2.34.0
-  tsdown: ^0.22.0
-  typescript: ^6.0.3
-  vitest: ^4.1.5
+  '@types/node': ^22.19.18
+  '@types/react': ^19.2.14
   '@vitest/coverage-v8': ^4.1.5
   '@vitest/ui': ^4.1.5
+  kubb: 5.0.0-beta.11
   oxfmt: ^0.47.0
   oxlint: ^1.63.0
+  prettier: ^3.8.3
+  remeda: ^2.34.0
+  'size-limit': ^12.1.0
+  tsdown: ^0.22.0
+  typescript: ^6.0.3
+  unplugin-kubb: 5.0.0-beta.11
+  vitest: ^4.1.5
+
+minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age
+minimumReleaseAgeExclude:
+  - '@kubb/*'
+  - 'kubb'
+  - 'unplugin-kubb'
+  - '@types/*'
+pmOnFail: warn
+resolutionMode: highest


### PR DESCRIPTION
## Summary

- Replace every `adapter.inputNode` reference across 22 generator files with `ctx.inputNode`
- Remove null-guards that existed solely because `adapter.inputNode` was nullable (e.g. the `!adapter.inputNode` early-return in `fakerGenerator`)
- Simplify cyclic-schema ternary guards in `fakerGenerator` and `zodGenerator` to direct calls
- Update 5 test files: move `inputNode` out of `createMockedAdapter({...})` into the top-level `RenderGeneratorOptions` so it flows into the generator context correctly
- Fix `examples/client/src/generators/clientStaticGenerator.tsx`

## Motivation

`adapter.inputNode` stored the same large parsed AST that `ctx.inputNode` already provides, doubling memory usage. The companion PR in kubb-labs/kubb removes `inputNode` from the `Adapter` interface entirely.

## Dependencies

Requires kubb-labs/kubb#3291 to land first (removes `inputNode` from `Adapter` type).

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes

https://claude.ai/code/session_01Um1gYNswDED59mYFW2Y7m5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Um1gYNswDED59mYFW2Y7m5)_