### PR TITLE
perf(e2e): validate streaming improvement with twitter benchmark; drop stripe (parser OOM)

### DIFF
--- a/tests/e2e/kubb.config.js
+++ b/tests/e2e/kubb.config.js
@@ -33,7 +33,7 @@ const schemas = [
   { name: 'dataset_api', path: './schemas/dataset_api.yaml' },
   { name: 'petStoreV3', path: 'https://petstore3.swagger.io/api/v3/openapi.json' },
   { name: 'openai', path: 'https://raw.githubusercontent.com/openai/openai-openapi/refs/heads/manual_spec/openapi.yaml', strict: false },
-  { name: 'stripe', path: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json', strict: false },
+  // stripe omitted: its circular-reference expansion OOMs at parse time regardless of streaming
   { name: 'vercel', path: 'https://openapi.vercel.sh/', strict: false },
 ]
 
@@ -120,9 +120,9 @@ const baseConfig = {
  * @link https://apis.guru/
  *
  * Set KUBB_SCHEMA to a comma-separated list of schema names to only run those schemas.
- * Per-plugin file flushing reduces peak generation memory, so large schemas
- * (e.g. twitter, stripe) can run alongside others without hitting OOM.
- * Example: KUBB_SCHEMA=stripe kubb generate
+ * Per-plugin file flushing reduces peak generation memory, so large schemas like twitter
+ * run alongside others without OOM. Use isolation for schemas that also stress the parser.
+ * Example: KUBB_SCHEMA=openai kubb generate
  */
 const schemaFilter = process.env.KUBB_SCHEMA?.split(',').map((s) => s.trim())
 

--- a/tests/e2e/kubb.config.js
+++ b/tests/e2e/kubb.config.js
@@ -33,6 +33,7 @@ const schemas = [
   { name: 'dataset_api', path: './schemas/dataset_api.yaml' },
   { name: 'petStoreV3', path: 'https://petstore3.swagger.io/api/v3/openapi.json' },
   { name: 'openai', path: 'https://raw.githubusercontent.com/openai/openai-openapi/refs/heads/manual_spec/openapi.yaml', strict: false },
+  { name: 'stripe', path: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json', strict: false },
   { name: 'vercel', path: 'https://openapi.vercel.sh/', strict: false },
 ]
 
@@ -119,7 +120,8 @@ const baseConfig = {
  * @link https://apis.guru/
  *
  * Set KUBB_SCHEMA to a comma-separated list of schema names to only run those schemas.
- * Useful for running large schemas (e.g. stripe, openai) in isolation to avoid OOM.
+ * Per-plugin file flushing reduces peak generation memory, so large schemas
+ * (e.g. twitter, stripe) can run alongside others without hitting OOM.
  * Example: KUBB_SCHEMA=stripe kubb generate
  */
 const schemaFilter = process.env.KUBB_SCHEMA?.split(',').map((s) => s.trim())

--- a/tests/performance/main.bench.ts
+++ b/tests/performance/main.bench.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { adapterOas } from '@kubb/adapter-oas'
-import { AsyncEventEmitter, createKubb, type Plugin } from '@kubb/core'
+import { AsyncEventEmitter, createKubb, memoryStorage, type Plugin } from '@kubb/core'
 import { pluginClient } from '@kubb/plugin-client'
 import { pluginFaker } from '@kubb/plugin-faker'
 import { pluginTs } from '@kubb/plugin-ts'
@@ -22,6 +22,7 @@ const __dirname = path.dirname(__filename)
 
 describe('Plugin Generation Performance', () => {
   const petStorePath = path.resolve(__dirname, '../../schemas/3.0.x/petStore.yaml')
+  const twitterPath = path.resolve(__dirname, '../e2e/schemas/twitter.json')
 
   bench(
     'single plugin generation (plugin-ts)',
@@ -35,8 +36,8 @@ describe('Plugin Generation Performance', () => {
         output: {
           path: './src/gen',
           clean: false,
-          write: false,
         },
+        storage: memoryStorage(),
         plugins: [
           pluginTs({
             output: {
@@ -68,8 +69,8 @@ describe('Plugin Generation Performance', () => {
         output: {
           path: './src/gen',
           clean: false,
-          write: false,
         },
+        storage: memoryStorage(),
         plugins: [
           pluginTs({
             output: {
@@ -106,8 +107,59 @@ describe('Plugin Generation Performance', () => {
         output: {
           path: './src/gen',
           clean: false,
-          write: false,
         },
+        storage: memoryStorage(),
+        plugins: [
+          pluginTs({
+            output: {
+              path: 'types',
+              barrel: false,
+            },
+            enumType: 'asConst',
+          }),
+          pluginClient({
+            output: {
+              path: 'clients',
+            },
+          }),
+          pluginZod({
+            output: {
+              path: 'zod',
+              barrel: false,
+            },
+            inferred: true,
+          }),
+          pluginFaker({
+            output: {
+              path: 'mocks',
+              barrel: false,
+            },
+          }),
+        ] as Plugin[],
+      })
+
+      const hooks = new AsyncEventEmitter()
+      await createKubb(config, { hooks }).build()
+    },
+    {
+      time: 10000,
+    },
+  )
+
+  bench(
+    'large schema streaming (twitter + multiple plugins)',
+    async () => {
+      const config = defineConfig({
+        root: '.',
+        input: {
+          path: twitterPath,
+        },
+        adapter: adapterOas({ validate: false }),
+        output: {
+          path: './src/gen',
+          clean: false,
+        },
+        storage: memoryStorage(),
         plugins: [
           pluginTs({
             output: {


### PR DESCRIPTION
## Summary

Validates that the per-plugin file flushing introduced in kubb core (`createKubb.ts`) improves generation for large schemas like Twitter, and fixes correctness issues in the performance benchmarks.

### What streaming fixes (and what it doesn't)

`createKubb.ts` now calls `flushPendingFiles()` after each plugin completes instead of accumulating all files until the end. This reduces **generation-phase** peak memory — files from `plugin-ts` are written to storage as that plugin finishes, then `plugin-react-query`, etc.

**Twitter**: benefits from streaming. ~400 schemas, many operations — per-plugin flushing keeps peak memory bounded. ✅

**Stripe**: does **not** benefit from streaming. Stripe fails at the **parse phase** in `adapter-oas` before generation even begins. Its dense circular-reference graph causes exponential subtree duplication in `parser.ts` (`resolvingRefs` only guards recursion within a single resolution chain, not repeated resolution of the same schema from different paths). This is a separate unfixed issue. ❌

### Changes in this PR

**`tests/performance/main.bench.ts`**
- Replace the invalid `output.write: false` option (not in `Config['output']` type — was silently ignored, benchmarks were writing to disk) with `storage: memoryStorage()` at the config top level
- Add **`large schema streaming (twitter + multiple plugins)`** benchmark: twitter.json through 4 plugins (`plugin-ts`, `plugin-client`, `plugin-zod`, `plugin-faker`) with `memoryStorage()`, giving a real throughput baseline for the streaming path

**`tests/e2e/kubb.config.js`**
- Remove `stripe` from the always-on schema list (it OOMs during parsing regardless of streaming)
- Update `KUBB_SCHEMA` comment to accurately reflect: streaming helps generation-phase memory (twitter runs fine in the suite), but parser-phase stress schemas should still be run in isolation

## Test plan

- [ ] `KUBB_SCHEMA=twitter pnpm generate` in `tests/e2e` — completes without OOM
- [ ] `pnpm bench` in `tests/performance` — all four benchmarks pass, no disk writes, new Twitter benchmark visible in results
- [ ] `KUBB_SCHEMA=stripe pnpm generate` (optional manual check) — still OOMs at parse time, confirming it was correctly excluded