### PR TITLE
fix(ci): ensure NPM_TOKEN is used for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
@@ -67,6 +72,7 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish ${{ inputs.tag || 'canary' }}
         id: canary
@@ -74,6 +80,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag || 'canary' }}
         run: |
           git checkout main


### PR DESCRIPTION
## Summary

- The `Setup Tools` action (which uses `actions/setup-node` internally) sets `NPM_CONFIG_USERCONFIG` to a temp `.npmrc` that authenticates via `NODE_AUTH_TOKEN`
- The `changesets/action` creates `~/.npmrc` with `NPM_TOKEN`, but npm ignores `~/.npmrc` when `NPM_CONFIG_USERCONFIG` is set — so publish was hitting npm with the wrong credential, causing E404 on every package
- Add a **Configure npm auth** step that appends the publish token to whichever `.npmrc` file npm actually reads (`$NPM_CONFIG_USERCONFIG`, or `~/.npmrc` as fallback)
- Pass `NPM_TOKEN` explicitly to both the changesets Publish step and the canary Publish step

## Test plan

- [ ] Verify the next release run no longer produces `E404 Not Found - PUT https://registry.npmjs.org/...` errors
- [ ] Verify canary publishes also succeed (the auth file is outside the git tree so `git checkout main` does not clobber it)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavSdp84rxx3Jnu5oQqgKx)_