### PR TITLE
fix(plugin-client): remove duplicate transformers option from extension YAML

### DIFF
--- a/.changeset/plugin-client-drop-dead-transformers-yaml.md
+++ b/.changeset/plugin-client-drop-dead-transformers-yaml.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-client": patch
+---
+
+Remove the duplicate `transformers` option from the plugin-client extension YAML. The TypeScript option type only defines `transformer` (singular), so the duplicate was dead metadata that bloated the published registry. The `transformer` option itself is unchanged.

--- a/packages/plugin-client/extension.yaml
+++ b/packages/plugin-client/extension.yaml
@@ -666,44 +666,6 @@ options:
       Define additional generators next to the built-in generators.
 
       See [Generators](https://kubb.dev/docs/5.x/guides/creating-plugins) for more information on how to use generators.
-  - name: transformers
-    type: Visitor
-    required: false
-    description: |
-      A single AST visitor applied to every node before code is printed. Each method you provide replaces the corresponding built-in one. When a method returns `null` or `undefined`, the preset transformer's result is used as the fallback — so you only need to supply the methods you want to change.
-
-      Visitor methods receive the node and a context object. Return a modified node to replace it, or return `undefined`/`void` to leave it unchanged.
-    examples:
-      - name: Strip descriptions before printing
-        files:
-          - lang: typescript
-            code: |
-              import { pluginTs } from '@kubb/plugin-ts'
-
-              pluginTs({
-                transformer: {
-                  schema(node) {
-                    return { ...node, description: undefined }
-                  },
-                },
-              })
-            twoslash: false
-      - name: Prefix every operationId
-        files:
-          - lang: typescript
-            code: |
-              import { pluginTs } from '@kubb/plugin-ts'
-
-              pluginTs({
-                transformer: {
-                  operation(node) {
-                    return { ...node, operationId: `api_${node.operationId}` }
-                  },
-                },
-              })
-            twoslash: false
-    tip: |
-      Use `transformer` to rewrite node properties before printing. For output naming customization, use `resolver` instead.
   - name: resolver
     type: Partial<ResolverClient> & ThisType<ResolverClient>
     required: false

--- a/plugins/plugin-client.yaml
+++ b/plugins/plugin-client.yaml
@@ -106,9 +106,6 @@ options:
   - extends: ./_shared/core/generators.yaml
     type: 'Array<Generator<PluginClient>>'
 
-  - extends: ./_shared/core/transformer.yaml
-    name: transformers
-
   - name: resolver
     type: 'Partial<ResolverClient> & ThisType<ResolverClient>'
     required: false


### PR DESCRIPTION
## Summary

`plugins/plugin-client.yaml` declared two blocks for the same TypeScript option: a dead `transformers` (plural) block at the top and the real `transformer` (singular) block below. The TypeScript type only defines `transformer?: ast.Visitor`, so the duplicate carried no runtime meaning. The generated kubb.dev markdown filters the duplicate out, so end-users never saw it, but the published `extension.yaml` registry still shipped the dead block.

This PR drops the duplicate from both the source YAML and the regenerated `packages/plugin-client/extension.yaml`.

## Files

- `plugins/plugin-client.yaml` — remove the `extends: ./_shared/core/transformer.yaml` block that aliased it to `transformers`.
- `packages/plugin-client/extension.yaml` — regenerated copy with the same block removed.
- `.changeset/plugin-client-drop-dead-transformers-yaml.md` — patch changeset.

## Test plan

- [ ] `pnpm build:extension-yaml` produces the same `packages/plugin-client/extension.yaml` shipped in this PR.
- [ ] `pnpm format && pnpm lint:fix`
- [ ] `pnpm typecheck`
- [ ] `pnpm test --filter=@kubb/plugin-client`

https://claude.ai/code/session_01M2iao3gc9Smat8zXKMH3uq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2iao3gc9Smat8zXKMH3uq)_