### PR TITLE
docs(plugins): polish JSDoc on resolvers, generators, and printers

### DIFF
--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -40,6 +40,11 @@ function resolveZodImportNames(node: ast.OperationNode, zodResolver: ResolverZod
   return names.filter((n): n is string => Boolean(n))
 }
 
+/**
+ * Built-in `operations` generator for `@kubb/plugin-client` when
+ * `clientType: 'class'`. Emits one class per tag, with one instance method
+ * per operation and a shared constructor for request configuration.
+ */
 export const classClientGenerator = defineGenerator<PluginClient>({
   name: 'classClient',
   renderer: jsxRendererSync,

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -8,6 +8,11 @@ import { Client } from '../components/Client'
 import { Url } from '../components/Url.tsx'
 import type { PluginClient } from '../types'
 
+/**
+ * Built-in operation generator for `@kubb/plugin-client`. Emits one async
+ * function per OpenAPI operation, plus the matching URL helper. Used when
+ * `clientType: 'function'` (the default).
+ */
 export const clientGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRendererSync,

--- a/packages/plugin-client/src/generators/groupedClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/groupedClientGenerator.tsx
@@ -4,6 +4,12 @@ import { defineGenerator } from '@kubb/core'
 import { File, Function, jsxRendererSync } from '@kubb/renderer-jsx'
 import type { PluginClient } from '../types'
 
+/**
+ * Emits one aggregate file per tag/group when `group` is configured. Each
+ * file re-exports every client function for that group, so callers can
+ * `import { petController } from './gen/clients'` instead of importing
+ * each operation individually.
+ */
 export const groupedClientGenerator = defineGenerator<PluginClient>({
   name: 'groupedClient',
   renderer: jsxRendererSync,

--- a/packages/plugin-client/src/generators/operationsGenerator.tsx
+++ b/packages/plugin-client/src/generators/operationsGenerator.tsx
@@ -3,6 +3,12 @@ import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { Operations } from '../components/Operations'
 import type { PluginClient } from '../types'
 
+/**
+ * Generates an `operations.ts` file that re-exports every operation grouped
+ * by HTTP method. Enabled when `pluginClient({ operations: true })`. Useful
+ * for building meta-tooling on top of the generated client (route
+ * registries, API explorers).
+ */
 export const operationsGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRendererSync,

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -38,6 +38,12 @@ function resolveZodImportNames(node: ast.OperationNode, zodResolver: ResolverZod
   return names.filter((n): n is string => Boolean(n))
 }
 
+/**
+ * Built-in `operations` generator for `@kubb/plugin-client` when
+ * `clientType: 'staticClass'`. Emits one class per tag, with a static method
+ * per operation so callers can use `Pet.getPetById(...)` without
+ * instantiating the class.
+ */
 export const staticClassClientGenerator = defineGenerator<PluginClient>({
   name: 'staticClassClient',
   renderer: jsxRendererSync,

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -23,9 +23,9 @@ export const pluginClientName = 'plugin-client' satisfies PluginClient['name']
 
 /**
  * Generates one HTTP client function per OpenAPI operation. Each function has
- * typed path params, query params, body, and response — call the API like any
- * other typed function. Ships with `axios` and `fetch` runtimes; bring your own
- * by setting `importPath`.
+ * typed path params, query params, body, and response, so callers use the API
+ * like any other typed function. Ships with `axios` and `fetch` runtimes; bring
+ * your own by setting `importPath`.
  *
  * @example
  * ```ts

--- a/packages/plugin-client/src/resolvers/resolverClient.ts
+++ b/packages/plugin-client/src/resolvers/resolverClient.ts
@@ -3,12 +3,18 @@ import { defineResolver } from '@kubb/core'
 import type { PluginClient } from '../types.ts'
 
 /**
- * Naming convention resolver for client plugin.
+ * Default resolver used by `@kubb/plugin-client`. Decides the names and file
+ * paths for every generated client function or class. Functions and files use
+ * camelCase; classes and tag groups use PascalCase.
  *
- * Provides default naming helpers using camelCase for functions and file paths.
+ * @example Resolve client function and class names
+ * ```ts
+ * import { resolverClient } from '@kubb/plugin-client'
  *
- * @example
- * `resolverClient.default('list pets', 'function')  // → 'listPets'`
+ * resolverClient.default('list pets', 'function') // 'listPets'
+ * resolverClient.resolveClassName('pet')          // 'Pet'
+ * resolverClient.resolveUrlName(operationNode)    // 'getShowPetByIdUrl'
+ * ```
  */
 export const resolverClient = defineResolver<PluginClient>(() => ({
   name: 'default',

--- a/packages/plugin-client/src/types.ts
+++ b/packages/plugin-client/src/types.ts
@@ -164,7 +164,7 @@ export type Options = {
   dataReturnType?: 'data' | 'full'
   /**
    * Rename parameter properties in the generated client (path, query, headers).
-   * The HTTP request still uses the original spec names — Kubb writes the mapping for you.
+   * The HTTP request still uses the original spec names; Kubb writes the mapping for you.
    *
    * @note Use the same value on `@kubb/plugin-ts` so types stay compatible.
    */

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -5,6 +5,11 @@ import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { Request } from '../components/Request.tsx'
 import type { PluginCypress } from '../types.ts'
 
+/**
+ * Built-in generator for `@kubb/plugin-cypress`. Emits one typed
+ * `cy.request()` wrapper per OpenAPI operation, ready to call inside Cypress
+ * test specs and custom commands.
+ */
 export const cypressGenerator = defineGenerator<PluginCypress>({
   name: 'cypress',
   renderer: jsxRendererSync,

--- a/packages/plugin-cypress/src/plugin.ts
+++ b/packages/plugin-cypress/src/plugin.ts
@@ -13,8 +13,8 @@ export const pluginCypressName = 'plugin-cypress' satisfies PluginCypress['name'
 
 /**
  * Generates one typed `cy.request()` wrapper per OpenAPI operation. Each helper
- * has typed path params, body, query, and a typed response — failing API calls
- * in Cypress show up at compile time instead of inside the test runner.
+ * has typed path params, body, query, and a typed response, so failing API
+ * calls in Cypress show up at compile time instead of inside the test runner.
  *
  * @example
  * ```ts

--- a/packages/plugin-cypress/src/resolvers/resolverCypress.ts
+++ b/packages/plugin-cypress/src/resolvers/resolverCypress.ts
@@ -3,12 +3,16 @@ import { defineResolver } from '@kubb/core'
 import type { PluginCypress } from '../types.ts'
 
 /**
- * Naming convention resolver for Cypress plugin.
+ * Default resolver used by `@kubb/plugin-cypress`. Decides the names and file
+ * paths for every generated `cy.request()` wrapper. Functions and files use
+ * camelCase, matching the convention from `@kubb/plugin-client`.
  *
- * Provides default naming helpers using camelCase for functions and file paths.
+ * @example Resolve a helper name
+ * ```ts
+ * import { resolverCypress } from '@kubb/plugin-cypress'
  *
- * @example
- * `resolverCypress.default('list pets', 'function')  // → 'listPets'`
+ * resolverCypress.default('list pets', 'function') // 'listPets'
+ * ```
  */
 export const resolverCypress = defineResolver<PluginCypress>(() => ({
   name: 'default',

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -7,6 +7,12 @@ import { printerFaker } from '../printers/printerFaker.ts'
 import type { PluginFaker } from '../types.ts'
 import { buildResponseUnionSchema, canOverrideSchema, localeToFakerImport, resolveParamNameByLocation, resolveTypeReference } from '../utils.ts'
 
+/**
+ * Built-in generator for `@kubb/plugin-faker`. Emits one `createX` factory
+ * per schema in the spec plus per-operation request/response factories. Each
+ * factory returns a value matching the corresponding TypeScript type from
+ * `@kubb/plugin-ts`.
+ */
 export const fakerGenerator = defineGenerator<PluginFaker>({
   name: 'faker',
   renderer: jsxRendererSync,

--- a/packages/plugin-faker/src/plugin.ts
+++ b/packages/plugin-faker/src/plugin.ts
@@ -13,7 +13,7 @@ export const pluginFakerName = 'plugin-faker' satisfies PluginFaker['name']
 
 /**
  * Generates one mock-data factory per OpenAPI schema using Faker.js. Call
- * `createPet()` to get a realistic `Pet` object — useful for tests, Storybook,
+ * `createPet()` to get a realistic `Pet` object. Useful for tests, Storybook,
  * and local development without a running backend.
  *
  * @example

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -3,12 +3,30 @@ import { ast } from '@kubb/core'
 import type { PluginFaker, ResolverFaker } from '../types.ts'
 
 /**
- * Partial printer nodes for Faker generation, mapping schema types to output strings.
+ * Partial map of node-type overrides for the Faker printer. Each key is a
+ * `SchemaType` (`'string'`, `'date'`, ...) and each handler returns the
+ * Faker expression for that schema as a string. Use `this.transform` to
+ * recurse into nested schema nodes and `this.options` to read printer options.
+ *
+ * @example Override the integer handler
+ * ```ts
+ * pluginFaker({
+ *   printer: {
+ *     nodes: {
+ *       integer() {
+ *         return 'faker.number.float()'
+ *       },
+ *     },
+ *   },
+ * })
+ * ```
  */
 export type PrinterFakerNodes = ast.PrinterPartial<string, PrinterFakerOptions>
 
 /**
- * Configuration options for the Faker printer, including resolvers, mappers, and cyclic schema tracking.
+ * Options passed to the Faker printer at instantiation: the parser library
+ * for date strings, the regex generator, the user-supplied schema-name
+ * mapper, and the resolver used to compute identifiers.
  */
 export type PrinterFakerOptions = {
   dateParser?: PluginFaker['resolvedOptions']['dateParser']

--- a/packages/plugin-faker/src/resolvers/resolverFaker.ts
+++ b/packages/plugin-faker/src/resolvers/resolverFaker.ts
@@ -5,12 +5,16 @@ import { defineResolver, KubbDriver } from '@kubb/core'
 import type { PluginFaker } from '../types.ts'
 
 /**
- * Naming convention resolver for Faker plugin.
+ * Default resolver used by `@kubb/plugin-faker`. Decides the names and file
+ * paths for every generated mock factory. Functions and files are prefixed
+ * with `create` so `Pet` becomes `createPet`.
  *
- * Provides default naming helpers using camelCase with a `create` prefix for factory functions and files.
+ * @example Resolve a factory name
+ * ```ts
+ * import { resolverFaker } from '@kubb/plugin-faker'
  *
- * @example
- * `resolverFaker.default('list pets', 'function')  // → 'createListPets'`
+ * resolverFaker.default('list pets', 'function') // 'createListPets'
+ * ```
  */
 export const resolverFaker = defineResolver<PluginFaker>(() => {
   return {

--- a/packages/plugin-faker/src/types.ts
+++ b/packages/plugin-faker/src/types.ts
@@ -127,8 +127,8 @@ export type Options = {
    */
   locale?: string
   /**
-   * Value passed to `faker.seed(...)`. Set this for deterministic mock output —
-   * useful for snapshot tests.
+   * Value passed to `faker.seed(...)`. Set this for deterministic mock output,
+   * which is useful for snapshot tests.
    */
   seed?: number | number[]
   /**

--- a/packages/plugin-mcp/src/generators/mcpGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/mcpGenerator.tsx
@@ -6,6 +6,12 @@ import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { McpHandler } from '../components/McpHandler.tsx'
 import type { PluginMcp } from '../types.ts'
 
+/**
+ * Built-in operation generator for `@kubb/plugin-mcp`. Emits one MCP tool
+ * handler per OpenAPI operation, wiring the input Zod schema, the HTTP call,
+ * and the response shape into a single function that an MCP server can
+ * register as a callable tool.
+ */
 export const mcpGenerator = defineGenerator<PluginMcp>({
   name: 'mcp',
   renderer: jsxRendererSync,

--- a/packages/plugin-mcp/src/resolvers/resolverMcp.ts
+++ b/packages/plugin-mcp/src/resolvers/resolverMcp.ts
@@ -3,12 +3,16 @@ import { defineResolver } from '@kubb/core'
 import type { PluginMcp } from '../types.ts'
 
 /**
- * Naming convention resolver for MCP plugin.
+ * Default resolver used by `@kubb/plugin-mcp`. Decides the names and file
+ * paths for every generated MCP tool handler. Function names get a `Handler`
+ * suffix so an operation `addPet` becomes `addPetHandler`.
  *
- * Provides default naming helpers using camelCase with a `handler` suffix for functions.
+ * @example Resolve a handler name
+ * ```ts
+ * import { resolverMcp } from '@kubb/plugin-mcp'
  *
- * @example
- * `resolverMcp.default('addPet', 'function')  // → 'addPetHandler'`
+ * resolverMcp.default('addPet', 'function') // 'addPetHandler'
+ * ```
  */
 export const resolverMcp = defineResolver<PluginMcp>(() => ({
   name: 'default',

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -36,7 +36,7 @@ export type Options = {
   client?: ClientImportPath & Pick<PluginClient['options'], 'clientType' | 'dataReturnType' | 'baseURL' | 'bundle' | 'paramsCasing'>
   /**
    * Rename parameter properties in the generated handlers. The HTTP layer still
-   * uses the original spec names — Kubb writes the mapping for you.
+   * uses the original spec names; Kubb writes the mapping for you.
    *
    * @note Must match the value of `paramsCasing` on `@kubb/plugin-ts`.
    */

--- a/packages/plugin-msw/src/generators/handlersGenerator.tsx
+++ b/packages/plugin-msw/src/generators/handlersGenerator.tsx
@@ -3,6 +3,12 @@ import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { Handlers } from '../components/Handlers.tsx'
 import type { PluginMsw } from '../types'
 
+/**
+ * Aggregate generator enabled by `pluginMsw({ handlers: true })`. Emits a
+ * `handlers.ts` file that re-exports every generated handler grouped by HTTP
+ * method, ready to spread into `setupServer(...handlers)` or
+ * `setupWorker(...handlers)`.
+ */
 export const handlersGenerator = defineGenerator<PluginMsw>({
   name: 'plugin-msw',
   renderer: jsxRendererSync,

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -7,6 +7,12 @@ import { Mock, MockWithFaker, Response } from '../components'
 import type { PluginMsw } from '../types'
 import { resolveFakerMeta } from '../utils.ts'
 
+/**
+ * Built-in operation generator for `@kubb/plugin-msw`. Emits one MSW handler
+ * per OpenAPI operation. With `parser: 'faker'` the handler returns a value
+ * from `@kubb/plugin-faker`; with `parser: 'data'` it returns a typed empty
+ * payload for tests to fill in.
+ */
 export const mswGenerator = defineGenerator<PluginMsw>({
   name: 'msw',
   renderer: jsxRendererSync,

--- a/packages/plugin-msw/src/plugin.ts
+++ b/packages/plugin-msw/src/plugin.ts
@@ -14,7 +14,7 @@ export const pluginMswName = 'plugin-msw' satisfies PluginMsw['name']
 
 /**
  * Generates MSW request handlers from an OpenAPI spec. Drop them into your
- * test setup or service worker to mock the API end-to-end — request path,
+ * test setup or service worker to mock the API end-to-end. Request path,
  * method, status, and response body all stay in sync with the spec. Combine
  * with `@kubb/plugin-faker` (via `parser: 'faker'`) to seed handlers with
  * realistic data.

--- a/packages/plugin-msw/src/resolvers/resolverMsw.ts
+++ b/packages/plugin-msw/src/resolvers/resolverMsw.ts
@@ -3,9 +3,16 @@ import { defineResolver } from '@kubb/core'
 import type { PluginMsw } from '../types.ts'
 
 /**
- * Naming convention resolver for MSW plugin.
+ * Default resolver used by `@kubb/plugin-msw`. Decides the names and file
+ * paths for every generated MSW handler. Function names get a `Handler`
+ * suffix; the aggregate export is always `handlers`.
  *
- * Provides default naming helpers using camelCase with a `handler` suffix.
+ * @example Resolve a handler name
+ * ```ts
+ * import { resolverMsw } from '@kubb/plugin-msw'
+ *
+ * resolverMsw.resolveName('addPet') // 'addPetHandler'
+ * ```
  */
 export const resolverMsw = defineResolver<PluginMsw>(() => ({
   name: 'default',

--- a/packages/plugin-react-query/src/generators/customHookOptionsFileGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/customHookOptionsFileGenerator.tsx
@@ -5,6 +5,12 @@ import { defineGenerator } from '@kubb/core'
 import { File, Function, jsxRendererSync } from '@kubb/renderer-jsx'
 import type { PluginReactQuery } from '../types'
 
+/**
+ * Scaffolds the user-editable `useCustomHookOptions` file when
+ * `pluginReactQuery({ customOptions: { ... } })` is configured. The file is
+ * only created when it does not already exist, so user edits persist across
+ * regeneration.
+ */
 export const customHookOptionsFileGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-custom-hook-options-file',
   renderer: jsxRendererSync,

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -9,6 +9,12 @@ import { resolveOperationOverrides } from '../utils.ts'
 type QueryOption = PluginReactQuery['resolvedOptions']['query']
 type MutationOption = PluginReactQuery['resolvedOptions']['mutation']
 
+/**
+ * Emits the `HookOptions` type used by `customOptions`. Enabled when
+ * `pluginReactQuery({ customOptions: { ... } })`. The generated type lists
+ * every hook keyed by name so user-supplied options stay in sync with the
+ * generated hooks at compile time.
+ */
 export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-hook-options',
   renderer: jsxRendererSync,

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -10,6 +10,12 @@ import { difference } from 'remeda'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginReactQuery } from '../types'
 
+/**
+ * Built-in generator for `useInfiniteQuery` hooks. Enabled when
+ * `pluginReactQuery({ infinite: { ... } })`. Emits one `useFooInfiniteQuery`
+ * hook per query operation, wiring the configured `nextParam` /
+ * `previousParam` paths into TanStack Query's cursor-based pagination.
+ */
 export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-infinite-query',
   renderer: jsxRendererSync,

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -10,6 +10,11 @@ import { difference } from 'remeda'
 import { Mutation, MutationKey, MutationOptions } from '../components'
 import type { PluginReactQuery } from '../types'
 
+/**
+ * Built-in generator for `useMutation` hooks. Emits one `useFooMutation` hook
+ * per POST/PUT/DELETE operation (configurable via `mutation.methods`) plus
+ * the matching `fooMutationKey` / `fooMutationOptions` helpers.
+ */
 export const mutationGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-mutation',
   renderer: jsxRendererSync,

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -10,6 +10,11 @@ import { difference } from 'remeda'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginReactQuery } from '../types'
 
+/**
+ * Built-in generator for `useQuery` hooks. Emits one `useFooQuery` hook per
+ * GET operation (configurable via `query.methods`) plus the matching
+ * `fooQueryKey` / `fooQueryOptions` helpers.
+ */
 export const queryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query',
   renderer: jsxRendererSync,

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -10,6 +10,12 @@ import { difference } from 'remeda'
 import { QueryKey, SuspenseInfiniteQuery, SuspenseInfiniteQueryOptions } from '../components'
 import type { PluginReactQuery } from '../types'
 
+/**
+ * Built-in generator for `useSuspenseInfiniteQuery` hooks. Enabled when both
+ * `suspense` and `infinite` are configured. Combines suspense semantics with
+ * cursor-based pagination — handlers throw promises while loading and pull
+ * additional pages on demand.
+ */
 export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-suspense-infinite-query',
   renderer: jsxRendererSync,

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -10,6 +10,12 @@ import { difference } from 'remeda'
 import { QueryKey, QueryOptions, SuspenseQuery } from '../components'
 import type { PluginReactQuery } from '../types'
 
+/**
+ * Built-in generator for `useSuspenseQuery` hooks. Enabled when
+ * `pluginReactQuery({ suspense: {} })`. Emits one `useFooSuspenseQuery` hook
+ * per query operation. Suspense queries throw promises while loading and
+ * require a `<Suspense>` boundary in the React tree. TanStack Query v5+ only.
+ */
 export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-suspense-query',
   renderer: jsxRendererSync,

--- a/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
+++ b/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
@@ -7,12 +7,23 @@ function capitalize(name: string): string {
 }
 
 /**
- * Naming convention resolver for React Query plugin.
+ * Default resolver used by `@kubb/plugin-react-query`. Decides the names and
+ * file paths for every generated TanStack Query hook (`useFooQuery`,
+ * `useFooMutation`, `useFooInfiniteQuery`, ...) and its companion helpers
+ * (`fooQueryKey`, `fooQueryOptions`).
  *
- * Provides default naming helpers using camelCase for functions and file paths.
+ * Functions and files use camelCase; hooks get the `use` prefix; suspense and
+ * infinite variants are suffixed with `Suspense`/`Infinite`.
  *
- * @example
- * `resolverReactQuery.default('list pets', 'function')  // → 'listPets'`
+ * @example Resolve hook and helper names
+ * ```ts
+ * import { resolverReactQuery } from '@kubb/plugin-react-query'
+ *
+ * resolverReactQuery.resolveQueryName(operationNode)       // 'useGetPetById'
+ * resolverReactQuery.resolveMutationName(operationNode)    // 'useUpdatePet'
+ * resolverReactQuery.resolveQueryKeyName(operationNode)    // 'getPetByIdQueryKey'
+ * resolverReactQuery.resolveQueryOptionsName(operationNode) // 'getPetByIdQueryOptions'
+ * ```
  */
 export const resolverReactQuery = defineResolver<PluginReactQuery>(() => ({
   name: 'default',

--- a/packages/plugin-redoc/src/redoc.tsx
+++ b/packages/plugin-redoc/src/redoc.tsx
@@ -13,6 +13,11 @@ type BuildDocsOptions = {
   templateOptions?: any
 }
 
+/**
+ * Renders a self-contained Redoc HTML page for an OpenAPI document. The page
+ * embeds the spec inline and pulls Redoc's bundle from a CDN at runtime, so
+ * the generated file works without further build steps.
+ */
 export async function getPageHTML(api: AdapterOas['document'], { title, disableGoogleFont, templateOptions }: BuildDocsOptions = {}) {
   const templateFileName = path.join(__dirname, '../static/redoc.hbs')
   const template = pkg.compile(fs.readFileSync(templateFileName).toString())

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -24,6 +24,12 @@ function getPerContentTypeName(dataName: string, suffix: string): string {
   return dataName + suffix
 }
 
+/**
+ * Built-in generator for `@kubb/plugin-ts`. Emits one TypeScript file per
+ * schema in the spec plus per-operation request, response, and parameter
+ * types. Drop-replace with a custom `Generator<PluginTs>` to change how
+ * TypeScript output is produced.
+ */
 export const typeGenerator = defineGenerator<PluginTs>({
   name: 'typescript',
   renderer: jsxRendererSync,

--- a/packages/plugin-ts/src/plugin.ts
+++ b/packages/plugin-ts/src/plugin.ts
@@ -12,7 +12,7 @@ export const pluginTsName = 'plugin-ts' satisfies PluginTs['name']
 
 /**
  * Generates TypeScript `type` aliases and `interface` declarations from an
- * OpenAPI spec. The foundation that every other Kubb plugin builds on —
+ * OpenAPI spec. The foundation that every other Kubb plugin builds on:
  * clients, query hooks, mocks, and validators all reference the names this
  * plugin produces.
  *

--- a/packages/plugin-ts/src/resolvers/resolverTs.ts
+++ b/packages/plugin-ts/src/resolvers/resolverTs.ts
@@ -3,20 +3,21 @@ import { defineResolver } from '@kubb/core'
 import type { PluginTs } from '../types.ts'
 
 /**
- * Resolver for `@kubb/plugin-ts` that provides the default naming and path-resolution
- * helpers used by the plugin. Import this in other plugins to resolve the exact names and
- * paths that `plugin-ts` generates without hardcoding the conventions.
+ * Default resolver used by `@kubb/plugin-ts`. Decides the names and file paths
+ * for every generated TypeScript type. Import this in other plugins that need
+ * to reference the exact names `plugin-ts` produces without duplicating the
+ * casing/file-layout rules.
  *
- * The `default` method is automatically injected by `defineResolver` — it uses `camelCase`
- * for identifiers/files and `pascalCase` for type names.
+ * The `default` method is supplied by `defineResolver`. It uses PascalCase for
+ * type names and PascalCase-with-isFile for files.
  *
- * @example
+ * @example Resolve a type and file name
  * ```ts
- * import { resolver } from '@kubb/plugin-ts'
+ * import { resolverTs } from '@kubb/plugin-ts'
  *
- * resolver.default('list pets', 'type')              // → 'ListPets'
- * resolver.resolveName('list pets status 200')        // → 'ListPetsStatus200'
- * resolver.resolvePathName('list pets', 'file')       // → 'listPets'
+ * resolverTs.default('list pets', 'type')        // 'ListPets'
+ * resolverTs.resolvePathName('list pets', 'file') // 'ListPets'
+ * resolverTs.resolveResponseStatusName(node, 200) // 'ListPetsStatus200'
  * ```
  */
 export const resolverTs = defineResolver<PluginTs>(() => {

--- a/packages/plugin-ts/src/types.ts
+++ b/packages/plugin-ts/src/types.ts
@@ -115,7 +115,7 @@ type EnumTypeOptions =
       /**
        * Suffix appended to the generated type alias name.
        *
-       * Only affects the type alias — the const object name is unchanged.
+       * Only affects the type alias; the const object name is unchanged.
        *
        * @default 'Key'
        * @example enumTypeSuffix: 'Value' → `export type PetStatusValue = …`
@@ -172,7 +172,7 @@ type EnumTypeOptions =
       enumTypeSuffix?: never
       /**
        * `enumKeyCasing` has no effect for this `enumType`.
-       * Literal and inlineLiteral modes emit only values — keys are discarded entirely.
+       * Literal and inlineLiteral modes emit only values; keys are discarded entirely.
        */
       enumKeyCasing?: never
     }

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -10,6 +10,12 @@ import { difference } from 'remeda'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginVueQuery } from '../types'
 
+/**
+ * Built-in generator for `useInfiniteQuery` composables. Enabled when
+ * `pluginVueQuery({ infinite: { ... } })`. Emits one `useFooInfiniteQuery`
+ * composable per query operation, wiring the configured cursor path into
+ * TanStack Query's cursor-based pagination.
+ */
 export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-infinite',
   renderer: jsxRendererSync,

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -10,6 +10,11 @@ import { difference } from 'remeda'
 import { Mutation, MutationKey } from '../components'
 import type { PluginVueQuery } from '../types'
 
+/**
+ * Built-in generator for `useMutation` composables. Emits one
+ * `useFooMutation` composable per POST/PUT/DELETE operation (configurable
+ * via `mutation.methods`) plus the matching `fooMutationKey` helper.
+ */
 export const mutationGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-mutation',
   renderer: jsxRendererSync,

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -10,6 +10,11 @@ import { difference } from 'remeda'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginVueQuery } from '../types'
 
+/**
+ * Built-in generator for `useQuery` composables. Emits one `useFooQuery`
+ * composable per GET operation (configurable via `query.methods`) plus the
+ * matching `fooQueryKey` / `fooQueryOptions` helpers.
+ */
 export const queryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query',
   renderer: jsxRendererSync,

--- a/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
+++ b/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
@@ -7,9 +7,20 @@ function capitalize(name: string): string {
 }
 
 /**
- * Naming convention resolver for Vue Query plugin.
+ * Default resolver used by `@kubb/plugin-vue-query`. Decides the names and
+ * file paths for every generated TanStack Query composable (`useFooQuery`,
+ * `useFooMutation`, `useFooInfiniteQuery`) and its companion helpers.
  *
- * Provides default naming helpers using camelCase for functions and file paths.
+ * Functions and files use camelCase; composables get the `use` prefix.
+ *
+ * @example Resolve composable and helper names
+ * ```ts
+ * import { resolverVueQuery } from '@kubb/plugin-vue-query'
+ *
+ * resolverVueQuery.resolveQueryName(operationNode)       // 'useGetPetById'
+ * resolverVueQuery.resolveQueryKeyName(operationNode)    // 'getPetByIdQueryKey'
+ * resolverVueQuery.resolveQueryOptionsName(operationNode) // 'getPetByIdQueryOptions'
+ * ```
  */
 export const resolverVueQuery = defineResolver<PluginVueQuery>(() => ({
   name: 'default',

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -17,6 +17,12 @@ type ZodMiniPrinterEntry = { printer: ReturnType<typeof printerZodMini>; guidTyp
 const zodPrinterCache = new WeakMap<ResolverZod, ZodPrinterEntry>()
 const zodMiniPrinterCache = new WeakMap<ResolverZod, ZodMiniPrinterEntry>()
 
+/**
+ * Built-in generator for `@kubb/plugin-zod`. Emits one Zod schema per
+ * schema in the spec plus per-operation request/response/parameter schemas.
+ * When `mini: true`, schemas use the Zod Mini functional API instead of
+ * chainable methods.
+ */
 export const zodGenerator = defineGenerator<PluginZod>({
   name: 'zod',
   renderer: jsxRendererSync,

--- a/packages/plugin-zod/src/resolvers/resolverZod.ts
+++ b/packages/plugin-zod/src/resolvers/resolverZod.ts
@@ -3,12 +3,17 @@ import { defineResolver } from '@kubb/core'
 import type { PluginZod } from '../types.ts'
 
 /**
- * Naming convention resolver for Zod plugin.
+ * Default resolver used by `@kubb/plugin-zod`. Decides the names and file
+ * paths for every generated Zod schema. Schemas use camelCase with a
+ * `Schema` suffix (`listPetsSchema`); their inferred types use PascalCase.
  *
- * Provides default naming helpers using camelCase with a `Schema` suffix for schemas.
+ * @example Resolve schema and type names
+ * ```ts
+ * import { resolverZod } from '@kubb/plugin-zod'
  *
- * @example
- * `resolverZod.default('list pets', 'function')  // → 'listPetsSchema'`
+ * resolverZod.default('list pets', 'function') // 'listPetsSchema'
+ * resolverZod.resolveSchemaTypeName('pet')     // 'PetSchema'
+ * ```
  */
 export const resolverZod = defineResolver<PluginZod>(() => {
   return {


### PR DESCRIPTION
## Summary

Extend the JSDoc rewrite from #185 to the rest of each plugin's public surface — the resolvers, generators, and printers that other plugins re-export and consume.

- **Resolvers** (`resolverTs`, `resolverClient`, `resolverZod`, `resolverFaker`, `resolverCypress`, `resolverMcp`, `resolverMsw`, `resolverReactQuery`, `resolverVueQuery`) — rewrite the top-level JSDoc with what each one produces and a concrete name/file example.
- **Generators** (`typeGenerator`, `zodGenerator`, `fakerGenerator`, all four client generators, `cypressGenerator`, `mcpGenerator`, `mswGenerator`, `handlersGenerator`, every React Query and Vue Query generator) — add a short JSDoc that says when the generator runs and what it emits.
- **Printers** — expand `PrinterFakerNodes` / `PrinterFakerOptions` descriptions and add a concrete override example.
- **plugin-redoc** — add JSDoc to `getPageHTML` describing the self-contained HTML output.

Also fixes the AI-y em-dashes the code review flagged:

- `plugin-{ts,client,cypress,faker,msw}/plugin.ts` intros (em-dashes used as commas/colons).
- `plugin-{ts,client,mcp,faker}/types.ts` (mid-sentence em-dashes).

## Test plan

- [x] `pnpm typecheck` passes for every package.

https://claude.ai/code/session_01Xugqs6g85WLdc1RbKfcMEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xugqs6g85WLdc1RbKfcMEs)_