### PR TITLE
ci: harden release pipeline and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Workflow and composite action changes are the highest-impact attack surface
+# for a supply-chain compromise; require explicit owner review on every change.
+# Enforcement also requires branch protection: "Require review from Code Owners"
+# on the main branch.
+
+.github/workflows/  @stijnvanhulle
+.github/actions/    @stijnvanhulle
+.github/CODEOWNERS  @stijnvanhulle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,12 @@ jobs:
           node-version: '22'
           cache: 'false'
 
+      - name: Reinstall dependencies (release hardening)
+        # Defense-in-depth: re-install so the release build does not implicitly
+        # trust a pnpm store restored from cache by the composite Setup Tools
+        # step. Lockfile integrity hashes still gate content.
+        run: pnpm install --frozen-lockfile --force
+
       - name: Build
         run: pnpm run build
 

--- a/.github/workflows/update-agents-skills.yml
+++ b/.github/workflows/update-agents-skills.yml
@@ -14,19 +14,22 @@ permissions: {}
 jobs:
   build-agents-md:
     runs-on: ubuntu-latest
+    # Skip fork PRs: they cannot push the resulting PR anyway, and we don't want
+    # to run a third-party action against fork-controlled .skills content.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Generate skills block
         id: build
-        uses: dave1010/skills-to-agents@12f69f287941dfafb2fcf761455e73a5c6361469  # v2
+        uses: dave1010/skills-to-agents@12f69f287941dfafb2fcf761455e73a5c6361469 # v2
         with:
           repo-root: .
           skills-dir: .skills
           agents-path: AGENTS.md
-      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         if: steps.build.outputs.changed == 'true'
         with:
           base: ${{ github.head_ref || github.ref_name }}


### PR DESCRIPTION
## Why

Security audit of GitHub Actions across `kubb-labs/{kubb,plugins,platform,config}` — this repo is well-hardened (SHA-pinned, scoped permissions, `permissions: {}` at workflow level), but two gaps remained, identical to the ones in `kubb-labs/kubb`:

1. **Release pipeline trusts the pnpm cache.** The `release.yml` Setup Tools step runs the shared composite, which always enables `actions/setup-node` `cache: 'pnpm'`. A poisoned pnpm store from an earlier job could theoretically survive into a release build.
2. **No CODEOWNERS** — workflow / composite action changes are the single most attractive target for a supply-chain attack and should always require an explicit second pair of eyes.

## What changed

- **`release.yml`**: insert a "Reinstall dependencies (release hardening)" step between Setup Tools and Build (`pnpm install --frozen-lockfile --force`). Re-fetches from registry so the release does not implicitly trust the restored pnpm store. Lockfile integrity hashes still gate content.
- **`update-agents-skills.yml`**: skip the job for fork PRs (`if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`). Forks can't push the resulting PR anyway, and we don't want a third-party action running against fork-controlled `.skills` content.
- **`CODEOWNERS`**: new file requiring owner review on `.github/workflows/**`, `.github/actions/**`, and `.github/CODEOWNERS` itself.

## Out of scope

- Per-user decision: no Dependabot.
- Existing SHA pins left as-is.

## Follow-up (manual)

CODEOWNERS only enforces review if branch protection on `main` has **"Require review from Code Owners"** enabled. Toggle in repo Settings → Branches.

## Test plan

- [ ] `pr.yml` runs green on this PR
- [ ] Next merged release-eligible PR exercises the new "Reinstall dependencies" step
- [ ] No `Unable to resolve action` errors

Ref: https://neciudan.dev/github-actions-poisoning

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJpz1ZGgU7KdLAHUV41aZK)_