### PR TITLE
refactor(plugin-ts): use `parserTs.print` from `@kubb/parser-ts`

### DIFF
--- a/.changeset/kubb-core-beta-24-alignment.md
+++ b/.changeset/kubb-core-beta-24-alignment.md
@@ -1,0 +1,14 @@
+---
+'@kubb/plugin-client': patch
+'@kubb/plugin-cypress': patch
+'@kubb/plugin-faker': patch
+'@kubb/plugin-mcp': patch
+'@kubb/plugin-msw': patch
+'@kubb/plugin-react-query': patch
+'@kubb/plugin-redoc': patch
+'@kubb/plugin-ts': patch
+'@kubb/plugin-vue-query': patch
+'@kubb/plugin-zod': patch
+---
+
+Align plugin release flow with the beta.24 core dependency update.

--- a/.changeset/plugin-ts-parserts-print.md
+++ b/.changeset/plugin-ts-parserts-print.md
@@ -1,0 +1,5 @@
+---
+'@kubb/plugin-ts': patch
+---
+
+Use `parserTs.print` instead of the removed standalone `print` / `safePrint` exports from `@kubb/parser-ts`. Requires `@kubb/parser-ts@^5.0.0-beta.24`.

--- a/packages/plugin-ts/src/components/Enum.tsx
+++ b/packages/plugin-ts/src/components/Enum.tsx
@@ -1,6 +1,6 @@
 import { camelCase, trimQuotes } from '@internals/utils'
 import type { ast } from '@kubb/core'
-import { safePrint } from '@kubb/parser-ts'
+import { parserTs } from '@kubb/parser-ts'
 import { File } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import { ENUM_TYPES_WITH_KEY_SUFFIX, ENUM_TYPES_WITH_RUNTIME_VALUE, ENUM_TYPES_WITH_TYPE_ONLY } from '../constants.ts'
@@ -72,11 +72,11 @@ export function Enum({ node, enumType, enumTypeSuffix, enumKeyCasing, resolver }
     <>
       {nameNode && (
         <File.Source name={enumName} isExportable isIndexable isTypeOnly={false}>
-          {safePrint(nameNode)}
+          {parserTs.print(nameNode)}
         </File.Source>
       )}
       <File.Source name={typeName} isIndexable isExportable={ENUM_TYPES_WITH_RUNTIME_VALUE.has(enumType)} isTypeOnly={ENUM_TYPES_WITH_TYPE_ONLY.has(enumType)}>
-        {safePrint(typeNode)}
+        {parserTs.print(typeNode)}
       </File.Source>
     </>
   )

--- a/packages/plugin-ts/src/factory.test.ts
+++ b/packages/plugin-ts/src/factory.test.ts
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/suspicious/noTemplateCurlyInString: just for testing */
 
-import { print } from '@kubb/parser-ts'
+import { parserTs } from '@kubb/parser-ts'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { format } from '#mocks'
@@ -23,7 +23,7 @@ import {
 const { factory } = ts
 
 const formatTS = (elements: ts.Node | (ts.Node | undefined)[]) => {
-  return format(print(...[elements].flat().filter(Boolean)))
+  return format(parserTs.print(...[elements].flat().filter(Boolean)))
 }
 
 describe('Code Generation', () => {
@@ -43,7 +43,7 @@ describe('Code Generation', () => {
   it('should create array declaration', () => {
     // Default arrayType: 'array' - generates (string | number)[]
     expect(
-      print(
+      parserTs.print(
         createArrayDeclaration({
           nodes: [factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword), factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)],
         })!,
@@ -52,7 +52,7 @@ describe('Code Generation', () => {
 
     // arrayType: 'generic' - generates Array<string | number>
     expect(
-      print(
+      parserTs.print(
         createArrayDeclaration({
           nodes: [factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword), factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)],
           arrayType: 'generic',
@@ -62,7 +62,7 @@ describe('Code Generation', () => {
 
     // Single node with default arrayType: 'array' - generates string[]
     expect(
-      print(
+      parserTs.print(
         createArrayDeclaration({
           nodes: [factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)],
         })!,
@@ -71,7 +71,7 @@ describe('Code Generation', () => {
 
     // Single node with arrayType: 'generic' - generates Array<string>
     expect(
-      print(
+      parserTs.print(
         createArrayDeclaration({
           nodes: [factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)],
           arrayType: 'generic',
@@ -82,7 +82,7 @@ describe('Code Generation', () => {
 
   it('should create intersection declaration', () => {
     expect(
-      print(
+      parserTs.print(
         createIntersectionDeclaration({
           nodes: [factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword), factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)],
         })!,
@@ -91,7 +91,7 @@ describe('Code Generation', () => {
   })
   it('should create union declaration', () => {
     expect(
-      print(
+      parserTs.print(
         createUnionDeclaration({
           nodes: [factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword), factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword)],
         })!,
@@ -100,7 +100,7 @@ describe('Code Generation', () => {
   })
   it('should create property signature', () => {
     expect(
-      print(
+      parserTs.print(
         createPropertySignature({
           modifiers: [modifiers.const],
           name: 'hello',
@@ -112,14 +112,14 @@ describe('Code Generation', () => {
 
   it('should create parameter signature', () => {
     expect(
-      print(
+      parserTs.print(
         createParameterSignature('hello', {
           type: factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
         })!,
       ),
     ).toMatchSnapshot()
     expect(
-      print(
+      parserTs.print(
         createParameterSignature('hello', {
           questionToken: true,
           type: factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
@@ -127,7 +127,7 @@ describe('Code Generation', () => {
       ),
     ).toMatchSnapshot()
     expect(
-      print(
+      parserTs.print(
         createParameterSignature('hello', {
           questionToken: true,
           type: factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword),
@@ -446,8 +446,8 @@ describe('Import/Export Sorting Consistency', () => {
       path: './test.ts',
     })
 
-    const output1 = print(import1)
-    const output2 = print(import2)
+    const output1 = parserTs.print(import1)
+    const output2 = parserTs.print(import2)
 
     // Both should produce the same sorted output
     expect(output1).toBe(output2)
@@ -465,8 +465,8 @@ describe('Import/Export Sorting Consistency', () => {
       path: './animals.ts',
     })
 
-    const output1 = print(export1)
-    const output2 = print(export2)
+    const output1 = parserTs.print(export1)
+    const output2 = parserTs.print(export2)
 
     // Both should produce the same sorted output
     expect(output1).toBe(output2)
@@ -479,7 +479,7 @@ describe('Import/Export Sorting Consistency', () => {
       path: './mixed.ts',
     })
 
-    const output = print(import1)
+    const output = parserTs.print(import1)
 
     // Should be sorted alphabetically: apple, banana as yellow, monkey, zoo
     expect(output).toContain('apple, banana as yellow, monkey, zoo')
@@ -504,9 +504,9 @@ describe('Import/Export Sorting Consistency', () => {
       path: './services.ts',
     })
 
-    const output1 = print(import1)
-    const output2 = print(import2)
-    const output3 = print(import3)
+    const output1 = parserTs.print(import1)
+    const output2 = parserTs.print(import2)
+    const output3 = parserTs.print(import3)
 
     // All three should produce identical output regardless of input order
     expect(output1).toBe(output2)
@@ -517,43 +517,43 @@ describe('Import/Export Sorting Consistency', () => {
   it('should create URL template type for path without parameters', () => {
     const result = createUrlTemplateType('/pets')
 
-    expect(print(result).trim()).toBe('"/pets"')
+    expect(parserTs.print(result).trim()).toBe('"/pets"')
   })
 
   it('should create URL template type for path with single parameter', () => {
     const result = createUrlTemplateType('/pets/{petId}')
 
-    expect(print(result).trim()).toBe('`/pets/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/pets/${string}`')
   })
 
   it('should create URL template type for path with multiple parameters', () => {
     const result = createUrlTemplateType('/pets/{petId}/owner/{ownerId}')
 
-    expect(print(result).trim()).toBe('`/pets/${string}/owner/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/pets/${string}/owner/${string}`')
   })
 
   it('should create URL template type for path with parameter at start', () => {
     const result = createUrlTemplateType('/{category}/pets')
 
-    expect(print(result).trim()).toBe('`/${string}/pets`')
+    expect(parserTs.print(result).trim()).toBe('`/${string}/pets`')
   })
 
   it('should create URL template type for path with parameter at end', () => {
     const result = createUrlTemplateType('/user/{username}')
 
-    expect(print(result).trim()).toBe('`/user/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/user/${string}`')
   })
 
   it('should create URL template type for complex path', () => {
     const result = createUrlTemplateType('/pet/findByStatus/{step_id}')
 
-    expect(print(result).trim()).toBe('`/pet/findByStatus/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/pet/findByStatus/${string}`')
   })
 
   it('should create URL template type for path with consecutive parameters', () => {
     const result = createUrlTemplateType('/api/{version}/{resource}')
 
-    expect(print(result).trim()).toBe('`/api/${string}/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/api/${string}/${string}`')
   })
 })
 
@@ -561,30 +561,30 @@ describe('createUrlTemplateType (Express-style paths)', () => {
   it('returns a string literal for paths without params', () => {
     const result = createUrlTemplateType('/pets')
 
-    expect(print(result).trim()).toBe('"/pets"')
+    expect(parserTs.print(result).trim()).toBe('"/pets"')
   })
 
   it('converts a single Express path param to a template literal', () => {
     const result = createUrlTemplateType('/pets/:petId')
 
-    expect(print(result).trim()).toBe('`/pets/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/pets/${string}`')
   })
 
   it('converts multiple Express path params to a template literal', () => {
     const result = createUrlTemplateType('/store/:storeId/order/:orderId')
 
-    expect(print(result).trim()).toBe('`/store/${string}/order/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/store/${string}/order/${string}`')
   })
 
   it('handles trailing static segments after params', () => {
     const result = createUrlTemplateType('/pets/:petId/photos')
 
-    expect(print(result).trim()).toBe('`/pets/${string}/photos`')
+    expect(parserTs.print(result).trim()).toBe('`/pets/${string}/photos`')
   })
 
   it('handles consecutive params', () => {
     const result = createUrlTemplateType('/api/:version/:resource')
 
-    expect(print(result).trim()).toBe('`/api/${string}/${string}`')
+    expect(parserTs.print(result).trim()).toBe('`/api/${string}/${string}`')
   })
 })

--- a/packages/plugin-ts/src/printers/printerTs.test.ts
+++ b/packages/plugin-ts/src/printers/printerTs.test.ts
@@ -1,5 +1,5 @@
 import { ast } from '@kubb/core'
-import { print } from '@kubb/parser-ts'
+import { parserTs } from '@kubb/parser-ts'
 import ts from 'typescript'
 import { describe, expect, it } from 'vitest'
 import { format } from '#mocks'
@@ -14,7 +14,7 @@ const formatTS = async (node: ts.Node | null | undefined): Promise<string> => {
   if (!node) return ''
 
   const alias = ts.factory.createTypeAliasDeclaration(undefined, '_', undefined, node as ts.TypeNode)
-  const source = print(alias)
+  const source = parserTs.print(alias)
   const formatted = await format(source)
 
   return formatted

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -1,5 +1,5 @@
 import { ast } from '@kubb/core'
-import { safePrint } from '@kubb/parser-ts'
+import { parserTs } from '@kubb/parser-ts'
 import type ts from 'typescript'
 import { ENUM_TYPES_WITH_KEY_SUFFIX, OPTIONAL_ADDS_QUESTION_TOKEN, OPTIONAL_ADDS_UNDEFINED } from '../constants.ts'
 import * as factory from '../factory.ts'
@@ -292,7 +292,7 @@ export const printerTs = ast.definePrinter<PrinterTs>((options) => {
           (meta.nullish || meta.optional) && addsUndefined
             ? factory.createUnionDeclaration({ nodes: [withNullable, factory.keywordTypeNodes.undefined] })
             : withNullable
-        return safePrint(result)
+        return parserTs.print(result)
       }
 
       // When keysToOmit is present, wrap with Omit first, then apply nullable/optional
@@ -320,7 +320,7 @@ export const printerTs = ast.definePrinter<PrinterTs>((options) => {
         }),
       })
 
-      return safePrint(typeNode)
+      return parserTs.print(typeNode)
     },
   }
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,23 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     '@kubb/agent':
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     '@kubb/core':
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     '@kubb/middleware-barrel':
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     '@kubb/parser-ts':
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     '@kubb/renderer-jsx':
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     '@size-limit/file':
       specifier: ^12.1.0
       version: 12.1.0
@@ -40,8 +40,8 @@ catalogs:
       specifier: ^4.1.6
       version: 4.1.6
     kubb:
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     oxfmt:
       specifier: ^0.47.0
       version: 0.47.0
@@ -64,8 +64,8 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     unplugin-kubb:
-      specifier: 5.0.0-beta.23
-      version: 5.0.0-beta.23
+      specifier: 5.0.0-beta.24
+      version: 5.0.0-beta.24
     vitest:
       specifier: ^4.1.6
       version: 4.1.6
@@ -82,16 +82,16 @@ importers:
         version: 2.31.0(@types/node@22.19.19)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/middleware-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))
+        version: 5.0.0-beta.24(@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -227,16 +227,16 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/agent':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -245,13 +245,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -260,13 +260,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -288,7 +288,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -307,7 +307,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -322,7 +322,7 @@ importers:
         version: 1.11.20
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -335,7 +335,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -344,7 +344,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
     devDependencies:
       react:
         specifier: ^19.2.6
@@ -357,13 +357,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -372,13 +372,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -394,7 +394,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-mcp':
         specifier: workspace:*
         version: link:../../packages/plugin-mcp
@@ -412,7 +412,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -428,7 +428,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -446,7 +446,7 @@ importers:
         version: 0.10.3(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -465,7 +465,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -486,7 +486,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -495,7 +495,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(@kubb/renderer-jsx@5.0.0-beta.23)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
+        version: 5.0.0-beta.24(@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(@kubb/renderer-jsx@5.0.0-beta.24)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -520,7 +520,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -529,7 +529,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -539,7 +539,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -563,7 +563,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -578,7 +578,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -587,7 +587,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -597,7 +597,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -618,7 +618,7 @@ importers:
         version: 1.16.1
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(@kubb/renderer-jsx@5.0.0-beta.23)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
+        version: 5.0.0-beta.24(@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(@kubb/renderer-jsx@5.0.0-beta.24)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0))
       vue:
         specifier: ^3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -652,7 +652,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -670,7 +670,7 @@ importers:
         version: link:../utils
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -686,13 +686,13 @@ importers:
         version: link:../utils
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -708,7 +708,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
@@ -717,7 +717,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -733,13 +733,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -752,13 +752,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -768,7 +768,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -780,7 +780,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -793,7 +793,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../plugin-faker
@@ -802,7 +802,7 @@ importers:
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -815,7 +815,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -827,7 +827,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -846,10 +846,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -862,13 +862,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -887,7 +887,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -899,7 +899,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -918,10 +918,10 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23
+        version: 5.0.0-beta.24
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -937,13 +937,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -989,7 +989,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1025,7 +1025,7 @@ importers:
         version: 15.15.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -1056,10 +1056,10 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+        version: 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1074,7 +1074,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3)
+        version: 5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1713,26 +1713,26 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@kubb/adapter-oas@5.0.0-beta.23':
-    resolution: {integrity: sha512-X7ZtUrtXnRQFcdooLXUQbpFMUQdeDNRt6VejY0mqeg1n+8oHMDXNFyhWEx3WJRf8NKRPCTigqyaLq1kOj1fkAA==}
+  '@kubb/adapter-oas@5.0.0-beta.24':
+    resolution: {integrity: sha512-RkVInAS1kUgyhcdTcc9deCYkwcKqO98hYalylVbLGR57LlWO1akDi37BOORPFrQTCDgDlKh9UkwhVRpdyGMf7w==}
     engines: {node: '>=22'}
 
-  '@kubb/agent@5.0.0-beta.23':
-    resolution: {integrity: sha512-+RsAysWoFqCIudMuD6i4VcPGg/b184PrXuvzEx4t+/98/08cge8MU+8CRmHmDU18fRjIMQLPXnPyQBX5sDBghA==}
+  '@kubb/agent@5.0.0-beta.24':
+    resolution: {integrity: sha512-444YJrq8tAtPDBbc5PHYTqgQun/Eh4QlCO72EFr783LSw2CRIvjD6U5Qeo5eK0HVvkyerqPhzgwKyWrGvWX5Jw==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-beta.23':
-    resolution: {integrity: sha512-XUXD4yu2PrhfIT56b0ohROhzP5XwWQUcF/h1Q692xeZ6tzcUEQqVJHvHS6t3TqextdhFES8sJKwg9l9UEFDA4Q==}
+  '@kubb/ast@5.0.0-beta.24':
+    resolution: {integrity: sha512-3mtspdXKwzT5vTdJD6iJRRMM4vCYUUpxAUzeufeBYdDYK73ClqQ0zlC+vU8oI2GRZEyBE1zVkOTNEZL9ZtN5sg==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-beta.23':
-    resolution: {integrity: sha512-Z0YEmCISXBY48Rlh1wwa2e0R0QL/5P37Bi9zokKxW8bbd2FG1eROJAYcC5ihbAxgzAFjSdsYIl5dVkzzzcJugA==}
+  '@kubb/cli@5.0.0-beta.24':
+    resolution: {integrity: sha512-2kagDqO4tvabpTCg/CaUFrLPKaDRhuGOhmr9MtGs0r+7MfODItsuUra02+vMTGJ7UQTAf9ug0qw4Q1Xfuizozw==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.23
-      '@kubb/agent': 5.0.0-beta.23
-      '@kubb/mcp': 5.0.0-beta.23
+      '@kubb/adapter-oas': 5.0.0-beta.24
+      '@kubb/agent': 5.0.0-beta.24
+      '@kubb/mcp': 5.0.0-beta.24
     peerDependenciesMeta:
       '@kubb/adapter-oas':
         optional: true
@@ -1741,31 +1741,31 @@ packages:
       '@kubb/mcp':
         optional: true
 
-  '@kubb/core@5.0.0-beta.23':
-    resolution: {integrity: sha512-dcTA59LtiRwvpC37XFd42Ke5mITTECcHuRRrWIz4SFdQJe9BZGHezEXbY2cmTsi2ZVGrA9SNAXv9H7jxon6TUw==}
+  '@kubb/core@5.0.0-beta.24':
+    resolution: {integrity: sha512-y0bTtlcjrowNT2ApACx/v2hIBzJC7F6owD9EifAoN72YcHtK6yp3WC411ikdE3bVq7j1S8pM4MhfMRVzW9JJpw==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.23
+      '@kubb/renderer-jsx': 5.0.0-beta.24
 
-  '@kubb/mcp@5.0.0-beta.23':
-    resolution: {integrity: sha512-X0Ip0RMhaTvEkIgCTFxJRKZvFqK2Kgg2D1viC4eT/jUCYBtE9lK2GF5ULkgSi12cTJbtH9TdHJUJr1FTTijbnQ==}
+  '@kubb/mcp@5.0.0-beta.24':
+    resolution: {integrity: sha512-yeZ+Rm9tvSCEX6WT2fbnK/waTUQZ7F4i1Cy5mcORZh+NnRSZx3jnf45O3IKcfkcowSnStxo5ZPHESacOU9k3wA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.23
+      '@kubb/renderer-jsx': 5.0.0-beta.24
 
-  '@kubb/middleware-barrel@5.0.0-beta.23':
-    resolution: {integrity: sha512-hlYIJYJd4qR79GvVcaLdrTFj4lNcFMid94+OeUUmBt2NWDGS7deDV4eXCVVEV9iUfQGSeQ9UJbOIOEnMw5Ip+Q==}
+  '@kubb/middleware-barrel@5.0.0-beta.24':
+    resolution: {integrity: sha512-eU0Qjr1QKSaVi+muqyX45Dv2Tb5NaaXEsHW9tvo3gM4b9RZAaEPVco1FuoLJmR3Tlzf8R2bbN2oNvbdCRrsJxQ==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-beta.23
+      '@kubb/core': 5.0.0-beta.24
 
-  '@kubb/parser-ts@5.0.0-beta.23':
-    resolution: {integrity: sha512-yHTFlHkT6nFCsUIBGglgd1UK5baYADOlejW3lSYVmBLFtxRX2kkZ2p05nIudwExiii2jA1Y5X9WFOVTV7GXAiw==}
+  '@kubb/parser-ts@5.0.0-beta.24':
+    resolution: {integrity: sha512-O+lPR4wZDe6J9sP2qyTvRQQqqNqeoN3gv0PF/lLgUNej4/4Cx3L56Tj7a/mQA6gCSNl8Szc2jOUzgQt4WAcVRQ==}
     engines: {node: '>=22'}
 
-  '@kubb/renderer-jsx@5.0.0-beta.23':
-    resolution: {integrity: sha512-eLeh6ag+XYn4GDOlVPV29Rm/wDM6MxyL7BBhYDD5xq5+rz+dKgSVQNBPXOAr90ytdeh/h45InJ5d3JlyJBrZVQ==}
+  '@kubb/renderer-jsx@5.0.0-beta.24':
+    resolution: {integrity: sha512-ca9lehJ6BIVpkdDayUb2F6S+VIV/e3Y16tmuJxaC1pjpc8YfI6mHmB21rHURcPkNw3GrWgPgRw47N0gKp8tqTA==}
     engines: {node: '>=22'}
 
   '@logtail/core@0.5.8':
@@ -3776,12 +3776,12 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-beta.23:
-    resolution: {integrity: sha512-vesGzHwMquspsvYZ0Ba2DIcSlU8WHoEqZgENf37pkb6OS9m5VjRjpetdiGMy8VS959bxkFog1ghxmSYdRuKIwg==}
+  kubb@5.0.0-beta.24:
+    resolution: {integrity: sha512-zAWmUMHYnkPsMAKQtTu9LLGnhTzJwseyCrGQo+Or6Gt4nCYgEHTM+BxoMv5WYVLyGbHFmx7YMs0iOZ60NO7juA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/agent': 5.0.0-beta.23
+      '@kubb/agent': 5.0.0-beta.24
     peerDependenciesMeta:
       '@kubb/agent':
         optional: true
@@ -4868,8 +4868,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-beta.23:
-    resolution: {integrity: sha512-cSAPRaMgvU8vc4iWm9tES99wY1N9v3vZqtXrcyyk5LEeStNlJQyPqKoVGEJuCF+kpiWKoMD2I1f3Gvn0uUprfw==}
+  unplugin-kubb@5.0.0-beta.24:
+    resolution: {integrity: sha512-cMR19ThdPvgwjOV6bUpbLnk2d2RetaYPd7LvWKSxM9oQgm8/j8Pb2KCEArD41DFELz1EiXBcWD/56hqODRYKPQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -5887,9 +5887,9 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kubb/adapter-oas@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)':
+  '@kubb/adapter-oas@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@redocly/openapi-core': 2.30.6
       oas: 32.1.18
       oas-normalize: 16.0.4
@@ -5898,10 +5898,10 @@ snapshots:
       - '@kubb/renderer-jsx'
       - encoding
 
-  '@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)':
+  '@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.23
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+      '@kubb/ast': 5.0.0-beta.24
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       '@logtail/node': 0.5.8
       consola: 3.4.2
       jiti: 2.7.0
@@ -5933,36 +5933,36 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@kubb/ast@5.0.0-beta.23': {}
+  '@kubb/ast@5.0.0-beta.24': {}
 
-  '@kubb/cli@5.0.0-beta.23(@kubb/adapter-oas@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(@kubb/mcp@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.23)(typescript@6.0.3)':
+  '@kubb/cli@5.0.0-beta.24(@kubb/adapter-oas@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(@kubb/mcp@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.24)(typescript@6.0.3)':
     dependencies:
       '@clack/prompts': 1.4.0
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       chokidar: 5.0.0
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.7.0
       tinyexec: 1.1.2
     optionalDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/agent': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/mcp': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)(typescript@6.0.3)
+      '@kubb/adapter-oas': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/agent': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/mcp': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
       - typescript
 
-  '@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)':
+  '@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.23
-      '@kubb/renderer-jsx': 5.0.0-beta.23
+      '@kubb/ast': 5.0.0-beta.24
+      '@kubb/renderer-jsx': 5.0.0-beta.24
       fflate: 0.8.3
       tinyexec: 1.1.2
 
-  '@kubb/mcp@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)(typescript@6.0.3)':
+  '@kubb/mcp@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)(typescript@6.0.3)':
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/renderer-jsx': 5.0.0-beta.23
+      '@kubb/adapter-oas': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/renderer-jsx': 5.0.0-beta.24
       '@remix-run/node-fetch-server': 0.13.1
       '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.0(typescript@6.0.3))
       '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@6.0.3))
@@ -5975,21 +5975,21 @@ snapshots:
       - encoding
       - typescript
 
-  '@kubb/middleware-barrel@5.0.0-beta.23(@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))':
+  '@kubb/middleware-barrel@5.0.0-beta.24(@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.23
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+      '@kubb/ast': 5.0.0-beta.24
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
 
-  '@kubb/parser-ts@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)':
+  '@kubb/parser-ts@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/renderer-jsx@5.0.0-beta.23':
+  '@kubb/renderer-jsx@5.0.0-beta.24':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.23
+      '@kubb/ast': 5.0.0-beta.24
 
   '@logtail/core@0.5.8':
     dependencies:
@@ -7954,17 +7954,17 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-beta.23(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(typescript@6.0.3):
+  kubb@5.0.0-beta.24(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(typescript@6.0.3):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/cli': 5.0.0-beta.23(@kubb/adapter-oas@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(@kubb/agent@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(@kubb/mcp@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.23)(typescript@6.0.3)
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/mcp': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)(typescript@6.0.3)
-      '@kubb/middleware-barrel': 5.0.0-beta.23(@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))
-      '@kubb/parser-ts': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/renderer-jsx': 5.0.0-beta.23
+      '@kubb/adapter-oas': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/cli': 5.0.0-beta.24(@kubb/adapter-oas@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(@kubb/agent@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(@kubb/mcp@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.24)(typescript@6.0.3)
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/mcp': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)(typescript@6.0.3)
+      '@kubb/middleware-barrel': 5.0.0-beta.24(@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))
+      '@kubb/parser-ts': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/renderer-jsx': 5.0.0-beta.24
     optionalDependencies:
-      '@kubb/agent': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+      '@kubb/agent': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - encoding
@@ -9112,12 +9112,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-beta.23(@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))(@kubb/renderer-jsx@5.0.0-beta.23)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.24(@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))(@kubb/renderer-jsx@5.0.0-beta.24)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.1)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/core': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
-      '@kubb/middleware-barrel': 5.0.0-beta.23(@kubb/core@5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23))
-      '@kubb/parser-ts': 5.0.0-beta.23(@kubb/renderer-jsx@5.0.0-beta.23)
+      '@kubb/adapter-oas': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/core': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
+      '@kubb/middleware-barrel': 5.0.0-beta.24(@kubb/core@5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24))
+      '@kubb/parser-ts': 5.0.0-beta.24(@kubb/renderer-jsx@5.0.0-beta.24)
       unplugin: 3.0.0
     optionalDependencies:
       esbuild: 0.28.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,18 +12,18 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.23
-  '@kubb/agent': 5.0.0-beta.23
-  '@kubb/core': 5.0.0-beta.23
-  '@kubb/middleware-barrel': 5.0.0-beta.23
-  '@kubb/parser-ts': 5.0.0-beta.23
-  '@kubb/renderer-jsx': 5.0.0-beta.23
+  '@kubb/adapter-oas': 5.0.0-beta.24
+  '@kubb/agent': 5.0.0-beta.24
+  '@kubb/core': 5.0.0-beta.24
+  '@kubb/middleware-barrel': 5.0.0-beta.24
+  '@kubb/parser-ts': 5.0.0-beta.24
+  '@kubb/renderer-jsx': 5.0.0-beta.24
   '@size-limit/file': ^12.1.0
   '@types/node': ^22.19.19
   '@types/react': ^19.2.14
   '@vitest/coverage-v8': ^4.1.6
   '@vitest/ui': ^4.1.6
-  kubb: 5.0.0-beta.23
+  kubb: 5.0.0-beta.24
   oxfmt: ^0.47.0
   oxlint: ^1.65.0
   prettier: ^3.8.3
@@ -31,7 +31,7 @@ catalog:
   'size-limit': ^12.1.0
   tsdown: ^0.22.0
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.23
+  unplugin-kubb: 5.0.0-beta.24
   vitest: ^4.1.6
 
 minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age


### PR DESCRIPTION
## Summary

- Replace `import { print } from '@kubb/parser-ts'` / `import { safePrint } from '@kubb/parser-ts'` with `import { parserTs } from '@kubb/parser-ts'` and call `parserTs.print(...)`.
- Touches four files: `printers/printerTs.ts`, `printers/printerTs.test.ts`, `components/Enum.tsx`, `factory.test.ts`.
- `safePrint` only added a `SyntaxKind.Unknown` guard on top of `print`; that check has never fired for plugin-ts's own factory-built nodes, so the switch is a no-op in practice.

## Depends on

- [kubb-labs/kubb#3356](https://github.com/kubb-labs/kubb/pull/3356) — `@kubb/parser-ts@^5.0.0-beta.24` (or canary). Land that first, publish the parser-ts beta, bump the catalog pin in `pnpm-workspace.yaml`, then merge this.

## Test plan

- [x] `pnpm format` + `pnpm lint` clean
- [ ] `pnpm --filter @kubb/plugin-ts typecheck` — passes once the catalog is bumped to the new parser-ts beta
- [ ] `pnpm --filter @kubb/plugin-ts test` — passes once the catalog is bumped to the new parser-ts beta


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSW2n8JhiJ5eqMDELwGMa5)_