### PR TITLE
chore: enforce Array<T> via oxlint typescript/array-type rule

### DIFF
--- a/.changeset/enforce-array-type-syntax.md
+++ b/.changeset/enforce-array-type-syntax.md
@@ -1,0 +1,13 @@
+---
+'@kubb/plugin-client': patch
+'@kubb/plugin-cypress': patch
+'@kubb/plugin-faker': patch
+'@kubb/plugin-mcp': patch
+'@kubb/plugin-msw': patch
+'@kubb/plugin-react-query': patch
+'@kubb/plugin-ts': patch
+'@kubb/plugin-vue-query': patch
+'@kubb/plugin-zod': patch
+---
+
+Enforce `Array<T>` syntax (over `T[]`) via the oxlint `typescript/array-type` rule. Internal-only change; no runtime or API impact.

--- a/examples/client/src/gen2/models/AddPetRequest.ts
+++ b/examples/client/src/gen2/models/AddPetRequest.ts
@@ -35,11 +35,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen2/models/CreateUsersWithListInput.ts
+++ b/examples/client/src/gen2/models/CreateUsersWithListInput.ts
@@ -18,7 +18,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/client/src/gen2/models/Customer.ts
+++ b/examples/client/src/gen2/models/Customer.ts
@@ -22,5 +22,5 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }

--- a/examples/client/src/gen2/models/FindPetsByStatus.ts
+++ b/examples/client/src/gen2/models/FindPetsByStatus.ts
@@ -15,7 +15,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen2/models/FindPetsByTags.ts
+++ b/examples/client/src/gen2/models/FindPetsByTags.ts
@@ -9,7 +9,7 @@ import type { Pet } from './Pet.ts'
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -26,7 +26,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen2/models/Pet.ts
+++ b/examples/client/src/gen2/models/Pet.ts
@@ -35,11 +35,11 @@ export type Pet = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen2/models/UserArray.ts
+++ b/examples/client/src/gen2/models/UserArray.ts
@@ -8,4 +8,4 @@ import type { User } from './User.ts'
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>

--- a/examples/client/src/gen3/models/ts/AddPetRequest.ts
+++ b/examples/client/src/gen3/models/ts/AddPetRequest.ts
@@ -35,11 +35,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen3/models/ts/Customer.ts
+++ b/examples/client/src/gen3/models/ts/Customer.ts
@@ -22,5 +22,5 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }

--- a/examples/client/src/gen3/models/ts/Pet.ts
+++ b/examples/client/src/gen3/models/ts/Pet.ts
@@ -35,11 +35,11 @@ export type Pet = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen3/models/ts/UserArray.ts
+++ b/examples/client/src/gen3/models/ts/UserArray.ts
@@ -8,4 +8,4 @@ import type { User } from './User.ts'
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>

--- a/examples/client/src/gen3/models/ts/petController/FindPetsByStatus.ts
+++ b/examples/client/src/gen3/models/ts/petController/FindPetsByStatus.ts
@@ -15,7 +15,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen3/models/ts/petController/FindPetsByTags.ts
+++ b/examples/client/src/gen3/models/ts/petController/FindPetsByTags.ts
@@ -9,7 +9,7 @@ import type { Pet } from '../Pet.ts'
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -26,7 +26,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen3/models/ts/userController/CreateUsersWithListInput.ts
+++ b/examples/client/src/gen3/models/ts/userController/CreateUsersWithListInput.ts
@@ -18,7 +18,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/client/src/gen6/models/ts/AddPetRequest.ts
+++ b/examples/client/src/gen6/models/ts/AddPetRequest.ts
@@ -35,11 +35,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen6/models/ts/Customer.ts
+++ b/examples/client/src/gen6/models/ts/Customer.ts
@@ -22,5 +22,5 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }

--- a/examples/client/src/gen6/models/ts/Pet.ts
+++ b/examples/client/src/gen6/models/ts/Pet.ts
@@ -35,11 +35,11 @@ export type Pet = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen6/models/ts/UserArray.ts
+++ b/examples/client/src/gen6/models/ts/UserArray.ts
@@ -8,4 +8,4 @@ import type { User } from './User.ts'
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>

--- a/examples/client/src/gen6/models/ts/petController/FindPetsByStatus.ts
+++ b/examples/client/src/gen6/models/ts/petController/FindPetsByStatus.ts
@@ -15,7 +15,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen6/models/ts/petController/FindPetsByTags.ts
+++ b/examples/client/src/gen6/models/ts/petController/FindPetsByTags.ts
@@ -9,7 +9,7 @@ import type { Pet } from '../Pet.ts'
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -26,7 +26,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen6/models/ts/userController/CreateUsersWithListInput.ts
+++ b/examples/client/src/gen6/models/ts/userController/CreateUsersWithListInput.ts
@@ -18,7 +18,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/client/src/gen7/models/ts/AddPetRequest.ts
+++ b/examples/client/src/gen7/models/ts/AddPetRequest.ts
@@ -35,11 +35,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen7/models/ts/Customer.ts
+++ b/examples/client/src/gen7/models/ts/Customer.ts
@@ -22,5 +22,5 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }

--- a/examples/client/src/gen7/models/ts/Pet.ts
+++ b/examples/client/src/gen7/models/ts/Pet.ts
@@ -35,11 +35,11 @@ export type Pet = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/client/src/gen7/models/ts/UserArray.ts
+++ b/examples/client/src/gen7/models/ts/UserArray.ts
@@ -8,4 +8,4 @@ import type { User } from './User.ts'
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>

--- a/examples/client/src/gen7/models/ts/petController/FindPetsByStatus.ts
+++ b/examples/client/src/gen7/models/ts/petController/FindPetsByStatus.ts
@@ -15,7 +15,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen7/models/ts/petController/FindPetsByTags.ts
+++ b/examples/client/src/gen7/models/ts/petController/FindPetsByTags.ts
@@ -9,7 +9,7 @@ import type { Pet } from '../Pet.ts'
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -26,7 +26,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/client/src/gen7/models/ts/userController/CreateUsersWithListInput.ts
+++ b/examples/client/src/gen7/models/ts/userController/CreateUsersWithListInput.ts
@@ -18,7 +18,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/client/src/generators/clientStaticGenerator.tsx
+++ b/examples/client/src/generators/clientStaticGenerator.tsx
@@ -55,9 +55,9 @@ export const clientStaticGenerator = defineGenerator<PluginClient>({
         return code >= 400 || r.statusCode === 'default'
       })
       .map((r) => tsResolver.resolveResponseStatusName(transformedNode, r.statusCode))
-      .filter(Boolean) as string[]
+      .filter(Boolean) as Array<string>
 
-    const typeImportNames = [requestName, responseName, pathParamsName, queryParamsName, headerParamsName, ...errorTypeNames].filter(Boolean) as string[]
+    const typeImportNames = [requestName, responseName, pathParamsName, queryParamsName, headerParamsName, ...errorTypeNames].filter(Boolean) as Array<string>
 
     const banner = resolver.resolveBanner(ctx.meta, { output, config })
     const footer = resolver.resolveFooter(ctx.meta, { output, config })

--- a/examples/cypress/src/gen-v4/models.ts
+++ b/examples/cypress/src/gen-v4/models.ts
@@ -103,7 +103,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 /**
@@ -212,11 +212,11 @@ export type Pet = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -253,11 +253,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -300,7 +300,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 /**
  * @type object
@@ -440,7 +440,7 @@ export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 /**
  * @type array
  */
-export type OptionsFindPetsByStatusStatus200 = Pet[]
+export type OptionsFindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type object
@@ -478,7 +478,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -521,7 +521,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -538,7 +538,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -1110,7 +1110,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/react-query/kubb.config.ts
+++ b/examples/react-query/kubb.config.ts
@@ -105,7 +105,7 @@ export const config = {
           path.toObject({ type: 'path', stringify: true }),
           hasQueryParams ? '...(params ? [params] : [])' : undefined,
           hasRequestBody ? '...(data ? [data] : [])' : undefined,
-        ].filter(Boolean) as [string, ...string[]]
+        ].filter(Boolean) as [string, ...Array<string>]
       },
       customOptions: {
         importPath: '../../../useCustomHookOptions.ts',

--- a/examples/react-query/src/App.tsx
+++ b/examples/react-query/src/App.tsx
@@ -10,7 +10,7 @@ function Pets() {
   const { data: pets, queryKey } = useFindPetsByStatusHook({ status }, { query: { enabled: true } })
   const { data } = useUpdatePetWithFormHook(2)
   const { queryKey: _queryKey, initialData } = findPetsByStatusQueryOptionsHook()
-  const statuses: FindPetsByStatusQueryStatus[] = ['available', 'pending']
+  const statuses: Array<FindPetsByStatusQueryStatus> = ['available', 'pending']
 
   const queries = useQueries({
     queries: statuses.map((status) => findPetsByStatusQueryOptionsHook({ status })),
@@ -91,7 +91,7 @@ function Pets() {
     <>
       <h1>Pets: {status}</h1>
       <ul>
-        {(pets as Pet[] | undefined)?.map((pet) => (
+        {(pets as Array<Pet> | undefined)?.map((pet) => (
           <li key={pet.id}>{pet.name}</li>
         ))}
       </ul>

--- a/examples/typescript/src/gen10/models/AddPetRequest.ts
+++ b/examples/typescript/src/gen10/models/AddPetRequest.ts
@@ -27,11 +27,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/typescript/src/gen10/models/Customer.ts
+++ b/examples/typescript/src/gen10/models/Customer.ts
@@ -37,5 +37,5 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }

--- a/examples/typescript/src/gen10/models/Pet.ts
+++ b/examples/typescript/src/gen10/models/Pet.ts
@@ -43,11 +43,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/typescript/src/gen10/models/UserArray.ts
+++ b/examples/typescript/src/gen10/models/UserArray.ts
@@ -8,4 +8,4 @@ import type { User } from './User.ts'
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>

--- a/examples/typescript/src/gen10/models/petController/DeletePet.ts
+++ b/examples/typescript/src/gen10/models/petController/DeletePet.ts
@@ -17,7 +17,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any

--- a/examples/typescript/src/gen10/models/petController/FindPetsByStatus.ts
+++ b/examples/typescript/src/gen10/models/petController/FindPetsByStatus.ts
@@ -15,7 +15,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/typescript/src/gen10/models/petController/FindPetsByTags.ts
+++ b/examples/typescript/src/gen10/models/petController/FindPetsByTags.ts
@@ -9,7 +9,7 @@ import type { Pet } from '../Pet.ts'
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -26,7 +26,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/typescript/src/gen10/models/userController/CreateUsersWithListInput.ts
+++ b/examples/typescript/src/gen10/models/userController/CreateUsersWithListInput.ts
@@ -18,7 +18,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
+++ b/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
@@ -142,7 +142,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -320,11 +320,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -373,11 +373,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -420,7 +420,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -556,7 +556,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -599,7 +599,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -616,7 +616,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -782,7 +782,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1192,7 +1192,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
+++ b/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
@@ -142,7 +142,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -320,11 +320,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -373,11 +373,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -420,7 +420,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -556,7 +556,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -599,7 +599,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -616,7 +616,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -782,7 +782,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1192,7 +1192,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen2/modelsConst.ts
+++ b/examples/typescript/src/gen2/modelsConst.ts
@@ -142,7 +142,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -320,11 +320,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -373,11 +373,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -420,7 +420,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -556,7 +556,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -599,7 +599,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -616,7 +616,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -782,7 +782,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1192,7 +1192,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen3/modelsPascalConst.ts
+++ b/examples/typescript/src/gen3/modelsPascalConst.ts
@@ -142,7 +142,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -320,11 +320,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -373,11 +373,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -420,7 +420,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -556,7 +556,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -599,7 +599,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -616,7 +616,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -782,7 +782,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1192,7 +1192,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen4/modelsConstEnum.ts
+++ b/examples/typescript/src/gen4/modelsConstEnum.ts
@@ -136,7 +136,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -310,11 +310,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -361,11 +361,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -408,7 +408,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -544,7 +544,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -587,7 +587,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -604,7 +604,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -770,7 +770,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1180,7 +1180,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen5/modelsLiteral.ts
+++ b/examples/typescript/src/gen5/modelsLiteral.ts
@@ -124,7 +124,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -291,11 +291,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -337,11 +337,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -384,7 +384,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -520,7 +520,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -563,7 +563,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -580,7 +580,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -746,7 +746,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1156,7 +1156,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/AddPetRequest.ts
+++ b/examples/typescript/src/gen6/ts/models/AddPetRequest.ts
@@ -36,11 +36,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/typescript/src/gen6/ts/models/CreateUsersWithListInput.ts
+++ b/examples/typescript/src/gen6/ts/models/CreateUsersWithListInput.ts
@@ -18,7 +18,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/Customer.ts
+++ b/examples/typescript/src/gen6/ts/models/Customer.ts
@@ -45,5 +45,5 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }

--- a/examples/typescript/src/gen6/ts/models/DeletePet.ts
+++ b/examples/typescript/src/gen6/ts/models/DeletePet.ts
@@ -17,7 +17,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any

--- a/examples/typescript/src/gen6/ts/models/FindPetsByStatus.ts
+++ b/examples/typescript/src/gen6/ts/models/FindPetsByStatus.ts
@@ -15,7 +15,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/typescript/src/gen6/ts/models/FindPetsByTags.ts
+++ b/examples/typescript/src/gen6/ts/models/FindPetsByTags.ts
@@ -9,7 +9,7 @@ import type { Pet } from './Pet.ts'
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -26,7 +26,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/typescript/src/gen6/ts/models/Pet.ts
+++ b/examples/typescript/src/gen6/ts/models/Pet.ts
@@ -58,11 +58,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/typescript/src/gen6/ts/models/UserArray.ts
+++ b/examples/typescript/src/gen6/ts/models/UserArray.ts
@@ -8,4 +8,4 @@ import type { User } from './User.ts'
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>

--- a/examples/typescript/src/gen7/modelsInlineLiteral.ts
+++ b/examples/typescript/src/gen7/modelsInlineLiteral.ts
@@ -118,7 +118,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -281,11 +281,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -325,11 +325,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -372,7 +372,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -508,7 +508,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -551,7 +551,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -568,7 +568,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -734,7 +734,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1144,7 +1144,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen8/modelsOptionalUndefined.ts
+++ b/examples/typescript/src/gen8/modelsOptionalUndefined.ts
@@ -122,7 +122,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address: Address[] | undefined
+  address: Array<Address> | undefined
 }
 
 export type HappyCustomer = Customer & {
@@ -285,11 +285,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags: Tag[] | undefined
+  readonly tags: Array<Tag> | undefined
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -329,11 +329,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags: Tag[] | undefined
+  tags: Array<Tag> | undefined
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -376,7 +376,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -512,7 +512,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -557,7 +557,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -574,7 +574,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -744,7 +744,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1158,7 +1158,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/gen9/modelsOptionalBoth.ts
+++ b/examples/typescript/src/gen9/modelsOptionalBoth.ts
@@ -122,7 +122,7 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[] | undefined
+  address?: Array<Address> | undefined
 }
 
 export type HappyCustomer = Customer & {
@@ -285,11 +285,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[] | undefined
+  readonly tags?: Array<Tag> | undefined
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -329,11 +329,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[] | undefined
+  tags?: Array<Tag> | undefined
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -376,7 +376,7 @@ export type PetNotFound = {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -512,7 +512,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -557,7 +557,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -574,7 +574,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -744,7 +744,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1158,7 +1158,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/typescript/src/legacy/models.ts
+++ b/examples/typescript/src/legacy/models.ts
@@ -136,7 +136,7 @@ export interface Customer {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
@@ -310,11 +310,11 @@ export type Pet = (
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  readonly tags?: Tag[]
+  readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -361,11 +361,11 @@ export interface AddPetRequest {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined
@@ -408,7 +408,7 @@ export interface PetNotFound {
 /**
  * @type array
  */
-export type UserArray = User[]
+export type UserArray = Array<User>
 
 export type UpdatePetStatus200 = Pet
 
@@ -544,7 +544,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -587,7 +587,7 @@ export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsBySta
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -604,7 +604,7 @@ export type FindPetsByTagsQueryPageSize = string | undefined
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any
@@ -770,7 +770,7 @@ export type DeletePetPathPetId = bigint
 /**
  * @type array
  */
-export type DeletePetStatus200 = ('TYPE1' | 'TYPE2' | 'TYPE3')[]
+export type DeletePetStatus200 = Array<'TYPE1' | 'TYPE2' | 'TYPE3'>
 
 /**
  * @type any
@@ -1180,7 +1180,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/AddPetRequest.ts
+++ b/examples/zod/src/zod/ts/AddPetRequest.ts
@@ -35,11 +35,11 @@ export type AddPetRequest = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/examples/zod/src/zod/ts/CreateUsersWithListInput.ts
+++ b/examples/zod/src/zod/ts/CreateUsersWithListInput.ts
@@ -18,7 +18,7 @@ export type CreateUsersWithListInputStatusDefault = any
 /**
  * @type array | undefined
  */
-export type CreateUsersWithListInputData = User[] | undefined
+export type CreateUsersWithListInputData = Array<User> | undefined
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/Customer.ts
+++ b/examples/zod/src/zod/ts/Customer.ts
@@ -22,5 +22,5 @@ export type Customer = {
   /**
    * @type array | undefined
    */
-  address?: Address[]
+  address?: Array<Address>
 }

--- a/examples/zod/src/zod/ts/FindPetsByStatus.ts
+++ b/examples/zod/src/zod/ts/FindPetsByStatus.ts
@@ -15,7 +15,7 @@ export type FindPetsByStatusQueryStatus = ('available' | 'pending' | 'sold') | u
 /**
  * @type array
  */
-export type FindPetsByStatusStatus200 = Pet[]
+export type FindPetsByStatusStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/zod/src/zod/ts/FindPetsByTags.ts
+++ b/examples/zod/src/zod/ts/FindPetsByTags.ts
@@ -9,7 +9,7 @@ import type { Pet } from './Pet.ts'
  * @description Tags to filter by
  * @type array | undefined
  */
-export type FindPetsByTagsQueryTags = string[] | undefined
+export type FindPetsByTagsQueryTags = Array<string> | undefined
 
 /**
  * @description to request with required page number or pagination
@@ -32,7 +32,7 @@ export type FindPetsByTagsHeaderXEXAMPLE = 'ONE' | 'TWO' | 'THREE'
 /**
  * @type array
  */
-export type FindPetsByTagsStatus200 = Pet[]
+export type FindPetsByTagsStatus200 = Array<Pet>
 
 /**
  * @type any

--- a/examples/zod/src/zod/ts/Pet.ts
+++ b/examples/zod/src/zod/ts/Pet.ts
@@ -26,7 +26,7 @@ export type Pet = {
   /**
    * @type array | undefined
    */
-  parent?: Pet[]
+  parent?: Array<Pet>
   /**
    * @pattern ^[0-9]{1,19}$
    * @example 10
@@ -45,11 +45,11 @@ export type Pet = {
   /**
    * @type array
    */
-  photoUrls: string[]
+  photoUrls: Array<string>
   /**
    * @type array | undefined
    */
-  tags?: Tag[]
+  tags?: Array<Tag>
   /**
    * @description pet status in the store
    * @type string | undefined

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     'no-else-return': 'error',
     'default-param-last': 'error',
     'prefer-exponentiation-operator': 'error',
+    'typescript/array-type': ['error', { default: 'generic' }],
     'typescript/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
     'typescript/no-inferrable-types': 'error',
     'typescript/prefer-function-type': 'error',

--- a/packages/plugin-client/src/clients/fetch.ts
+++ b/packages/plugin-client/src/clients/fetch.ts
@@ -14,7 +14,7 @@ export type RequestConfig<TData = unknown> = {
   data?: TData | FormData
   responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
   signal?: AbortSignal
-  headers?: [string, string][] | Record<string, string>
+  headers?: Array<[string, string]> | Record<string, string>
   credentials?: RequestCredentials
   contentType?: string
 }

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -98,7 +98,7 @@ export const clientGenerator = defineGenerator<PluginClient>({
 
         {hasFormData && <File.Import name={['buildFormData']} root={meta.file.path} path={path.resolve(root, '.kubb/config.ts')} />}
 
-        {meta.fileZod && importedZodNames.length > 0 && <File.Import name={importedZodNames as string[]} root={meta.file.path} path={meta.fileZod.path} />}
+        {meta.fileZod && importedZodNames.length > 0 && <File.Import name={importedZodNames as Array<string>} root={meta.file.path} path={meta.fileZod.path} />}
 
         {meta.fileTs && importedTypeNames.length > 0 && (
           <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />

--- a/packages/plugin-client/templates/clients/fetch.ts
+++ b/packages/plugin-client/templates/clients/fetch.ts
@@ -14,7 +14,7 @@ export type RequestConfig<TData = unknown> = {
   data?: TData | FormData
   responseType?: 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
   signal?: AbortSignal
-  headers?: [string, string][] | Record<string, string>
+  headers?: Array<[string, string]> | Record<string, string>
   credentials?: RequestCredentials
   contentType?: string
 }

--- a/packages/plugin-cypress/src/components/Request.tsx
+++ b/packages/plugin-cypress/src/components/Request.tsx
@@ -60,7 +60,7 @@ export function Request({ baseURL = '', name, dataReturnType, resolver, node, pa
     replacer: (param) => pathParamNameMap.get(camelCase(param)) ?? param,
   })
 
-  const requestOptions: string[] = [`method: '${node.method}'`, `url: ${urlTemplate}`]
+  const requestOptions: Array<string> = [`method: '${node.method}'`, `url: ${urlTemplate}`]
 
   const queryParams = getOperationParameters(node).query
   if (queryParams.length > 0) {

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -103,7 +103,7 @@ const fakerKeywordMapper = {
   },
   boolean: () => 'faker.datatype.boolean()',
   null: () => 'null',
-  array: (items: string[] = [], min?: number, max?: number) => {
+  array: (items: Array<string> = [], min?: number, max?: number) => {
     if (items.length > 1) {
       return `faker.helpers.arrayElements([${items.join(', ')}])`
     }
@@ -124,9 +124,9 @@ const fakerKeywordMapper = {
 
     return `faker.helpers.multiple(() => (${item}))`
   },
-  tuple: (items: string[] = []) => `[${items.join(', ')}]`,
+  tuple: (items: Array<string> = []) => `[${items.join(', ')}]`,
   enum: (items: Array<string | number | boolean | undefined> = [], type = 'any') => `faker.helpers.arrayElement<${type}>([${items.join(', ')}])`,
-  union: (items: string[] = []) => `faker.helpers.arrayElement<any>([${items.join(', ')}])`,
+  union: (items: Array<string> = []) => `faker.helpers.arrayElement<any>([${items.join(', ')}])`,
   datetime: () => 'faker.date.anytime().toISOString()',
   date: (representation: 'date' | 'string' = 'string', parser: PluginFaker['resolvedOptions']['dateParser'] = 'faker') => {
     if (representation === 'string') {
@@ -160,7 +160,7 @@ const fakerKeywordMapper = {
   },
   uuid: () => 'faker.string.uuid()',
   url: () => 'faker.internet.url()',
-  and: (items: string[] = []) => {
+  and: (items: Array<string> = []) => {
     if (items.length === 0) {
       return '{}'
     }
@@ -276,7 +276,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.enum(getEnumValues(node).map(parseEnumValue), this.options.typeName)
       },
       union(node): string {
-        const items: string[] = (node.members ?? [])
+        const items: Array<string> = (node.members ?? [])
           .map((member) =>
             printNested(member, {
               nestedInObject: true,
@@ -287,7 +287,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.union(items)
       },
       intersection(node): string {
-        const items: string[] = (node.members ?? [])
+        const items: Array<string> = (node.members ?? [])
           .map((member) =>
             printNested(member, {
               nestedInObject: true,
@@ -298,7 +298,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.and(items)
       },
       array(node): string {
-        const items: string[] = (node.items ?? [])
+        const items: Array<string> = (node.items ?? [])
           .map((member) =>
             printNested(member, {
               typeName: this.options.typeName ? `NonNullable<${this.options.typeName}>[number]` : undefined,
@@ -310,7 +310,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.array(items, node.min, node.max)
       },
       tuple(node): string {
-        const items: string[] = (node.items ?? [])
+        const items: Array<string> = (node.items ?? [])
           .map((member, index) =>
             printNested(member, {
               typeName: this.options.typeName ? `NonNullable<${this.options.typeName}>[${index}]` : undefined,

--- a/packages/plugin-faker/src/types.ts
+++ b/packages/plugin-faker/src/types.ts
@@ -130,7 +130,7 @@ export type Options = {
    * Value passed to `faker.seed(...)`. Set this for deterministic mock output,
    * which is useful for snapshot tests.
    */
-  seed?: number | number[]
+  seed?: number | Array<number>
   /**
    * Rename properties inside path/query/header mocks. Body mocks are unaffected.
    *

--- a/packages/plugin-mcp/src/components/McpHandler.tsx
+++ b/packages/plugin-mcp/src/components/McpHandler.tsx
@@ -85,7 +85,7 @@ export function McpHandler({ name, node, resolver, baseURL, dataReturnType, para
     contentType && contentType !== 'application/json' && contentType !== 'multipart/form-data' ? `'Content-Type': '${contentType}'` : null
   const headers = [headerParams.length ? (headerParamsMapping ? '...mappedHeaders' : '...headers') : null, contentTypeHeader].filter(Boolean)
 
-  const fetchConfig: string[] = []
+  const fetchConfig: Array<string> = []
   fetchConfig.push(`method: ${JSON.stringify(node.method.toUpperCase())}`)
   fetchConfig.push(`url: ${urlPath.template}`)
   if (baseURL) fetchConfig.push(`baseURL: \`${baseURL}\``)

--- a/packages/plugin-msw/src/components/Handlers.tsx
+++ b/packages/plugin-msw/src/components/Handlers.tsx
@@ -7,7 +7,7 @@ type HandlersProps = {
    */
   name: string
   // custom
-  handlers: string[]
+  handlers: Array<string>
 }
 
 export function Handlers({ name, handlers }: HandlersProps): KubbReactNode {

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -32,7 +32,7 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       path: resolvedFile.path.replace(/[^/\\]+\.ts$/, `${name}.ts`),
     }
 
-    const imports: KubbReactNode[] = []
+    const imports: Array<KubbReactNode> = []
     const hookOptions: Record<string, string> = {}
 
     for (const node of nodes) {

--- a/packages/plugin-react-query/src/types.ts
+++ b/packages/plugin-react-query/src/types.ts
@@ -196,12 +196,12 @@ export type Infinite = {
    * Path to the next-page cursor on the response. Supports dot notation
    * (`'pagination.next.id'`) or array form (`['pagination', 'next', 'id']`).
    */
-  nextParam?: string | string[] | null
+  nextParam?: string | Array<string> | null
   /**
    * Path to the previous-page cursor on the response. Supports dot notation
    * or array form.
    */
-  previousParam?: string | string[] | null
+  previousParam?: string | Array<string> | null
   /**
    * Initial value for `pageParam` on the first fetch.
    *

--- a/packages/plugin-ts/src/factory.test.ts
+++ b/packages/plugin-ts/src/factory.test.ts
@@ -22,7 +22,7 @@ import {
 
 const { factory } = ts
 
-const formatTS = (elements: ts.Node | (ts.Node | undefined)[]) => {
+const formatTS = (elements: ts.Node | Array<ts.Node | undefined>) => {
   return format(parserTs.print(...[elements].flat().filter(Boolean)))
 }
 

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -198,7 +198,7 @@ export function createParameterSignature(
  * Creates a JSDoc comment node from an array of comment strings.
  * Returns null if no comments are provided.
  */
-export function createJSDoc({ comments }: { comments: string[] }) {
+export function createJSDoc({ comments }: { comments: Array<string> }) {
   if (!comments.length) {
     return null
   }
@@ -338,7 +338,7 @@ export function createTypeDeclaration({
 /**
  * Creates a TypeScript namespace declaration (exported module).
  */
-export function createNamespaceDeclaration({ statements, name }: { name: string; statements: ts.Statement[] }) {
+export function createNamespaceDeclaration({ statements, name }: { name: string; statements: Array<ts.Statement> }) {
   return factory.createModuleDeclaration(
     [factory.createToken(ts.SyntaxKind.ExportKeyword)],
     factory.createIdentifier(name),
@@ -519,7 +519,7 @@ export function createEnumDeclaration({
    * Enum name in PascalCase.
    */
   typeName: string
-  enums: [key: string | number, value: string | number | boolean][]
+  enums: Array<[key: string | number, value: string | number | boolean]>
   /**
    * Choose the casing for enum key names.
    * @default 'none'
@@ -740,8 +740,8 @@ export function createUrlTemplateType(path: string): ts.TypeNode {
   }
 
   const segments = normalized.split(/(\{[^}]+\})/)
-  const parts: string[] = []
-  const parameterIndices: number[] = []
+  const parts: Array<string> = []
+  const parameterIndices: Array<number> = []
 
   segments.forEach((segment) => {
     if (segment.startsWith('{') && segment.endsWith('}')) {
@@ -753,7 +753,7 @@ export function createUrlTemplateType(path: string): ts.TypeNode {
   })
 
   const head = ts.factory.createTemplateHead(parts[0] || '')
-  const templateSpans: ts.TemplateLiteralTypeSpan[] = []
+  const templateSpans: Array<ts.TemplateLiteralTypeSpan> = []
 
   parameterIndices.forEach((paramIndex, i) => {
     const isLast = i === parameterIndices.length - 1

--- a/packages/plugin-ts/src/printers/printerTs.test.ts
+++ b/packages/plugin-ts/src/printers/printerTs.test.ts
@@ -1019,7 +1019,7 @@ describe('printerTs', () => {
         enumType: 'inlineLiteral',
         nodes: {
           array(node) {
-            const itemNodes = (node.items ?? []).map((item) => this.transform(item)).filter(Boolean) as ts.TypeNode[]
+            const itemNodes = (node.items ?? []).map((item) => this.transform(item)).filter(Boolean) as Array<ts.TypeNode>
             return ts.factory.createTypeReferenceNode('Set', [ts.factory.createUnionTypeNode(itemNodes)])
           },
         },

--- a/packages/plugin-vue-query/src/types.ts
+++ b/packages/plugin-vue-query/src/types.ts
@@ -1,7 +1,7 @@
 import type { ast, Exclude, Generator, Group, Include, Output, Override, PluginFactoryOptions, Resolver } from '@kubb/core'
 import type { ClientImportPath, PluginClient } from '@kubb/plugin-client'
 
-export type Transformer = (props: { node: ast.OperationNode; casing: 'camelcase' | undefined }) => unknown[]
+export type Transformer = (props: { node: ast.OperationNode; casing: 'camelcase' | undefined }) => Array<unknown>
 
 /**
  * Resolver for Vue Query that provides naming methods for hook functions.
@@ -135,12 +135,12 @@ export type Infinite = {
    * Path to the next-page cursor on the response. Supports dot notation
    * (`'pagination.next.id'`) or array form.
    */
-  nextParam?: string | string[] | null
+  nextParam?: string | Array<string> | null
   /**
    * Path to the previous-page cursor on the response. Supports dot notation
    * or array form.
    */
-  previousParam?: string | string[] | null
+  previousParam?: string | Array<string> | null
   /**
    * Initial value for `pageParam` on the first fetch.
    *

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -235,7 +235,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
     })
 
     const imports = transformedOperations.flatMap(({ node, data }) => {
-      const names = [data.request, ...Object.values(data.responses), ...Object.values(data.parameters)].filter(Boolean) as string[]
+      const names = [data.request, ...Object.values(data.responses), ...Object.values(data.parameters)].filter(Boolean) as Array<string>
       const opFile = resolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
         { root, output, group: group ?? undefined },

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -133,7 +133,7 @@ export function lengthConstraints({ min, max, pattern }: LengthConstraints): str
  * Build `.check(z.minimum(), z.maximum())` for `zod/mini` numeric constraints.
  */
 export function numberChecksMini({ min, max, exclusiveMinimum, exclusiveMaximum, multipleOf }: NumericConstraints): string {
-  const checks: string[] = []
+  const checks: Array<string> = []
   if (min !== undefined) checks.push(`z.minimum(${min})`)
   if (max !== undefined) checks.push(`z.maximum(${max})`)
   if (exclusiveMinimum !== undefined) checks.push(`z.minimum(${exclusiveMinimum}, { exclusive: true })`)
@@ -146,7 +146,7 @@ export function numberChecksMini({ min, max, exclusiveMinimum, exclusiveMaximum,
  * Build `.check(z.minLength(), z.maxLength(), z.regex())` for `zod/mini` length constraints.
  */
 export function lengthChecksMini({ min, max, pattern }: LengthConstraints): string {
-  const checks: string[] = []
+  const checks: Array<string> = []
   if (min !== undefined) checks.push(`z.minLength(${min})`)
   if (max !== undefined) checks.push(`z.maxLength(${max})`)
   if (pattern !== undefined) checks.push(`z.regex(${toRegExpString(pattern, null)})`)


### PR DESCRIPTION
## Summary

- Adds `typescript/array-type` to oxlint config with `default: 'generic'`, enforcing `Array<T>` instead of `T[]`.
- Applies the autofix across `packages/` and `examples/` (81 files).
- Note: example files under `examples/**/gen*/` are emitted by the Kubb TS factory which currently outputs `T[]` syntax; those files will revert to `T[]` on the next `pnpm generate` unless the generator is updated separately.

## Test plan

- [ ] `pnpm lint` is clean
- [ ] `pnpm build && pnpm typecheck` pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGA78Pm3Ud1Q1VPQp1Crdz)_