### PR TITLE
feat(plugins): forward per-file banner/footer context across generators

### DIFF
--- a/.changeset/client-banner-aggregation-context.md
+++ b/.changeset/client-banner-aggregation-context.md
@@ -1,10 +1,18 @@
 ---
 "@kubb/plugin-client": minor
+"@kubb/plugin-ts": minor
+"@kubb/plugin-zod": minor
+"@kubb/plugin-faker": minor
+"@kubb/plugin-msw": minor
+"@kubb/plugin-react-query": minor
+"@kubb/plugin-vue-query": minor
+"@kubb/plugin-cypress": minor
+"@kubb/plugin-mcp": minor
 ---
 
 Forward per-file context to `output.banner`/`output.footer` so a directive like `'use server'` can be skipped on re-export files.
 
-Every client generator now passes the file it renders into (`filePath`, `baseName`) to the banner/footer resolver, and the grouped client generator flags its group `[dir]/[dir].ts` files as `isAggregation`. Combined with the `BannerMeta` context added in `@kubb/core`, a banner function can branch per file:
+Every generator now passes the file it renders into (`filePath`, `baseName`) to the banner/footer resolver, and the grouped client generator (`@kubb/plugin-client`) flags its group `[dir]/[dir].ts` files as `isAggregation`. Combined with the `BannerMeta` context added in `@kubb/core`, a banner function can branch per file:
 
 ```ts
 pluginClient({

--- a/.changeset/client-banner-aggregation-context.md
+++ b/.changeset/client-banner-aggregation-context.md
@@ -1,0 +1,17 @@
+---
+"@kubb/plugin-client": minor
+---
+
+Forward per-file context to `output.banner`/`output.footer` so a directive like `'use server'` can be skipped on re-export files.
+
+Every client generator now passes the file it renders into (`filePath`, `baseName`) to the banner/footer resolver, and the grouped client generator flags its group `[dir]/[dir].ts` files as `isAggregation`. Combined with the `BannerMeta` context added in `@kubb/core`, a banner function can branch per file:
+
+```ts
+pluginClient({
+  output: {
+    banner: (meta) => (meta.isBarrel || meta.isAggregation ? '' : "'use server'"),
+  },
+})
+```
+
+Requires `@kubb/core` with `BannerMeta` per-file banner context.

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -169,8 +169,8 @@ export const classClientGenerator = defineGenerator<PluginClient>({
           baseName={file.baseName}
           path={file.path}
           meta={file.meta}
-          banner={resolver.resolveBanner(ctx.meta, { output, config })}
-          footer={resolver.resolveFooter(ctx.meta, { output, config })}
+          banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
+          footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
         >
           {importPath ? (
             <>
@@ -228,8 +228,8 @@ export const classClientGenerator = defineGenerator<PluginClient>({
           baseName={sdkFile.baseName}
           path={sdkFile.path}
           meta={sdkFile.meta}
-          banner={resolver.resolveBanner(ctx.meta, { output, config })}
-          footer={resolver.resolveFooter(ctx.meta, { output, config })}
+          banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: sdkFile.path, baseName: sdkFile.baseName } })}
+          footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: sdkFile.path, baseName: sdkFile.baseName } })}
         >
           {importPath ? (
             <File.Import name={['Client', 'RequestConfig']} path={importPath} isTypeOnly />

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -76,8 +76,8 @@ export const clientGenerator = defineGenerator<PluginClient>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {importPath ? (
           <>

--- a/packages/plugin-client/src/generators/groupedClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/groupedClientGenerator.tsx
@@ -61,8 +61,8 @@ export const groupedClientGenerator = defineGenerator<PluginClient>({
               baseName={file.baseName}
               path={file.path}
               meta={file.meta}
-              banner={resolver.resolveBanner(ctx.meta, { output, config })}
-              footer={resolver.resolveFooter(ctx.meta, { output, config })}
+              banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName, isAggregation: true } })}
+              footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName, isAggregation: true } })}
             >
               {clients.map((client) => (
                 <File.Import key={client.name} name={[client.name]} root={file.path} path={client.file.path} />

--- a/packages/plugin-client/src/generators/operationsGenerator.tsx
+++ b/packages/plugin-client/src/generators/operationsGenerator.tsx
@@ -24,8 +24,8 @@ export const operationsGenerator = defineGenerator<PluginClient>({
         baseName={file.baseName}
         path={file.path}
         meta={file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
       >
         <Operations name={name} nodes={nodes} />
       </File>

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -170,8 +170,8 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
               baseName={file.baseName}
               path={file.path}
               meta={file.meta}
-              banner={resolver.resolveBanner(ctx.meta, { output, config })}
-              footer={resolver.resolveFooter(ctx.meta, { output, config })}
+              banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
+              footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
             >
               {importPath ? (
                 <>

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -48,8 +48,8 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {meta.fileTs && importedTypeNames.length > 0 && <File.Import name={importedTypeNames} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />}
         <Request

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -73,8 +73,8 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         <File.Import name={locale ? [{ propertyName: localeToFakerImport(locale), name: 'faker' }] : ['faker']} path="@faker-js/faker" />
         {regexGenerator === 'randexp' && <File.Import name={'RandExp'} path={'randexp'} />}
@@ -230,8 +230,8 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         <File.Import name={locale ? [{ propertyName: localeToFakerImport(locale), name: 'faker' }] : ['faker']} path="@faker-js/faker" />
         {regexGenerator === 'randexp' && <File.Import name={'RandExp'} path={'randexp'} />}

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -111,8 +111,8 @@ export const serverGenerator = defineGenerator<PluginMcp>({
           baseName={serverFile.baseName}
           path={serverFile.path}
           meta={serverFile.meta}
-          banner={resolver.resolveBanner(ctx.meta, { output, config })}
-          footer={resolver.resolveFooter(ctx.meta, { output, config })}
+          banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: serverFile.path, baseName: serverFile.baseName } })}
+          footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: serverFile.path, baseName: serverFile.baseName } })}
         >
           <File.Import name={['McpServer']} path={'@modelcontextprotocol/sdk/server/mcp'} />
           <File.Import name={['z']} path={'zod'} />

--- a/packages/plugin-msw/src/generators/handlersGenerator.tsx
+++ b/packages/plugin-msw/src/generators/handlersGenerator.tsx
@@ -36,8 +36,8 @@ export const handlersGenerator = defineGenerator<PluginMsw>({
         baseName={file.baseName}
         path={file.path}
         meta={file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
       >
         {imports}
         <Handlers name={handlersName} handlers={handlers} />

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -63,8 +63,8 @@ export const mswGenerator = defineGenerator<PluginMsw>({
         baseName={mock.file.baseName}
         path={mock.file.path}
         meta={mock.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: mock.file.path, baseName: mock.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: mock.file.path, baseName: mock.file.baseName } })}
       >
         <File.Import name={['http']} path="msw" />
         <File.Import name={['HttpResponseResolver']} isTypeOnly path="msw" />

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -122,8 +122,8 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
         baseName={hookOptionsFile.baseName}
         path={hookOptionsFile.path}
         meta={hookOptionsFile.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: hookOptionsFile.path, baseName: hookOptionsFile.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: hookOptionsFile.path, baseName: hookOptionsFile.baseName } })}
       >
         {imports}
         <File.Source name={name} isExportable isIndexable isTypeOnly>

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -103,8 +103,8 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -88,8 +88,8 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -93,8 +93,8 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -112,8 +112,8 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -95,8 +95,8 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -82,8 +82,8 @@ export const typeGenerator = defineGenerator<PluginTs>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {mode === 'split' &&
           imports.map((imp) => (
@@ -290,8 +290,8 @@ export const typeGenerator = defineGenerator<PluginTs>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {paramTypes}
         {responseTypes}

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -103,8 +103,8 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -87,8 +87,8 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -92,8 +92,8 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         {fileZod && zodSchemaNames.length > 0 && <File.Import name={zodSchemaNames} root={meta.file.path} path={fileZod.path} />}
         {clientOptions.importPath ? (

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -77,8 +77,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         <File.Import name={isZodImport ? 'z' : ['z']} path={importPath} isNameSpace={isZodImport} />
         {mode === 'split' && imports.map((imp) => <File.Import key={[node.name, imp.path].join('-')} root={meta.file.path} path={imp.path} name={imp.name} />)}
@@ -201,8 +201,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         <File.Import name={isZodImport ? 'z' : ['z']} path={importPath} isNameSpace={isZodImport} />
         {paramSchemas}
@@ -249,8 +249,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
         baseName={meta.file.baseName}
         path={meta.file.path}
         meta={meta.file.meta}
-        banner={resolver.resolveBanner(ctx.meta, { output, config })}
-        footer={resolver.resolveFooter(ctx.meta, { output, config })}
+        banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
+        footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
         <File.Import isTypeOnly name={isZodImport ? 'z' : ['z']} path={importPath} isNameSpace={isZodImport} />
         {imports}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,23 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     '@kubb/agent':
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     '@kubb/core':
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     '@kubb/middleware-barrel':
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     '@kubb/parser-ts':
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     '@kubb/renderer-jsx':
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     '@size-limit/file':
       specifier: ^12.1.0
       version: 12.1.0
@@ -40,8 +40,8 @@ catalogs:
       specifier: ^4.1.7
       version: 4.1.7
     kubb:
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     oxfmt:
       specifier: ^0.47.0
       version: 0.47.0
@@ -64,8 +64,8 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     unplugin-kubb:
-      specifier: 5.0.0-beta.27
-      version: 5.0.0-beta.27
+      specifier: 5.0.0-beta.28
+      version: 5.0.0-beta.28
     vitest:
       specifier: ^4.1.7
       version: 4.1.7
@@ -82,16 +82,16 @@ importers:
         version: 2.31.0(@types/node@22.19.19)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/middleware-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))
+        version: 5.0.0-beta.28(@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -227,16 +227,16 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/agent':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -245,13 +245,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -260,13 +260,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -288,7 +288,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -307,7 +307,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -322,7 +322,7 @@ importers:
         version: 1.11.20
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -335,7 +335,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -344,7 +344,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
     devDependencies:
       react:
         specifier: ^19.2.6
@@ -357,13 +357,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -372,13 +372,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -394,7 +394,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-mcp':
         specifier: workspace:*
         version: link:../../packages/plugin-mcp
@@ -412,7 +412,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -428,7 +428,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -446,7 +446,7 @@ importers:
         version: 0.10.3(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -465,7 +465,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -486,7 +486,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -495,7 +495,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(@kubb/renderer-jsx@5.0.0-beta.27)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 5.0.0-beta.28(@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(@kubb/renderer-jsx@5.0.0-beta.28)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -520,7 +520,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -529,7 +529,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -539,7 +539,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -563,7 +563,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -578,7 +578,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -587,7 +587,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -597,7 +597,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -618,7 +618,7 @@ importers:
         version: 1.16.1
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(@kubb/renderer-jsx@5.0.0-beta.27)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 5.0.0-beta.28(@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(@kubb/renderer-jsx@5.0.0-beta.28)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       vue:
         specifier: ^3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -652,7 +652,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -670,7 +670,7 @@ importers:
         version: link:../utils
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -686,13 +686,13 @@ importers:
         version: link:../utils
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -708,7 +708,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
@@ -717,7 +717,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -733,13 +733,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -752,13 +752,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -768,7 +768,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -780,7 +780,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -793,7 +793,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../plugin-faker
@@ -802,7 +802,7 @@ importers:
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -815,7 +815,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -827,7 +827,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -846,10 +846,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -862,13 +862,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -887,7 +887,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -899,7 +899,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -918,10 +918,10 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27
+        version: 5.0.0-beta.28
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -937,13 +937,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -989,7 +989,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1025,7 +1025,7 @@ importers:
         version: 15.15.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -1056,10 +1056,10 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+        version: 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1074,7 +1074,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3)
+        version: 5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1713,26 +1713,26 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@kubb/adapter-oas@5.0.0-beta.27':
-    resolution: {integrity: sha512-LLrgKL0F6XoeeLV892T67hzpqelMPnq3opRq5BezCpFyJLExt2kH4ngBC3P9fqCHX+YivOw/kDp5aFge/pFo5Q==}
+  '@kubb/adapter-oas@5.0.0-beta.28':
+    resolution: {integrity: sha512-ozTk62KKs29aym1usylGijnGcZ+VInsX/ZDoTSsvt3b4egCjXN/wlvPRizdJeGtrWfDANsvFOwbEx3qZcYMR3A==}
     engines: {node: '>=22'}
 
-  '@kubb/agent@5.0.0-beta.27':
-    resolution: {integrity: sha512-F7RuxtmnJwUKlCmpXQEErgxR3kv/JA+aKHDb40ZDwiO61u+eCivSDonC7B+XYB5f5cjaFssX4FVjxC+1BoC3wA==}
+  '@kubb/agent@5.0.0-beta.28':
+    resolution: {integrity: sha512-KZjryFcLUr/UB06PghrG9dROsn7y7La+6z2AjG9GFB14/cBOeFddYfBT0jvkhlwsDx5VXPc4e14/Lhr1NSFFzQ==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-beta.27':
-    resolution: {integrity: sha512-v6SEi0SPlymYvA1DfN/2tmRzhaWu+m93R3A/XB8rUvTOiyjS/CLsoqeDneWpX198HQ7kdZwQTCvFm742a0LmqQ==}
+  '@kubb/ast@5.0.0-beta.28':
+    resolution: {integrity: sha512-CJ2kL3Dw1/DKHLeh3fGgA3Dmf2yaEYndpUu/2w7AtYVOqMrC4Bo06HMGWsI9TKzh4ApDZdVFlYBsgyGg/J+jPA==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-beta.27':
-    resolution: {integrity: sha512-UEdLzjJkZj3Tx7Sqn8kyDnrlXBBa9GBUwtyZbfPZaTh4L1SbqFBfd8EyJbpWvTCnC3Dx0FZ+2waJOqVyv2HHmQ==}
+  '@kubb/cli@5.0.0-beta.28':
+    resolution: {integrity: sha512-v3p1jsLIEfEr5kiUdHlswTPNH8yq8ddmtALh3wf7GGa1Tvn7YrTnjOHOYTW9UCh0AA4asIYIUx3rD5cQOIeCbA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.27
-      '@kubb/agent': 5.0.0-beta.27
-      '@kubb/mcp': 5.0.0-beta.27
+      '@kubb/adapter-oas': 5.0.0-beta.28
+      '@kubb/agent': 5.0.0-beta.28
+      '@kubb/mcp': 5.0.0-beta.28
     peerDependenciesMeta:
       '@kubb/adapter-oas':
         optional: true
@@ -1741,35 +1741,35 @@ packages:
       '@kubb/mcp':
         optional: true
 
-  '@kubb/core@5.0.0-beta.27':
-    resolution: {integrity: sha512-Euag3R6OB/etV01Gp+v5IvaxCtlMGboEzGwewZU4gVcW31ScBsfqcEPaajAa6QGclbKE1n3rMI4J5oCcY7KuQQ==}
+  '@kubb/core@5.0.0-beta.28':
+    resolution: {integrity: sha512-iw5493a3ncXs1CnSRs6oUTbi/nQ2S+1W/jok9ACpIntxxz3RqPJTUL2anD+haKbShqott9MfmU5K3D6oPCqr4A==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.27
+      '@kubb/renderer-jsx': 5.0.0-beta.28
 
-  '@kubb/mcp@5.0.0-beta.27':
-    resolution: {integrity: sha512-fvq8SuattVPKXkmZ6GiBEcdEdXIvktvo+iLwt0RLYA8UKJuWCrpUzhAK6tyxU99fVWkcaFtPgCUYQjl/2d+s1A==}
+  '@kubb/mcp@5.0.0-beta.28':
+    resolution: {integrity: sha512-upz+GW4zjyABHHOgf3DvXGcJTht1OdGe0egUr3PcGP/0NWkcFRz3CfCYauNBVkdPBf46svx1P9Fs+t5Rnh2GCA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.27
+      '@kubb/renderer-jsx': 5.0.0-beta.28
 
-  '@kubb/middleware-barrel@5.0.0-beta.27':
-    resolution: {integrity: sha512-hXCnoDL8+U3bneHpp3MQ0Xi/Kj5rXZE+SP3ZXBp58GBu2Nu1vbF3FDl0VjL8t+T6kI58sgwQkEmT0BshI7c1XA==}
+  '@kubb/middleware-barrel@5.0.0-beta.28':
+    resolution: {integrity: sha512-uMrBO63Zzgww9+kjcMvoxx95i2+dR0d8P2k/Wcl+ens8aIBQuYJLqJhZXHBPNqg90xZdeAY9RmfWQa2zEOmsLQ==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-beta.27
+      '@kubb/core': 5.0.0-beta.28
 
-  '@kubb/parser-md@5.0.0-beta.27':
-    resolution: {integrity: sha512-oADXnX9nVBJRss2DWgVeaMZMWll3w9jT6ZgBo6hMAN6Jp5DuQ9CyUt6vKOhM4V+Z/BfLhckTjsNnqvZGTiCKpA==}
+  '@kubb/parser-md@5.0.0-beta.28':
+    resolution: {integrity: sha512-vnj5myNmzu2Hc8DkCvwx12BbJ+PFFKSyt2GEpRiOtcw5xC8fcDyitvoDryCHmlEktV4EYMyrgPupRuq1rutgMA==}
     engines: {node: '>=22'}
 
-  '@kubb/parser-ts@5.0.0-beta.27':
-    resolution: {integrity: sha512-BzZtSvRcfwN3NeIZWCJTzj0lJKxpEzblxBe6umZErfpFOhgAyHwh3fs4rbqElPOWtKvO0zBI4TJhU/opDnCu1w==}
+  '@kubb/parser-ts@5.0.0-beta.28':
+    resolution: {integrity: sha512-mzQWRJaHwduDf8vbyzzIaUbFOlS+lQkBJNQHEpXXj7DTtuMkhtxw13uzIEGETeP1mbQno9EJw3hqZ5RWi349og==}
     engines: {node: '>=22'}
 
-  '@kubb/renderer-jsx@5.0.0-beta.27':
-    resolution: {integrity: sha512-tcuA5gLaERWbEHG4FsTB5rsc9oelrWGEpai0RJzKf4qzidtEG1O+jHQGQuc+pNsUlA77/z4TCm3iZ5wiNUYxvA==}
+  '@kubb/renderer-jsx@5.0.0-beta.28':
+    resolution: {integrity: sha512-ZsP1wk0VOeQP7vRJrVRSKIHQgwVodezRHyRdYkx1uO29V36Prc2h+7EdVEt37mz2lZYZQBrQDp3I2F/Rlkqg+g==}
     engines: {node: '>=22'}
 
   '@logtail/core@0.5.8':
@@ -2136,8 +2136,8 @@ packages:
     resolution: {integrity: sha512-qKXAdKTRKqWArIWbMOHOELJGgfISMFD5pK0w5CaklH8LAn5M6BbyCocqz52IqMMUIiEyAsqb46a4vtuqPhLZwg==}
     engines: {node: '>=22.12.0 || >=20.19.0 <21.0.0', npm: '>=10'}
 
-  '@remix-run/node-fetch-server@0.13.1':
-    resolution: {integrity: sha512-dOL+A/C84EA47gO/ps52KGrVSiYy96512rwtbXmJfWKYFm1FbrbjA3jao1hcIfao+jwVNEaZ1kTMwFjiino+HQ==}
+  '@remix-run/node-fetch-server@0.13.2':
+    resolution: {integrity: sha512-gPux086JQjK3PmYWe75unUXKRMsJjdxKs+lW46gg2B/vvSPRRoOdWriVUPktIXYd1Uglq1PTjGW/fWPuslSfag==}
 
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
@@ -3777,12 +3777,12 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-beta.27:
-    resolution: {integrity: sha512-HpT3ZSWiZ1OUenFmbH9l5FV14Q/mitozVuIcuS2hVQLeu0meWOnkpCiRbZaYztDAWtjwpq6zlPPdPTnvxLYtaA==}
+  kubb@5.0.0-beta.28:
+    resolution: {integrity: sha512-CMgLcUyymH8/B3cURCMoCYLh6ASHzK14iz6YXgblMxySGpLCxjbtA9T/3Lu3+LLNn3eBoEvf8H5+b7GnzooroA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/agent': 5.0.0-beta.27
+      '@kubb/agent': 5.0.0-beta.28
     peerDependenciesMeta:
       '@kubb/agent':
         optional: true
@@ -4869,8 +4869,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-beta.27:
-    resolution: {integrity: sha512-xelZF6Dnbfqz9/z5FCCU6uVrorBcXQTUSX+w6gCEn60nu6FQWKR0ExyA2f7NqG6GmNQnGaTiwQ2T8LXBFktIJg==}
+  unplugin-kubb@5.0.0-beta.28:
+    resolution: {integrity: sha512-ThCMwGGOibRUfGJ9wRsbNjDTLgGeM4HXZqRVX13ef8UhPm+TMedc+dlsSvnJA/ubcF7Vk+In/GyS03QjXaGLRQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -5888,9 +5888,9 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kubb/adapter-oas@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)':
+  '@kubb/adapter-oas@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@redocly/openapi-core': 2.31.2
       oas: 32.1.18
       oas-normalize: 16.0.4
@@ -5899,10 +5899,10 @@ snapshots:
       - '@kubb/renderer-jsx'
       - encoding
 
-  '@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)':
+  '@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.27
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/ast': 5.0.0-beta.28
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       '@logtail/node': 0.5.8
       consola: 3.4.2
       jiti: 2.7.0
@@ -5934,37 +5934,37 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@kubb/ast@5.0.0-beta.27': {}
+  '@kubb/ast@5.0.0-beta.28': {}
 
-  '@kubb/cli@5.0.0-beta.27(@kubb/adapter-oas@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(@kubb/mcp@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.27)(typescript@6.0.3)':
+  '@kubb/cli@5.0.0-beta.28(@kubb/adapter-oas@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(@kubb/mcp@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.28)(typescript@6.0.3)':
     dependencies:
       '@clack/prompts': 1.4.0
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       chokidar: 5.0.0
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.7.0
       tinyexec: 1.1.2
     optionalDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/agent': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/mcp': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)(typescript@6.0.3)
+      '@kubb/adapter-oas': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/agent': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/mcp': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
       - typescript
 
-  '@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)':
+  '@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.27
-      '@kubb/renderer-jsx': 5.0.0-beta.27
+      '@kubb/ast': 5.0.0-beta.28
+      '@kubb/renderer-jsx': 5.0.0-beta.28
       fflate: 0.8.3
       tinyexec: 1.1.2
 
-  '@kubb/mcp@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)(typescript@6.0.3)':
+  '@kubb/mcp@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)(typescript@6.0.3)':
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/renderer-jsx': 5.0.0-beta.27
-      '@remix-run/node-fetch-server': 0.13.1
+      '@kubb/adapter-oas': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/renderer-jsx': 5.0.0-beta.28
+      '@remix-run/node-fetch-server': 0.13.2
       '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.0(typescript@6.0.3))
       '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@6.0.3))
       '@tmcp/transport-stdio': 0.4.3(tmcp@1.19.4(typescript@6.0.3))
@@ -5976,28 +5976,28 @@ snapshots:
       - encoding
       - typescript
 
-  '@kubb/middleware-barrel@5.0.0-beta.27(@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))':
+  '@kubb/middleware-barrel@5.0.0-beta.28(@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.27
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/ast': 5.0.0-beta.28
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
 
-  '@kubb/parser-md@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)':
+  '@kubb/parser-md@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/parser-ts@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)':
+  '@kubb/parser-ts@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/renderer-jsx@5.0.0-beta.27':
+  '@kubb/renderer-jsx@5.0.0-beta.28':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.27
+      '@kubb/ast': 5.0.0-beta.28
       yaml: 2.9.0
 
   '@logtail/core@0.5.8':
@@ -6296,7 +6296,7 @@ snapshots:
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
 
-  '@remix-run/node-fetch-server@0.13.1': {}
+  '@remix-run/node-fetch-server@0.13.2': {}
 
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
@@ -7961,18 +7961,18 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-beta.27(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(typescript@6.0.3):
+  kubb@5.0.0-beta.28(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(typescript@6.0.3):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/cli': 5.0.0-beta.27(@kubb/adapter-oas@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(@kubb/agent@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(@kubb/mcp@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.27)(typescript@6.0.3)
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/mcp': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)(typescript@6.0.3)
-      '@kubb/middleware-barrel': 5.0.0-beta.27(@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))
-      '@kubb/parser-md': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/parser-ts': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/renderer-jsx': 5.0.0-beta.27
+      '@kubb/adapter-oas': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/cli': 5.0.0-beta.28(@kubb/adapter-oas@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(@kubb/agent@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(@kubb/mcp@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.28)(typescript@6.0.3)
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/mcp': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)(typescript@6.0.3)
+      '@kubb/middleware-barrel': 5.0.0-beta.28(@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))
+      '@kubb/parser-md': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/parser-ts': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/renderer-jsx': 5.0.0-beta.28
     optionalDependencies:
-      '@kubb/agent': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/agent': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - encoding
@@ -9120,12 +9120,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-beta.27(@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))(@kubb/renderer-jsx@5.0.0-beta.27)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.28(@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))(@kubb/renderer-jsx@5.0.0-beta.28)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/core': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
-      '@kubb/middleware-barrel': 5.0.0-beta.27(@kubb/core@5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27))
-      '@kubb/parser-ts': 5.0.0-beta.27(@kubb/renderer-jsx@5.0.0-beta.27)
+      '@kubb/adapter-oas': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/core': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
+      '@kubb/middleware-barrel': 5.0.0-beta.28(@kubb/core@5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28))
+      '@kubb/parser-ts': 5.0.0-beta.28(@kubb/renderer-jsx@5.0.0-beta.28)
       unplugin: 3.0.0
     optionalDependencies:
       esbuild: 0.28.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,18 +12,18 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.27
-  '@kubb/agent': 5.0.0-beta.27
-  '@kubb/core': 5.0.0-beta.27
-  '@kubb/middleware-barrel': 5.0.0-beta.27
-  '@kubb/parser-ts': 5.0.0-beta.27
-  '@kubb/renderer-jsx': 5.0.0-beta.27
+  '@kubb/adapter-oas': 5.0.0-beta.28
+  '@kubb/agent': 5.0.0-beta.28
+  '@kubb/core': 5.0.0-beta.28
+  '@kubb/middleware-barrel': 5.0.0-beta.28
+  '@kubb/parser-ts': 5.0.0-beta.28
+  '@kubb/renderer-jsx': 5.0.0-beta.28
   '@size-limit/file': ^12.1.0
   '@types/node': ^22.19.19
   '@types/react': ^19.2.15
   '@vitest/coverage-v8': ^4.1.7
   '@vitest/ui': ^4.1.7
-  kubb: 5.0.0-beta.27
+  kubb: 5.0.0-beta.28
   oxfmt: ^0.47.0
   oxlint: ^1.66.0
   prettier: ^3.8.3
@@ -31,7 +31,7 @@ catalog:
   'size-limit': ^12.1.0
   tsdown: ^0.22.0
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.27
+  unplugin-kubb: 5.0.0-beta.28
   vitest: ^4.1.7
 
 minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age


### PR DESCRIPTION
## Summary

Companion to **kubb-labs/kubb#3371** for [kubb-labs/kubb#2265](https://github.com/kubb-labs/kubb/issues/2265).

Forwards per-file context to `output.banner`/`output.footer` in **every plugin generator** so a directive like `'use server'` can be skipped on re-export files:

- Each generator passes the file it renders into (`filePath`, `baseName`) to `resolveBanner`/`resolveFooter`.
- `groupedClientGenerator` (`@kubb/plugin-client`) flags its group `[dir]/[dir].ts` files as `isAggregation: true` — these aggregate function references and break under `'use server'`.

```ts
pluginClient({
  output: {
    banner: (meta) => (meta.isBarrel || meta.isAggregation ? '' : "'use server'"),
  },
})
```

`isBarrel` is set by the barrel middleware in `@kubb/core` (these plugin generators emit content/aggregation files, not barrels, so they forward `path`/`baseName` and `isBarrel`/`isAggregation` default to `false`).

## Changes

21 generators across all plugins now pass `file` context:

- `@kubb/plugin-client` — operations, client, classClient (×2), staticClassClient, **grouped** (`isAggregation: true`)
- `@kubb/plugin-ts` — typeGenerator (×2)
- `@kubb/plugin-zod` — zodGenerator (×3)
- `@kubb/plugin-faker` — fakerGenerator (×2)
- `@kubb/plugin-msw` — handlers, msw
- `@kubb/plugin-react-query` — mutation, query, infiniteQuery, suspenseQuery, suspenseInfiniteQuery, hookOptions
- `@kubb/plugin-vue-query` — mutation, query, infiniteQuery
- `@kubb/plugin-cypress` — cypress
- `@kubb/plugin-mcp` — server

Also bumps the `@kubb/*` catalog to `5.0.0-beta.28` (which ships the `BannerMeta` context from #3371) and updates the lockfile. Plugin package versions stay at `5.0.0-beta.27`.

## Test plan

Validated against `@kubb/core@5.0.0-beta.28`:

- [x] `pnpm typecheck` — 13 packages clean
- [x] `pnpm test` — 867 passing (56 files), no snapshot changes
- [x] `pnpm lint` clean / `pnpm format` no-op

---
_Generated by [Claude Code](https://claude.ai/code/session_018Y4aNh1uygs2eRST5JcyhS)_