### PR TITLE
feat: add format in jsdoc for type generation

### DIFF
--- a/.changeset/dull-areas-happen.md
+++ b/.changeset/dull-areas-happen.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-ts": patch
+---
+
+Add format info into description of generated fields

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -224,4 +224,27 @@ describe('buildPropertyJSDocComments', () => {
     expect(comments).not.toContain('@minLength 1')
     expect(comments).not.toContain('@maxLength 10')
   })
+
+  it('emits format on a separate line when both description and format exist', () => {
+    const schema = ast.createSchema({ type: 'string', format: 'uuid', description: 'Unique identifier' })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).toContain('@description Unique identifier')
+    expect(comments).toContain(' ')
+    expect(comments).toContain('Format: `uuid`')
+  })
+
+  it('emits format-only @description when no description exists', () => {
+    const schema = ast.createSchema({ type: 'string', format: 'date-time' })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).toContain('@description Format: `date-time`')
+  })
+
+  it('does not emit @description when neither description nor format exist', () => {
+    const schema = ast.createSchema({ type: 'string' })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).not.toContain('@description')
+  })
 })

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -234,11 +234,12 @@ describe('buildPropertyJSDocComments', () => {
     expect(comments).toContain('Format: `uuid`')
   })
 
-  it('emits format-only @description when no description exists', () => {
+  it('emits @description and Format on separate lines when only format exists', () => {
     const schema = ast.createSchema({ type: 'string', format: 'date-time' })
     const comments = buildPropertyJSDocComments(schema)
 
-    expect(comments).toContain('@description Format: `date-time`')
+    expect(comments).toContain('@description')
+    expect(comments).toContain('Format: `date-time`')
   })
 
   it('does not emit @description when neither description nor format exist', () => {

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -15,15 +15,15 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode): Array<string
 
   const isArray = meta?.primitive === 'array'
 
-
   const hasDescription = meta && 'description' in meta && meta.description
-  
-  const formatComment = meta && 'format' in meta && meta.format
-    ? hasDescription
-      // Empty line between description and format
-      ? [' ', `Format: \`${meta.format}\``]
-      : [`@description Format: \`${meta.format}\``]
-    : []
+
+  const formatComment =
+    meta && 'format' in meta && meta.format
+      ? hasDescription
+        ? // Empty line between description and format
+          [' ', `Format: \`${meta.format}\``]
+        : [`@description Format: \`${meta.format}\``]
+      : []
 
   return [
     hasDescription ? `@description ${jsStringEscape(meta.description)}` : null,

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -15,14 +15,19 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode): Array<string
 
   const isArray = meta?.primitive === 'array'
 
-  return [
-    meta && 'description' in meta && meta.description ? `@description ${jsStringEscape(meta.description)}` : null,
-    meta && 'format' in meta && meta.format && !('description' in meta && meta.description)
-      ? `@description Format: \`${meta.format}\``
-      : null,
-    ...(meta && 'format' in meta && meta.format && 'description' in meta && meta.description
+
+  const hasDescription = meta && 'description' in meta && meta.description
+  
+  const formatComment = meta && 'format' in meta && meta.format
+    ? hasDescription
+      // Empty line between description and format
       ? [' ', `Format: \`${meta.format}\``]
-      : []),
+      : [`@description Format: \`${meta.format}\``]
+    : []
+
+  return [
+    hasDescription ? `@description ${jsStringEscape(meta.description)}` : null,
+    ...formatComment,
     meta && 'deprecated' in meta && meta.deprecated ? '@deprecated' : null,
     // minItems/maxItems on arrays should not be emitted as @minLength/@maxLength
     !isArray && meta && 'min' in meta && meta.min !== undefined ? `@minLength ${meta.min}` : null,

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -17,6 +17,12 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode): Array<string
 
   return [
     meta && 'description' in meta && meta.description ? `@description ${jsStringEscape(meta.description)}` : null,
+    meta && 'format' in meta && meta.format && !('description' in meta && meta.description)
+      ? `@description Format: \`${meta.format}\``
+      : null,
+    ...(meta && 'format' in meta && meta.format && 'description' in meta && meta.description
+      ? [' ', `Format: \`${meta.format}\``]
+      : []),
     meta && 'deprecated' in meta && meta.deprecated ? '@deprecated' : null,
     // minItems/maxItems on arrays should not be emitted as @minLength/@maxLength
     !isArray && meta && 'min' in meta && meta.min !== undefined ? `@minLength ${meta.min}` : null,

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -22,7 +22,7 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode): Array<string
       ? hasDescription
         ? // Empty line between description and format
           [' ', `Format: \`${meta.format}\``]
-        : [`@description Format: \`${meta.format}\``]
+        : ['@description', `Format: \`${meta.format}\``]
       : []
 
   return [

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/ElectricCar.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/ElectricCar.ts
@@ -18,6 +18,8 @@ export type ElectricCar = (Vehicle & {
     type?: TypeEnumKey;
     /**
      * @description Battery capacity in kWh
+     *
+     * Format: `float`
      * @type number | undefined
     */
     batteryCapacity?: number;

--- a/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/ElectricCar.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/ElectricCar.ts
@@ -18,6 +18,8 @@ export type ElectricCar = (Vehicle & {
     type?: ElectricCarTypeEnumKey;
     /**
      * @description Battery capacity in kWh
+     *
+     * Format: `float`
      * @type number | undefined
     */
     batteryCapacity?: number;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
@@ -1,7 +1,8 @@
 // Custom banner
 
 /**
- * @description Format: `int64`
+ * @description
+ * Format: `int64`
  * @type integer
 */
 export type CustomGetItemPathId = bigint;

--- a/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
@@ -1,6 +1,7 @@
 // Custom banner
 
 /**
+ * @description Format: `int64`
  * @type integer
 */
 export type CustomGetItemPathId = bigint;

--- a/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/Item.ts
+++ b/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/Item.ts
@@ -18,7 +18,8 @@ export type CustomItem = {
     */
     name: string;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     count?: number;

--- a/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/Item.ts
+++ b/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/Item.ts
@@ -7,6 +7,8 @@
 export type CustomItem = {
     /**
      * @description Unique identifier
+     *
+     * Format: `int64`
      * @type integer
     */
     id: bigint;
@@ -16,6 +18,7 @@ export type CustomItem = {
     */
     name: string;
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     count?: number;

--- a/tests/3.0.x/__snapshots__/main/simple/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/main/simple/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/main/simple/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/main/simple/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/main/simple/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/main/simple/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/main/simple/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/main/simple/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/main/simple/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/main/simple/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/main/simple/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/main/simple/types/User.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/User.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
@@ -6,7 +6,8 @@
 import type { Item } from "./Item.ts";
 
 /**
- * @description Format: `int64`
+ * @description
+ * Format: `int64`
  * @example test
  * @type integer
 */

--- a/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
@@ -6,6 +6,7 @@
 import type { Item } from "./Item.ts";
 
 /**
+ * @description Format: `int64`
  * @example test
  * @type integer
 */

--- a/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/Item.ts
+++ b/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/Item.ts
@@ -9,7 +9,8 @@
 */
 export type Item = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example test
      * @type integer
     */
@@ -20,7 +21,8 @@ export type Item = {
     */
     name: string;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example test
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/Item.ts
+++ b/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/Item.ts
@@ -9,6 +9,7 @@
 */
 export type Item = {
     /**
+     * @description Format: `int64`
      * @example test
      * @type integer
     */
@@ -19,6 +20,7 @@ export type Item = {
     */
     name: string;
     /**
+     * @description Format: `int32`
      * @example test
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPetRequest.ts
@@ -19,6 +19,7 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPetRequest.ts
@@ -19,7 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
 */
 export type AddPetRequest = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/ApiResponse.ts
@@ -8,6 +8,7 @@
 */
 export type ApiResponse = {
     /**
+     * @description Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/ApiResponse.ts
@@ -8,7 +8,8 @@
 */
 export type ApiResponse = {
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @type integer | undefined
     */
     code?: number;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Category.ts
@@ -8,6 +8,7 @@
 */
 export type Category = {
     /**
+     * @description Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Category.ts
@@ -8,7 +8,8 @@
 */
 export type Category = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Customer.ts
@@ -10,6 +10,7 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
+     * @description Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Customer.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Customer.ts
@@ -10,7 +10,8 @@ import type { Address } from "./Address.ts";
 */
 export type Customer = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 100000
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeleteOrderPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined;
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
 */
 export type DeletePetPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from "./Order.ts";
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetOrderByIdPathOrderId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from "./Pet.ts";
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
 */
 export type GetPetByIdPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Order.ts
@@ -16,21 +16,25 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
+     * @description Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
+     * @description Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
+     * @description Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Order.ts
@@ -16,25 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
 */
 export type Order = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */
     id?: bigint;
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 198772
      * @type integer | undefined
     */
     petId?: bigint;
     /**
-     * @description Format: `int32`
+     * @description
+     * Format: `int32`
      * @example 7
      * @type integer | undefined
     */
     quantity?: number;
     /**
-     * @description Format: `date-time`
+     * @description
+     * Format: `date-time`
      * @type string | undefined
     */
     shipDate?: string;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Pet.ts
@@ -19,6 +19,7 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Pet.ts
@@ -19,7 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
 */
 export type Pet = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Tag.ts
@@ -8,7 +8,8 @@
 */
 export type Tag = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Tag.ts
@@ -8,6 +8,7 @@
 */
 export type Tag = {
     /**
+     * @description Format: `int64`
      * @type integer | undefined
     */
     id?: bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UpdatePetWithFormPathPetId = bigint;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from "./ApiResponse.ts";
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
 */
 export type UploadFilePathPetId = bigint;
@@ -23,6 +25,7 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
+ * @description Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
@@ -25,7 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined;
 export type UploadFileStatus200 = ApiResponse;
 
 /**
- * @description Format: `binary`
+ * @description
+ * Format: `binary`
  * @type string | undefined
 */
 export type UploadFileData = Blob | undefined;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/User.ts
@@ -8,6 +8,7 @@
 */
 export type User = {
     /**
+     * @description Format: `int64`
      * @example 10
      * @type integer | undefined
     */
@@ -44,6 +45,8 @@ export type User = {
     phone?: string;
     /**
      * @description User Status
+     *
+     * Format: `int32`
      * @example 1
      * @type integer | undefined
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/User.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/User.ts
@@ -8,7 +8,8 @@
 */
 export type User = {
     /**
-     * @description Format: `int64`
+     * @description
+     * Format: `int64`
      * @example 10
      * @type integer | undefined
     */


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Add the format info into the `@description` of the generated type.


Closes #167 

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
