### PR TITLE
fix(plugins): handle optional OperationNode.method/path

### DIFF
--- a/.changeset/operation-optional-method-path.md
+++ b/.changeset/operation-optional-method-path.md
@@ -1,0 +1,11 @@
+---
+"@kubb/plugin-client": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-msw": patch
+"@kubb/plugin-cypress": patch
+"@kubb/plugin-mcp": patch
+"@kubb/plugin-zod": patch
+---
+
+Handle the now-optional `OperationNode.method`/`path` from `@kubb/ast` (generalized so non-HTTP specs map onto the same node). The client and query generators guard these accesses (`node.method?.toLowerCase()`, `new URLPath(node.path ?? '')`, etc.). For OpenAPI operations `method`/`path` are always present, so generated output is unchanged. Pairs with the `@kubb/ast` node-vocabulary change.

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -62,7 +62,7 @@ function getOperationLink(node: ast.OperationNode, link: OperationCommentLink): 
     return node.path ? `{@link ${new URLPath(node.path).URL}}` : null
   }
 
-  return `{@link ${node.path.replaceAll('{', ':').replaceAll('}', '')}}`
+  return `{@link ${(node.path ?? '').replaceAll('{', ':').replaceAll('}', '')}}`
 }
 
 export function getContentTypeInfo(node: ast.OperationNode): ContentTypeInfo {

--- a/internals/tanstack-query/src/components/MutationKey.tsx
+++ b/internals/tanstack-query/src/components/MutationKey.tsx
@@ -16,7 +16,7 @@ type Props = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export const mutationKeyTransformer: Transformer = ({ node, casing }) => {
-  const path = new URLPath(node.path, { casing })
+  const path = new URLPath(node.path ?? '', { casing })
   return [`{ url: '${path.toURLPath()}' }`]
 }
 

--- a/internals/tanstack-query/src/components/QueryKey.tsx
+++ b/internals/tanstack-query/src/components/QueryKey.tsx
@@ -21,7 +21,7 @@ type Props = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export const queryKeyTransformer: Transformer = ({ node, casing }) => {
-  const path = new URLPath(node.path, { casing })
+  const path = new URLPath(node.path ?? '', { casing })
   const hasQueryParams = getOperationParameters(node).query.length > 0
   const hasRequestBody = !!node.requestBody?.content?.[0]?.schema
 

--- a/internals/tanstack-query/src/utils.ts
+++ b/internals/tanstack-query/src/utils.ts
@@ -16,8 +16,8 @@ function matchesPattern(node: ast.OperationNode, ov: { type: string; pattern: st
   const matches = (value: string) => (typeof pattern === 'string' ? value === pattern : pattern.test(value))
   if (type === 'operationId') return matches(node.operationId)
   if (type === 'tag') return node.tags.some((t) => matches(t))
-  if (type === 'path') return matches(node.path)
-  if (type === 'method') return matches(node.method)
+  if (type === 'path') return node.path !== undefined && matches(node.path)
+  if (type === 'method') return node.method !== undefined && matches(node.method)
   return false
 }
 

--- a/packages/plugin-client/src/components/ClassClient.tsx
+++ b/packages/plugin-client/src/components/ClassClient.tsx
@@ -58,7 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
-  const path = new URLPath(node.path, { casing: paramsCasing })
+  const path = new URLPath(node.path ?? '', { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
   const { header: headerParams } = getOperationParameters(node)

--- a/packages/plugin-client/src/components/Client.tsx
+++ b/packages/plugin-client/src/components/Client.tsx
@@ -96,7 +96,7 @@ export function Client({
   children,
   isConfigurable = true,
 }: Props): KubbReactNode {
-  const path = new URLPath(node.path)
+  const path = new URLPath(node.path ?? '')
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
 
@@ -156,7 +156,7 @@ export function Client({
       mode: 'object',
       children: {
         method: {
-          value: JSON.stringify(node.method.toUpperCase()),
+          value: JSON.stringify(node.method?.toUpperCase()),
         },
         url: {
           value: urlName ? `${urlName}(${urlParamsCall}).url.toString()` : path.template,

--- a/packages/plugin-client/src/components/Operations.tsx
+++ b/packages/plugin-client/src/components/Operations.tsx
@@ -13,8 +13,8 @@ export function Operations({ name, nodes }: OperationsProps): KubbReactNode {
 
   nodes.forEach((node) => {
     operationsObject[node.operationId] = {
-      path: new URLPath(node.path).URL,
-      method: node.method.toLowerCase(),
+      path: new URLPath(node.path ?? '').URL,
+      method: node.method?.toLowerCase() ?? '',
     }
   })
 

--- a/packages/plugin-client/src/components/StaticClassClient.tsx
+++ b/packages/plugin-client/src/components/StaticClassClient.tsx
@@ -58,7 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
-  const path = new URLPath(node.path, { casing: paramsCasing })
+  const path = new URLPath(node.path ?? '', { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
   const { header: headerParams } = getOperationParameters(node)

--- a/packages/plugin-client/src/components/Url.tsx
+++ b/packages/plugin-client/src/components/Url.tsx
@@ -57,7 +57,7 @@ export function Url({
   node,
   tsResolver,
 }: Props): KubbReactNode {
-  const path = new URLPath(node.path)
+  const path = new URLPath(node.path ?? '')
 
   const paramsNode = buildUrlParamsNode({
     paramsType,
@@ -81,7 +81,7 @@ export function Url({
             .map(([originalName, camelCaseName]) => `const ${originalName} = ${camelCaseName}`)
             .join('\n')}
         {pathParamsMapping && Object.keys(pathParamsMapping).length > 0 && <br />}
-        <Const name={'res'}>{`{ method: '${node.method.toUpperCase()}', url: ${path.toTemplateString({ prefix: baseURL })} as const }`}</Const>
+        <Const name={'res'}>{`{ method: '${node.method?.toUpperCase()}', url: ${path.toTemplateString({ prefix: baseURL })} as const }`}</Const>
         <br />
         return res
       </Function>

--- a/packages/plugin-client/src/utils.ts
+++ b/packages/plugin-client/src/utils.ts
@@ -65,7 +65,7 @@ export function buildClassClientParams({
           mode: 'inlineSpread',
         },
         method: {
-          value: JSON.stringify(node.method.toUpperCase()),
+          value: JSON.stringify(node.method?.toUpperCase()),
         },
         url: {
           value: path.template,

--- a/packages/plugin-cypress/src/components/Request.tsx
+++ b/packages/plugin-cypress/src/components/Request.tsx
@@ -54,7 +54,7 @@ export function Request({ baseURL = '', name, dataReturnType, resolver, node, pa
   // even when the OpenAPI spec has inconsistent casing between the two.
   const pathParamNameMap = new Map(casedPathParams.map((p) => [camelCase(p.name), p.name]))
 
-  const urlPath = new URLPath(node.path, { casing: paramsCasing })
+  const urlPath = new URLPath(node.path ?? '', { casing: paramsCasing })
   const urlTemplate = urlPath.toTemplateString({
     prefix: baseURL,
     replacer: (param) => pathParamNameMap.get(camelCase(param)) ?? param,

--- a/packages/plugin-mcp/src/components/McpHandler.tsx
+++ b/packages/plugin-mcp/src/components/McpHandler.tsx
@@ -50,7 +50,7 @@ function buildRemappingCode(mapping: Record<string, string>, varName: string, so
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export function McpHandler({ name, node, resolver, baseURL, dataReturnType, paramsCasing }: Props): KubbReactNode {
-  const urlPath = new URLPath(node.path)
+  const urlPath = new URLPath(node.path ?? '')
   const contentType = node.requestBody?.content?.[0]?.contentType
   const isFormData = contentType === 'multipart/form-data'
 
@@ -86,7 +86,7 @@ export function McpHandler({ name, node, resolver, baseURL, dataReturnType, para
   const headers = [headerParams.length ? (headerParamsMapping ? '...mappedHeaders' : '...headers') : null, contentTypeHeader].filter(Boolean)
 
   const fetchConfig: Array<string> = []
-  fetchConfig.push(`method: ${JSON.stringify(node.method.toUpperCase())}`)
+  fetchConfig.push(`method: ${JSON.stringify(node.method?.toUpperCase())}`)
   fetchConfig.push(`url: ${urlPath.template}`)
   if (baseURL) fetchConfig.push(`baseURL: \`${baseURL}\``)
   if (queryParams.length) fetchConfig.push(queryParamsMapping ? 'params: mappedParams' : 'params')

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -70,7 +70,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
         tool: {
           name: node.operationId,
           title: node.summary || undefined,
-          description: node.description || `Make a ${node.method.toUpperCase()} request to ${node.path}`,
+          description: node.description || `Make a ${node.method?.toUpperCase()} request to ${node.path}`,
         },
         mcp: {
           name: resolver.resolveHandlerName(node),

--- a/packages/plugin-msw/src/utils.ts
+++ b/packages/plugin-msw/src/utils.ts
@@ -30,14 +30,14 @@ function getResponseContentType(response: ast.ResponseNode | null | undefined): 
  * Converts an HTTP method to its lowercase MSW equivalent (e.g., 'POST' → 'post').
  */
 export function getMswMethod(node: ast.OperationNode): string {
-  return node.method.toLowerCase()
+  return node.method?.toLowerCase() ?? ''
 }
 
 /**
  * Converts an OpenAPI-style path to an Express/MSW-style path by replacing `{param}` with `:param`.
  */
 export function getMswUrl(node: ast.OperationNode): string {
-  return node.path.replaceAll('{', ':').replaceAll('}', '')
+  return (node.path ?? '').replaceAll('{', ':').replaceAll('}', '')
 }
 
 /**

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -45,12 +45,12 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       // query: false means "still a query but skip the useQuery hook"
       const isQueryOp =
         nodeQuery === false
-          ? !!query && query.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
-          : !!nodeQuery && nodeQuery.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
+          ? !!query && query.methods.some((m) => node.method?.toLowerCase() === m.toLowerCase())
+          : !!nodeQuery && nodeQuery.methods.some((m) => node.method?.toLowerCase() === m.toLowerCase())
       const isMutationOp =
         nodeMutation !== false &&
         !isQueryOp &&
-        difference(nodeMutation ? nodeMutation.methods : [], nodeQuery ? nodeQuery.methods : []).some((m) => node.method.toLowerCase() === m.toLowerCase())
+        difference(nodeMutation ? nodeMutation.methods : [], nodeQuery ? nodeQuery.methods : []).some((m) => node.method?.toLowerCase() === m.toLowerCase())
       const isSuspenseOp = !!suspense
       const isInfiniteOp = !!nodeInfiniteOptions
 

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -27,11 +27,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -26,11 +26,11 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -27,11 +27,11 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     // query: false means "this IS a query op, but skip the useQuery hook"
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -40,11 +40,11 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -28,11 +28,11 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     // query: false means "this IS a query op" (suspense hooks still generate)
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
 
     if (!isQuery || isMutation || !isSuspense) return null

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -27,11 +27,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -26,11 +26,11 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -26,11 +26,11 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method?.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method?.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-zod/src/components/Operations.tsx
+++ b/packages/plugin-zod/src/components/Operations.tsx
@@ -32,7 +32,7 @@ export function Operations({ name, operations }: Props): KubbReactNode {
   const pathsJSON = operations.reduce<Record<string, Record<string, string>>>((prev, acc) => {
     prev[`"${acc.node.path}"`] = {
       ...(prev[`"${acc.node.path}"`] ?? {}),
-      [acc.node.method]: `operations["${acc.node.operationId}"]`,
+      [acc.node.method ?? '']: `operations["${acc.node.operationId}"]`,
     }
 
     return prev


### PR DESCRIPTION
## Summary

Coordinated follow-up to **kubb-labs/kubb#3378**, which generalizes `@kubb/ast`'s `OperationNode` so `method` and `path` become **optional** (non-HTTP specs use `protocol`/`action`/`channel` instead). This guards every place the client/query/mock generators read those fields.

- `node.method?.toLowerCase()` / `node.method?.toUpperCase()` in the react-query, vue-query, client, msw, and mcp generators.
- `new URLPath(node.path ?? '')` in client/cypress/mcp components and the shared tanstack-query key components.
- Guarded the `path`/`method` filter predicates in `@internals/tanstack-query` and the `getMswUrl`/`getMswMethod` helpers.
- `[acc.node.method ?? '']` for the computed key in the zod operations object.

For OpenAPI operations `method`/`path` are always present, so **generated output is unchanged** — these are forward-compatible guards.

## Release ordering

Depends on `@kubb/ast` from kubb#3378. In this environment the plugins still resolve the published `@kubb/ast` (where `method`/`path` are required), so these guards are verified output-neutral against the current types; they become *necessary* once the new `@kubb/ast` is released and the catalog bumps. **CI will fully validate after kubb#3378 releases.**

## Test plan

- [x] Typecheck clean across all 9 affected packages (current `@kubb/ast`)
- [x] Affected suites green: client / react-query / vue-query / msw / mcp / zod (444 tests) — output unchanged
- [x] oxfmt + oxlint clean
- [ ] CI green against the released `@kubb/ast` from kubb#3378


---
_Generated by [Claude Code](https://claude.ai/code/session_01FMNrXFj7FiJp4nPbUHbqap)_