### PR TITLE
refactor: adopt @kubb/ast HttpOperationNode union

### DIFF
--- a/.changeset/operation-optional-method-path.md
+++ b/.changeset/operation-optional-method-path.md
@@ -8,4 +8,4 @@
 "@kubb/plugin-zod": patch
 ---
 
-Handle the now-optional `method`/`path` on `@kubb/ast`'s `OperationNode`. These plugins target OpenAPI, where both fields are always present, so they assert the value where a definite `method`/`path` is required. OpenAPI output is unchanged.
+Adopt `@kubb/ast`'s `HttpOperationNode` union. Each operation generator narrows the incoming node with `ast.isHttpOperationNode` (HTTP-only plugins), and shared helpers/components accept `ast.HttpOperationNode`, so `method`/`path` are non-nullable without manual assertions. OpenAPI output is unchanged.

--- a/.changeset/operation-optional-method-path.md
+++ b/.changeset/operation-optional-method-path.md
@@ -1,0 +1,11 @@
+---
+"@kubb/plugin-client": patch
+"@kubb/plugin-cypress": patch
+"@kubb/plugin-mcp": patch
+"@kubb/plugin-msw": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-zod": patch
+---
+
+Handle the now-optional `method`/`path` on `@kubb/ast`'s `OperationNode`. These plugins target OpenAPI, where both fields are always present, so they assert the value where a definite `method`/`path` is required. OpenAPI output is unchanged.

--- a/examples/advanced/src/gen/models/ts/AddPetRequest.ts
+++ b/examples/advanced/src/gen/models/ts/AddPetRequest.ts
@@ -14,6 +14,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/advanced/src/gen/models/ts/ApiResponse.ts
+++ b/examples/advanced/src/gen/models/ts/ApiResponse.ts
@@ -3,6 +3,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/advanced/src/gen/models/ts/Category.ts
+++ b/examples/advanced/src/gen/models/ts/Category.ts
@@ -3,6 +3,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/advanced/src/gen/models/ts/Customer.ts
+++ b/examples/advanced/src/gen/models/ts/Customer.ts
@@ -13,6 +13,8 @@ export type CustomerParamsStatusEnumKey = (typeof customerParamsStatusEnum)[keyo
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/advanced/src/gen/models/ts/Order.ts
+++ b/examples/advanced/src/gen/models/ts/Order.ts
@@ -34,11 +34,15 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: number
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -59,6 +63,8 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
@@ -74,6 +80,8 @@ export type Order = {
    */
   type?: string
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/advanced/src/gen/models/ts/Pet.ts
+++ b/examples/advanced/src/gen/models/ts/Pet.ts
@@ -14,6 +14,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -33,6 +35,8 @@ export type Pet = {
    */
   name: string
   /**
+   * @description
+   * Format: `uri`
    * @maxLength 255
    * @type string | undefined
    */

--- a/examples/advanced/src/gen/models/ts/PetNotFound.ts
+++ b/examples/advanced/src/gen/models/ts/PetNotFound.ts
@@ -3,6 +3,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/advanced/src/gen/models/ts/User.ts
+++ b/examples/advanced/src/gen/models/ts/User.ts
@@ -5,6 +5,8 @@ import type { TagTag } from './tag/Tag.ts'
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -15,6 +17,8 @@ export type User = {
    */
   username?: string
   /**
+   * @description
+   * Format: `uuid`
    * @deprecated
    * @type string | undefined
    */
@@ -36,6 +40,8 @@ export type User = {
    */
   lastName?: string
   /**
+   * @description
+   * Format: `email`
    * @example john@email.com
    * @type string | undefined
    */
@@ -52,6 +58,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/advanced/src/gen/models/ts/petController/AddFiles.ts
+++ b/examples/advanced/src/gen/models/ts/petController/AddFiles.ts
@@ -16,6 +16,8 @@ export type AddFilesStatus405 = any
 export type AddFilesJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string

--- a/examples/advanced/src/gen/models/ts/petController/AddPet.ts
+++ b/examples/advanced/src/gen/models/ts/petController/AddPet.ts
@@ -6,6 +6,8 @@ import type { Pet } from '../Pet.ts'
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/advanced/src/gen/models/ts/petController/DeletePet.ts
+++ b/examples/advanced/src/gen/models/ts/petController/DeletePet.ts
@@ -5,6 +5,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = number

--- a/examples/advanced/src/gen/models/ts/petController/GetPetById.ts
+++ b/examples/advanced/src/gen/models/ts/petController/GetPetById.ts
@@ -2,6 +2,8 @@ import type { Pet } from '../Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = number

--- a/examples/advanced/src/gen/models/ts/petController/UpdatePet.ts
+++ b/examples/advanced/src/gen/models/ts/petController/UpdatePet.ts
@@ -10,6 +10,8 @@ export type UpdatePetStatus200 = Omit<NonNullable<Pet>, 'name'>
  */
 export type UpdatePetStatus202 = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/advanced/src/gen/models/ts/petController/UpdatePetWithForm.ts
+++ b/examples/advanced/src/gen/models/ts/petController/UpdatePetWithForm.ts
@@ -1,5 +1,7 @@
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = number

--- a/examples/advanced/src/gen/models/ts/petController/UploadFile.ts
+++ b/examples/advanced/src/gen/models/ts/petController/UploadFile.ts
@@ -2,6 +2,8 @@ import type { ApiResponse } from '../ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = number
@@ -18,6 +20,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string
  */
 export type UploadFileData = Blob

--- a/examples/advanced/src/gen/models/ts/storeController/DeleteOrder.ts
+++ b/examples/advanced/src/gen/models/ts/storeController/DeleteOrder.ts
@@ -1,5 +1,7 @@
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = number

--- a/examples/advanced/src/gen/models/ts/storeController/GetOrderById.ts
+++ b/examples/advanced/src/gen/models/ts/storeController/GetOrderById.ts
@@ -2,6 +2,8 @@ import type { Order } from '../Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = number

--- a/examples/advanced/src/gen/models/ts/tag/Tag.ts
+++ b/examples/advanced/src/gen/models/ts/tag/Tag.ts
@@ -4,6 +4,8 @@
  */
 export type TagTag = {
   /**
+   * @description
+   * Format: `int64`
    * @deprecated
    * @default 1
    * @type integer | undefined

--- a/examples/client/src/gen/models/ts/AddPetRequest.ts
+++ b/examples/client/src/gen/models/ts/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen/models/ts/ApiResponse.ts
+++ b/examples/client/src/gen/models/ts/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen/models/ts/Category.ts
+++ b/examples/client/src/gen/models/ts/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen/models/ts/Customer.ts
+++ b/examples/client/src/gen/models/ts/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.js'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/client/src/gen/models/ts/Order.ts
+++ b/examples/client/src/gen/models/ts/Order.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: Date

--- a/examples/client/src/gen/models/ts/Pet.ts
+++ b/examples/client/src/gen/models/ts/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen/models/ts/PetNotFound.ts
+++ b/examples/client/src/gen/models/ts/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen/models/ts/Tag.ts
+++ b/examples/client/src/gen/models/ts/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/client/src/gen/models/ts/User.ts
+++ b/examples/client/src/gen/models/ts/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen/models/ts/petController/AddPet.ts
+++ b/examples/client/src/gen/models/ts/petController/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen/models/ts/petController/DeletePet.ts
+++ b/examples/client/src/gen/models/ts/petController/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/client/src/gen/models/ts/petController/GetPetById.ts
+++ b/examples/client/src/gen/models/ts/petController/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from '../Pet.js'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/client/src/gen/models/ts/petController/UpdatePetWithForm.ts
+++ b/examples/client/src/gen/models/ts/petController/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/client/src/gen/models/ts/petController/UploadFile.ts
+++ b/examples/client/src/gen/models/ts/petController/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from '../ApiResponse.js'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -28,6 +30,8 @@ export type UploadFileStatus200 = ApiResponse
 export type UploadFileJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string
@@ -38,6 +42,8 @@ export type UploadFileJsonData = {
  */
 export type UploadFileFormData = {
   /**
+   * @description
+   * Format: `binary`
    * @type string
    */
   file: Blob

--- a/examples/client/src/gen/models/ts/storeController/DeleteOrder.ts
+++ b/examples/client/src/gen/models/ts/storeController/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/client/src/gen/models/ts/storeController/GetOrderById.ts
+++ b/examples/client/src/gen/models/ts/storeController/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from '../Order.js'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/client/src/gen2/models/AddPet.ts
+++ b/examples/client/src/gen2/models/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen2/models/AddPetRequest.ts
+++ b/examples/client/src/gen2/models/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen2/models/ApiResponse.ts
+++ b/examples/client/src/gen2/models/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen2/models/Category.ts
+++ b/examples/client/src/gen2/models/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen2/models/Customer.ts
+++ b/examples/client/src/gen2/models/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/client/src/gen2/models/DeleteOrder.ts
+++ b/examples/client/src/gen2/models/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/client/src/gen2/models/DeletePet.ts
+++ b/examples/client/src/gen2/models/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/client/src/gen2/models/GetOrderById.ts
+++ b/examples/client/src/gen2/models/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from './Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/client/src/gen2/models/GetPetById.ts
+++ b/examples/client/src/gen2/models/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from './Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/client/src/gen2/models/Order.ts
+++ b/examples/client/src/gen2/models/Order.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/client/src/gen2/models/Pet.ts
+++ b/examples/client/src/gen2/models/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen2/models/PetNotFound.ts
+++ b/examples/client/src/gen2/models/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen2/models/Tag.ts
+++ b/examples/client/src/gen2/models/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/client/src/gen2/models/UpdatePetWithForm.ts
+++ b/examples/client/src/gen2/models/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/client/src/gen2/models/UploadFile.ts
+++ b/examples/client/src/gen2/models/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from './ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -28,6 +30,8 @@ export type UploadFileStatus200 = ApiResponse
 export type UploadFileJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string
@@ -38,6 +42,8 @@ export type UploadFileJsonData = {
  */
 export type UploadFileFormData = {
   /**
+   * @description
+   * Format: `binary`
    * @type string
    */
   file: Blob

--- a/examples/client/src/gen2/models/User.ts
+++ b/examples/client/src/gen2/models/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen3/models/ts/AddPetRequest.ts
+++ b/examples/client/src/gen3/models/ts/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen3/models/ts/ApiResponse.ts
+++ b/examples/client/src/gen3/models/ts/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen3/models/ts/Category.ts
+++ b/examples/client/src/gen3/models/ts/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen3/models/ts/Customer.ts
+++ b/examples/client/src/gen3/models/ts/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/client/src/gen3/models/ts/Order.ts
+++ b/examples/client/src/gen3/models/ts/Order.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: Date

--- a/examples/client/src/gen3/models/ts/Pet.ts
+++ b/examples/client/src/gen3/models/ts/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen3/models/ts/PetNotFound.ts
+++ b/examples/client/src/gen3/models/ts/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen3/models/ts/Tag.ts
+++ b/examples/client/src/gen3/models/ts/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/client/src/gen3/models/ts/User.ts
+++ b/examples/client/src/gen3/models/ts/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen3/models/ts/petController/AddPet.ts
+++ b/examples/client/src/gen3/models/ts/petController/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen3/models/ts/petController/DeletePet.ts
+++ b/examples/client/src/gen3/models/ts/petController/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/client/src/gen3/models/ts/petController/GetPetById.ts
+++ b/examples/client/src/gen3/models/ts/petController/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from '../Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/client/src/gen3/models/ts/petController/UpdatePetWithForm.ts
+++ b/examples/client/src/gen3/models/ts/petController/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/client/src/gen3/models/ts/petController/UploadFile.ts
+++ b/examples/client/src/gen3/models/ts/petController/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from '../ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -28,6 +30,8 @@ export type UploadFileStatus200 = ApiResponse
 export type UploadFileJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string
@@ -38,6 +42,8 @@ export type UploadFileJsonData = {
  */
 export type UploadFileFormData = {
   /**
+   * @description
+   * Format: `binary`
    * @type string
    */
   file: Blob

--- a/examples/client/src/gen3/models/ts/storeController/DeleteOrder.ts
+++ b/examples/client/src/gen3/models/ts/storeController/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/client/src/gen3/models/ts/storeController/GetOrderById.ts
+++ b/examples/client/src/gen3/models/ts/storeController/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from '../Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/client/src/gen6/models/ts/AddPetRequest.ts
+++ b/examples/client/src/gen6/models/ts/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen6/models/ts/ApiResponse.ts
+++ b/examples/client/src/gen6/models/ts/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen6/models/ts/Category.ts
+++ b/examples/client/src/gen6/models/ts/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen6/models/ts/Customer.ts
+++ b/examples/client/src/gen6/models/ts/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/client/src/gen6/models/ts/Order.ts
+++ b/examples/client/src/gen6/models/ts/Order.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: Date

--- a/examples/client/src/gen6/models/ts/Pet.ts
+++ b/examples/client/src/gen6/models/ts/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen6/models/ts/PetNotFound.ts
+++ b/examples/client/src/gen6/models/ts/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen6/models/ts/Tag.ts
+++ b/examples/client/src/gen6/models/ts/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/client/src/gen6/models/ts/User.ts
+++ b/examples/client/src/gen6/models/ts/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen6/models/ts/petController/AddPet.ts
+++ b/examples/client/src/gen6/models/ts/petController/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen6/models/ts/petController/DeletePet.ts
+++ b/examples/client/src/gen6/models/ts/petController/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/client/src/gen6/models/ts/petController/GetPetById.ts
+++ b/examples/client/src/gen6/models/ts/petController/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from '../Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/client/src/gen6/models/ts/petController/UpdatePetWithForm.ts
+++ b/examples/client/src/gen6/models/ts/petController/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/client/src/gen6/models/ts/petController/UploadFile.ts
+++ b/examples/client/src/gen6/models/ts/petController/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from '../ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -28,6 +30,8 @@ export type UploadFileStatus200 = ApiResponse
 export type UploadFileJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string
@@ -38,6 +42,8 @@ export type UploadFileJsonData = {
  */
 export type UploadFileFormData = {
   /**
+   * @description
+   * Format: `binary`
    * @type string
    */
   file: Blob

--- a/examples/client/src/gen6/models/ts/storeController/DeleteOrder.ts
+++ b/examples/client/src/gen6/models/ts/storeController/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/client/src/gen6/models/ts/storeController/GetOrderById.ts
+++ b/examples/client/src/gen6/models/ts/storeController/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from '../Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/client/src/gen7/models/ts/AddPetRequest.ts
+++ b/examples/client/src/gen7/models/ts/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen7/models/ts/ApiResponse.ts
+++ b/examples/client/src/gen7/models/ts/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen7/models/ts/Category.ts
+++ b/examples/client/src/gen7/models/ts/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen7/models/ts/Customer.ts
+++ b/examples/client/src/gen7/models/ts/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/client/src/gen7/models/ts/Order.ts
+++ b/examples/client/src/gen7/models/ts/Order.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: Date

--- a/examples/client/src/gen7/models/ts/Pet.ts
+++ b/examples/client/src/gen7/models/ts/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/client/src/gen7/models/ts/PetNotFound.ts
+++ b/examples/client/src/gen7/models/ts/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen7/models/ts/Tag.ts
+++ b/examples/client/src/gen7/models/ts/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/client/src/gen7/models/ts/User.ts
+++ b/examples/client/src/gen7/models/ts/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/client/src/gen7/models/ts/petController/AddPet.ts
+++ b/examples/client/src/gen7/models/ts/petController/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/client/src/gen7/models/ts/petController/DeletePet.ts
+++ b/examples/client/src/gen7/models/ts/petController/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/client/src/gen7/models/ts/petController/GetPetById.ts
+++ b/examples/client/src/gen7/models/ts/petController/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from '../Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/client/src/gen7/models/ts/petController/UpdatePetWithForm.ts
+++ b/examples/client/src/gen7/models/ts/petController/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/client/src/gen7/models/ts/petController/UploadFile.ts
+++ b/examples/client/src/gen7/models/ts/petController/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from '../ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -28,6 +30,8 @@ export type UploadFileStatus200 = ApiResponse
 export type UploadFileJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string
@@ -38,6 +42,8 @@ export type UploadFileJsonData = {
  */
 export type UploadFileFormData = {
   /**
+   * @description
+   * Format: `binary`
    * @type string
    */
   file: Blob

--- a/examples/client/src/gen7/models/ts/storeController/DeleteOrder.ts
+++ b/examples/client/src/gen7/models/ts/storeController/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/client/src/gen7/models/ts/storeController/GetOrderById.ts
+++ b/examples/client/src/gen7/models/ts/storeController/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from '../Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/cypress/src/gen-v4/models.ts
+++ b/examples/cypress/src/gen-v4/models.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -91,6 +99,8 @@ export type Address = {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -111,6 +121,8 @@ export type Customer = {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -127,6 +139,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -163,6 +177,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -174,6 +190,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -196,6 +214,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -237,6 +257,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -270,6 +292,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -288,6 +312,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -381,6 +407,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -589,6 +617,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -643,6 +673,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -708,6 +740,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -755,6 +789,8 @@ export type DeletePetResponse = DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -771,6 +807,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -954,6 +992,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1008,6 +1048,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/cypress/src/gen/models.ts
+++ b/examples/cypress/src/gen/models.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -91,6 +99,8 @@ export type Address = {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -111,6 +121,8 @@ export type Customer = {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -127,6 +139,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -163,6 +177,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -174,6 +190,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -196,6 +214,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -237,6 +257,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -270,6 +292,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -288,6 +312,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -381,6 +407,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -589,6 +617,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -643,6 +673,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -708,6 +740,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -755,6 +789,8 @@ export type DeletePetResponse = DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -771,6 +807,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -954,6 +992,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1008,6 +1048,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/faker/src/gen/models/ApiResponse.ts
+++ b/examples/faker/src/gen/models/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/faker/src/gen/models/Category.ts
+++ b/examples/faker/src/gen/models/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/faker/src/gen/models/Customer.ts
+++ b/examples/faker/src/gen/models/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/faker/src/gen/models/DeleteOrder.ts
+++ b/examples/faker/src/gen/models/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/faker/src/gen/models/DeletePet.ts
+++ b/examples/faker/src/gen/models/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/faker/src/gen/models/GetOrderById.ts
+++ b/examples/faker/src/gen/models/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from './Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/faker/src/gen/models/GetPetById.ts
+++ b/examples/faker/src/gen/models/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from './Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/faker/src/gen/models/Order.ts
+++ b/examples/faker/src/gen/models/Order.ts
@@ -16,29 +16,41 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDateTime?: string
   /**
+   * @description
+   * Format: `date`
    * @type string | undefined
    */
   shipDate?: string
   /**
+   * @description
+   * Format: `time`
    * @type string | undefined
    */
   shipTime?: string

--- a/examples/faker/src/gen/models/Pet.ts
+++ b/examples/faker/src/gen/models/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/faker/src/gen/models/Tag.ts
+++ b/examples/faker/src/gen/models/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/faker/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/faker/src/gen/models/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/faker/src/gen/models/UploadFile.ts
+++ b/examples/faker/src/gen/models/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from './ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -23,6 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined

--- a/examples/faker/src/gen/models/User.ts
+++ b/examples/faker/src/gen/models/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/fetch/src/gen/models.ts
+++ b/examples/fetch/src/gen/models.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -91,6 +99,8 @@ export type Address = {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -111,6 +121,8 @@ export type Customer = {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -127,6 +139,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -163,6 +177,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -174,6 +190,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -196,6 +214,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -237,6 +257,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -270,6 +292,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -288,6 +312,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -381,6 +407,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -558,6 +586,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -612,6 +642,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -677,6 +709,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -724,6 +758,8 @@ export type DeletePetResponse = DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -745,6 +781,8 @@ export type UploadFileStatus200 = ApiResponse
 export type UploadFileJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string
@@ -755,6 +793,8 @@ export type UploadFileJsonData = {
  */
 export type UploadFileFormData = {
   /**
+   * @description
+   * Format: `binary`
    * @type string
    */
   file: Blob
@@ -941,6 +981,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -995,6 +1037,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/mcp/src/gen/models/ts/AddFiles.ts
+++ b/examples/mcp/src/gen/models/ts/AddFiles.ts
@@ -22,6 +22,8 @@ export type AddFilesJsonData =
   | {
       /**
        * @description URL of the image to upload
+       *
+       * Format: `uri`
        * @type string
        */
       url: string

--- a/examples/mcp/src/gen/models/ts/AddPet.ts
+++ b/examples/mcp/src/gen/models/ts/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Omit<NonNullable<Pet>, 'name'>
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/mcp/src/gen/models/ts/AddPetRequest.ts
+++ b/examples/mcp/src/gen/models/ts/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/mcp/src/gen/models/ts/ApiResponse.ts
+++ b/examples/mcp/src/gen/models/ts/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/mcp/src/gen/models/ts/Category.ts
+++ b/examples/mcp/src/gen/models/ts/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/mcp/src/gen/models/ts/Customer.ts
+++ b/examples/mcp/src/gen/models/ts/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.js'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/mcp/src/gen/models/ts/DeleteOrder.ts
+++ b/examples/mcp/src/gen/models/ts/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = number

--- a/examples/mcp/src/gen/models/ts/DeletePet.ts
+++ b/examples/mcp/src/gen/models/ts/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = number

--- a/examples/mcp/src/gen/models/ts/GetOrderById.ts
+++ b/examples/mcp/src/gen/models/ts/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from './Order.js'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = number

--- a/examples/mcp/src/gen/models/ts/GetPetById.ts
+++ b/examples/mcp/src/gen/models/ts/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from './Pet.js'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = number

--- a/examples/mcp/src/gen/models/ts/Order.ts
+++ b/examples/mcp/src/gen/models/ts/Order.ts
@@ -31,16 +31,22 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: number
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: number
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
@@ -56,6 +62,8 @@ export type Order = {
    */
   type?: string
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/mcp/src/gen/models/ts/Pet.ts
+++ b/examples/mcp/src/gen/models/ts/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/mcp/src/gen/models/ts/PetNotFound.ts
+++ b/examples/mcp/src/gen/models/ts/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/mcp/src/gen/models/ts/UpdatePet.ts
+++ b/examples/mcp/src/gen/models/ts/UpdatePet.ts
@@ -15,6 +15,8 @@ export type UpdatePetStatus200 = Omit<NonNullable<Pet>, 'name'>
  */
 export type UpdatePetStatus202 = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/mcp/src/gen/models/ts/UpdatePetWithForm.ts
+++ b/examples/mcp/src/gen/models/ts/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = number

--- a/examples/mcp/src/gen/models/ts/User.ts
+++ b/examples/mcp/src/gen/models/ts/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -18,6 +20,8 @@ export type User = {
    */
   username?: string
   /**
+   * @description
+   * Format: `uuid`
    * @deprecated
    * @type string | undefined
    */
@@ -33,6 +37,8 @@ export type User = {
    */
   lastName?: string
   /**
+   * @description
+   * Format: `email`
    * @example john@email.com
    * @type string | undefined
    */
@@ -49,6 +55,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/mcp/src/gen/models/ts/tag/Tag.ts
+++ b/examples/mcp/src/gen/models/ts/tag/Tag.ts
@@ -9,6 +9,8 @@
  */
 export type TagTag = {
   /**
+   * @description
+   * Format: `int64`
    * @deprecated
    * @default 1
    * @type integer | undefined

--- a/examples/msw/src/gen/models/AddPet.ts
+++ b/examples/msw/src/gen/models/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/msw/src/gen/models/AddPetRequest.ts
+++ b/examples/msw/src/gen/models/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/msw/src/gen/models/ApiResponse.ts
+++ b/examples/msw/src/gen/models/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/msw/src/gen/models/Category.ts
+++ b/examples/msw/src/gen/models/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/msw/src/gen/models/Customer.ts
+++ b/examples/msw/src/gen/models/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/msw/src/gen/models/DeleteOrder.ts
+++ b/examples/msw/src/gen/models/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/msw/src/gen/models/DeletePet.ts
+++ b/examples/msw/src/gen/models/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/msw/src/gen/models/GetOrderById.ts
+++ b/examples/msw/src/gen/models/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from './Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/msw/src/gen/models/GetPetById.ts
+++ b/examples/msw/src/gen/models/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from './Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/msw/src/gen/models/Order.ts
+++ b/examples/msw/src/gen/models/Order.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/msw/src/gen/models/Pet.ts
+++ b/examples/msw/src/gen/models/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/msw/src/gen/models/PetNotFound.ts
+++ b/examples/msw/src/gen/models/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/msw/src/gen/models/Tag.ts
+++ b/examples/msw/src/gen/models/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/msw/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/msw/src/gen/models/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/msw/src/gen/models/UploadFile.ts
+++ b/examples/msw/src/gen/models/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from './ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -23,6 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined

--- a/examples/msw/src/gen/models/User.ts
+++ b/examples/msw/src/gen/models/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/react-query/src/gen/models/AddPet.ts
+++ b/examples/react-query/src/gen/models/AddPet.ts
@@ -13,6 +13,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/react-query/src/gen/models/AddPetRequest.ts
+++ b/examples/react-query/src/gen/models/AddPetRequest.ts
@@ -16,6 +16,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/react-query/src/gen/models/ApiResponse.ts
+++ b/examples/react-query/src/gen/models/ApiResponse.ts
@@ -5,6 +5,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/react-query/src/gen/models/Category.ts
+++ b/examples/react-query/src/gen/models/Category.ts
@@ -5,6 +5,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/react-query/src/gen/models/Customer.ts
+++ b/examples/react-query/src/gen/models/Customer.ts
@@ -7,6 +7,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/react-query/src/gen/models/DeleteOrder.ts
+++ b/examples/react-query/src/gen/models/DeleteOrder.ts
@@ -2,6 +2,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = number

--- a/examples/react-query/src/gen/models/DeletePet.ts
+++ b/examples/react-query/src/gen/models/DeletePet.ts
@@ -7,6 +7,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = number

--- a/examples/react-query/src/gen/models/GetOrderById.ts
+++ b/examples/react-query/src/gen/models/GetOrderById.ts
@@ -4,6 +4,8 @@ import type { Order } from './Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = number

--- a/examples/react-query/src/gen/models/GetPetById.ts
+++ b/examples/react-query/src/gen/models/GetPetById.ts
@@ -4,6 +4,8 @@ import type { Pet } from './Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = number

--- a/examples/react-query/src/gen/models/Order.ts
+++ b/examples/react-query/src/gen/models/Order.ts
@@ -21,21 +21,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: number
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: number
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/react-query/src/gen/models/Pet.ts
+++ b/examples/react-query/src/gen/models/Pet.ts
@@ -16,6 +16,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/react-query/src/gen/models/PetNotFound.ts
+++ b/examples/react-query/src/gen/models/PetNotFound.ts
@@ -5,6 +5,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/react-query/src/gen/models/Tag.ts
+++ b/examples/react-query/src/gen/models/Tag.ts
@@ -5,6 +5,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: number

--- a/examples/react-query/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/react-query/src/gen/models/UpdatePetWithForm.ts
@@ -2,6 +2,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = number

--- a/examples/react-query/src/gen/models/UploadFile.ts
+++ b/examples/react-query/src/gen/models/UploadFile.ts
@@ -4,6 +4,8 @@ import type { ApiResponse } from './ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = number
@@ -20,6 +22,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined

--- a/examples/react-query/src/gen/models/User.ts
+++ b/examples/react-query/src/gen/models/User.ts
@@ -5,6 +5,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -41,6 +43,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/sdk/src/gen/models/AddPetRequest.ts
+++ b/examples/sdk/src/gen/models/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/sdk/src/gen/models/ApiResponse.ts
+++ b/examples/sdk/src/gen/models/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/sdk/src/gen/models/Category.ts
+++ b/examples/sdk/src/gen/models/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/sdk/src/gen/models/Customer.ts
+++ b/examples/sdk/src/gen/models/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/sdk/src/gen/models/Order.ts
+++ b/examples/sdk/src/gen/models/Order.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/sdk/src/gen/models/Pet.ts
+++ b/examples/sdk/src/gen/models/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/sdk/src/gen/models/PetNotFound.ts
+++ b/examples/sdk/src/gen/models/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/sdk/src/gen/models/Tag.ts
+++ b/examples/sdk/src/gen/models/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/sdk/src/gen/models/User.ts
+++ b/examples/sdk/src/gen/models/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/sdk/src/gen/models/petController/AddPet.ts
+++ b/examples/sdk/src/gen/models/petController/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/sdk/src/gen/models/petController/DeletePet.ts
+++ b/examples/sdk/src/gen/models/petController/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/sdk/src/gen/models/petController/GetPetById.ts
+++ b/examples/sdk/src/gen/models/petController/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from '../Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/sdk/src/gen/models/petController/UpdatePetWithForm.ts
+++ b/examples/sdk/src/gen/models/petController/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/sdk/src/gen/models/petController/UploadFile.ts
+++ b/examples/sdk/src/gen/models/petController/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from '../ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -28,6 +30,8 @@ export type UploadFileStatus200 = ApiResponse
 export type UploadFileJsonData = {
   /**
    * @description URL of the image to upload
+   *
+   * Format: `uri`
    * @type string
    */
   url: string
@@ -38,6 +42,8 @@ export type UploadFileJsonData = {
  */
 export type UploadFileFormData = {
   /**
+   * @description
+   * Format: `binary`
    * @type string
    */
   file: Blob

--- a/examples/sdk/src/gen/models/storeController/DeleteOrder.ts
+++ b/examples/sdk/src/gen/models/storeController/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/sdk/src/gen/models/storeController/GetOrderById.ts
+++ b/examples/sdk/src/gen/models/storeController/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from '../Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/simple-single/src/gen/models.ts
+++ b/examples/simple-single/src/gen/models.ts
@@ -24,21 +24,29 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -91,6 +99,8 @@ export type Address = {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -111,6 +121,8 @@ export type Customer = {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -134,6 +146,8 @@ export type Person = {
 
 export type User = Person & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -170,6 +184,8 @@ export type User = Person & {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -181,6 +197,8 @@ export type User = Person & {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -203,6 +221,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -244,6 +264,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -277,6 +299,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -295,6 +319,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -388,6 +414,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -565,6 +593,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -619,6 +649,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -684,6 +716,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -731,6 +765,8 @@ export type DeletePetResponse = DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -747,6 +783,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -930,6 +968,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -984,6 +1024,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen/models.ts
+++ b/examples/typescript/src/gen/models.ts
@@ -30,11 +30,15 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export interface Order {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -55,11 +59,15 @@ export interface Order {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -121,6 +129,8 @@ export type CustomerParamsStatusEnumKey = (typeof customerParamsStatusEnum)[keyo
  */
 export interface Customer {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -174,6 +184,8 @@ export type UnhappyCustomer = Customer & {
  */
 export interface Category {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -190,6 +202,8 @@ export interface Category {
  */
 export interface User {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -226,6 +240,8 @@ export interface User {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -237,6 +253,8 @@ export interface User {
  */
 export interface Tag {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -306,6 +324,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -364,6 +384,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export interface AddPetRequest {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -397,6 +419,8 @@ export interface AddPetRequest {
  */
 export interface ApiResponse {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -415,6 +439,8 @@ export interface ApiResponse {
  */
 export interface PetNotFound {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -499,6 +525,8 @@ export type AddPetStatus200 = Pet
  */
 export interface AddPetStatus405 {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -674,6 +702,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -725,6 +755,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -790,6 +822,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -851,6 +885,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -867,6 +903,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -1051,6 +1089,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1105,6 +1145,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen10/models/AddPetRequest.ts
+++ b/examples/typescript/src/gen10/models/AddPetRequest.ts
@@ -11,6 +11,8 @@ import type { Tag } from './Tag.ts'
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen10/models/ApiResponse.ts
+++ b/examples/typescript/src/gen10/models/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/typescript/src/gen10/models/Category.ts
+++ b/examples/typescript/src/gen10/models/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen10/models/Customer.ts
+++ b/examples/typescript/src/gen10/models/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen10/models/Order.ts
+++ b/examples/typescript/src/gen10/models/Order.ts
@@ -8,11 +8,15 @@
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -33,11 +37,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/typescript/src/gen10/models/Pet.ts
+++ b/examples/typescript/src/gen10/models/Pet.ts
@@ -23,6 +23,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen10/models/PetNotFound.ts
+++ b/examples/typescript/src/gen10/models/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/typescript/src/gen10/models/Tag.ts
+++ b/examples/typescript/src/gen10/models/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/typescript/src/gen10/models/User.ts
+++ b/examples/typescript/src/gen10/models/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen10/models/petController/AddPet.ts
+++ b/examples/typescript/src/gen10/models/petController/AddPet.ts
@@ -13,6 +13,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/typescript/src/gen10/models/petController/DeletePet.ts
+++ b/examples/typescript/src/gen10/models/petController/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/typescript/src/gen10/models/petController/GetPetById.ts
+++ b/examples/typescript/src/gen10/models/petController/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from '../Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/typescript/src/gen10/models/petController/UpdatePetWithForm.ts
+++ b/examples/typescript/src/gen10/models/petController/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/typescript/src/gen10/models/petController/UploadFile.ts
+++ b/examples/typescript/src/gen10/models/petController/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from '../ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -23,6 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined

--- a/examples/typescript/src/gen10/models/storeController/DeleteOrder.ts
+++ b/examples/typescript/src/gen10/models/storeController/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen10/models/storeController/GetOrderById.ts
+++ b/examples/typescript/src/gen10/models/storeController/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from '../Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
+++ b/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
@@ -30,11 +30,15 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -55,11 +59,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -121,6 +129,8 @@ export type CustomerParamsStatusEnumKey = (typeof customerParamsStatusEnum)[keyo
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -174,6 +184,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -190,6 +202,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -226,6 +240,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -237,6 +253,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -306,6 +324,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -364,6 +384,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -397,6 +419,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -415,6 +439,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -499,6 +525,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -674,6 +702,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -725,6 +755,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -790,6 +822,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -851,6 +885,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -867,6 +903,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -1051,6 +1089,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1105,6 +1145,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
+++ b/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
@@ -30,11 +30,15 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -55,11 +59,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -121,6 +129,8 @@ export type CustomerParamsStatusEnumKey = (typeof customerParamsStatusEnum)[keyo
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -174,6 +184,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -190,6 +202,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -226,6 +240,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -237,6 +253,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -306,6 +324,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -364,6 +384,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -397,6 +419,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -415,6 +439,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -499,6 +525,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -674,6 +702,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -725,6 +755,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -790,6 +822,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -851,6 +885,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -867,6 +903,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -1051,6 +1089,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1105,6 +1145,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen2/modelsConst.ts
+++ b/examples/typescript/src/gen2/modelsConst.ts
@@ -30,11 +30,15 @@ export type OrderHttpStatusEnumenumType = (typeof orderHttpStatusEnum)[keyof typ
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -55,11 +59,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -121,6 +129,8 @@ export type CustomerParamsStatusEnumenumType = (typeof customerParamsStatusEnum)
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -174,6 +184,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -190,6 +202,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -226,6 +240,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -237,6 +253,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -306,6 +324,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -364,6 +384,8 @@ export type AddPetRequestStatusEnumenumType = (typeof addPetRequestStatusEnum)[k
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -397,6 +419,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -415,6 +439,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -499,6 +525,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -674,6 +702,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -725,6 +755,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -790,6 +822,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -851,6 +885,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -867,6 +903,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -1051,6 +1089,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1105,6 +1145,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen3/modelsPascalConst.ts
+++ b/examples/typescript/src/gen3/modelsPascalConst.ts
@@ -30,11 +30,15 @@ export type OrderHttpStatusEnumKey = (typeof OrderHttpStatusEnum)[keyof typeof O
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -55,11 +59,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -121,6 +129,8 @@ export type CustomerParamsStatusEnumKey = (typeof CustomerParamsStatusEnum)[keyo
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -174,6 +184,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -190,6 +202,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -226,6 +240,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -237,6 +253,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -306,6 +324,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -364,6 +384,8 @@ export type AddPetRequestStatusEnumKey = (typeof AddPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -397,6 +419,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -415,6 +439,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -499,6 +525,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -674,6 +702,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -725,6 +755,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -790,6 +822,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -851,6 +885,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -867,6 +903,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -1051,6 +1089,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1105,6 +1145,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen4/modelsConstEnum.ts
+++ b/examples/typescript/src/gen4/modelsConstEnum.ts
@@ -24,11 +24,15 @@ export const enum OrderHttpStatusEnum {
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -49,11 +53,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -113,6 +121,8 @@ export const enum CustomerParamsStatusEnum {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -166,6 +176,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -182,6 +194,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -218,6 +232,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -229,6 +245,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -294,6 +312,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -350,6 +370,8 @@ export const enum AddPetRequestStatusEnum {
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -383,6 +405,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -401,6 +425,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -485,6 +511,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -658,6 +686,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -709,6 +739,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -774,6 +806,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -833,6 +867,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -849,6 +885,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -1033,6 +1071,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1087,6 +1127,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen5/modelsLiteral.ts
+++ b/examples/typescript/src/gen5/modelsLiteral.ts
@@ -14,11 +14,15 @@ export type OrderHttpStatusEnum = 200 | 400 | 500
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -39,11 +43,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -99,6 +107,8 @@ export type CustomerParamsStatusEnum = 'placed' | 'approved' | 'delivered'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -152,6 +162,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -168,6 +180,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -204,6 +218,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -215,6 +231,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -273,6 +291,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -324,6 +344,8 @@ export type AddPetRequestStatusEnum = 'available' | 'pending' | 'sold' | 'in sto
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -357,6 +379,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -375,6 +399,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -459,6 +485,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -628,6 +656,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -679,6 +709,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -744,6 +776,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -799,6 +833,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -815,6 +851,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -999,6 +1037,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1053,6 +1093,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen6/ts/models/AddPet.ts
+++ b/examples/typescript/src/gen6/ts/models/AddPet.ts
@@ -13,6 +13,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/typescript/src/gen6/ts/models/AddPetRequest.ts
+++ b/examples/typescript/src/gen6/ts/models/AddPetRequest.ts
@@ -20,6 +20,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen6/ts/models/ApiResponse.ts
+++ b/examples/typescript/src/gen6/ts/models/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/typescript/src/gen6/ts/models/Category.ts
+++ b/examples/typescript/src/gen6/ts/models/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen6/ts/models/Customer.ts
+++ b/examples/typescript/src/gen6/ts/models/Customer.ts
@@ -18,6 +18,8 @@ export type CustomerParamsStatusEnumKey = (typeof customerParamsStatusEnum)[keyo
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen6/ts/models/DeleteOrder.ts
+++ b/examples/typescript/src/gen6/ts/models/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen6/ts/models/DeletePet.ts
+++ b/examples/typescript/src/gen6/ts/models/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/typescript/src/gen6/ts/models/GetOrderById.ts
+++ b/examples/typescript/src/gen6/ts/models/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from './Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/typescript/src/gen6/ts/models/GetPetById.ts
+++ b/examples/typescript/src/gen6/ts/models/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from './Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/typescript/src/gen6/ts/models/Order.ts
+++ b/examples/typescript/src/gen6/ts/models/Order.ts
@@ -30,11 +30,15 @@ export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof o
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -55,11 +59,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/typescript/src/gen6/ts/models/Pet.ts
+++ b/examples/typescript/src/gen6/ts/models/Pet.ts
@@ -38,6 +38,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen6/ts/models/PetNotFound.ts
+++ b/examples/typescript/src/gen6/ts/models/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/typescript/src/gen6/ts/models/Tag.ts
+++ b/examples/typescript/src/gen6/ts/models/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/typescript/src/gen6/ts/models/UpdatePetWithForm.ts
+++ b/examples/typescript/src/gen6/ts/models/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/typescript/src/gen6/ts/models/UploadFile.ts
+++ b/examples/typescript/src/gen6/ts/models/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from './ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -23,6 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined

--- a/examples/typescript/src/gen6/ts/models/User.ts
+++ b/examples/typescript/src/gen6/ts/models/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/typescript/src/gen7/modelsInlineLiteral.ts
+++ b/examples/typescript/src/gen7/modelsInlineLiteral.ts
@@ -8,11 +8,15 @@
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -33,11 +37,15 @@ export type Order = {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -91,6 +99,8 @@ export type Address = {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -144,6 +154,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -160,6 +172,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -196,6 +210,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -207,6 +223,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -261,6 +279,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -310,6 +330,8 @@ export type FullAddress = Address & {
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -343,6 +365,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -361,6 +385,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -445,6 +471,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -612,6 +640,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -663,6 +693,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -728,6 +760,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -781,6 +815,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -797,6 +833,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -981,6 +1019,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1035,6 +1075,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen8/modelsOptionalUndefined.ts
+++ b/examples/typescript/src/gen8/modelsOptionalUndefined.ts
@@ -8,11 +8,15 @@
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id: bigint | undefined
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -35,11 +39,15 @@ export type Order = {
       }
     | undefined
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity: number | undefined
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate: string | undefined
@@ -93,6 +101,8 @@ export type Address = {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -148,6 +158,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -164,6 +176,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -200,6 +214,8 @@ export type User = {
   phone: string | undefined
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -211,6 +227,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id: bigint | undefined
@@ -265,6 +283,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -314,6 +334,8 @@ export type FullAddress = Address & {
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -347,6 +369,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code: number | undefined
@@ -365,6 +389,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code: number | undefined
@@ -449,6 +475,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code: number | undefined
@@ -620,6 +648,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -671,6 +701,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -738,6 +770,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -793,6 +827,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -809,6 +845,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -995,6 +1033,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1049,6 +1089,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/gen9/modelsOptionalBoth.ts
+++ b/examples/typescript/src/gen9/modelsOptionalBoth.ts
@@ -8,11 +8,15 @@
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint | undefined
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -35,11 +39,15 @@ export type Order = {
       }
     | undefined
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number | undefined
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string | undefined
@@ -93,6 +101,8 @@ export type Address = {
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -148,6 +158,8 @@ export type UnhappyCustomer = Customer & {
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -164,6 +176,8 @@ export type Category = {
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -200,6 +214,8 @@ export type User = {
   phone?: string | undefined
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -211,6 +227,8 @@ export type User = {
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint | undefined
@@ -265,6 +283,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -314,6 +334,8 @@ export type FullAddress = Address & {
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -347,6 +369,8 @@ export type AddPetRequest = {
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number | undefined
@@ -365,6 +389,8 @@ export type ApiResponse = {
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number | undefined
@@ -449,6 +475,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number | undefined
@@ -620,6 +648,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -671,6 +701,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -738,6 +770,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -793,6 +827,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -809,6 +845,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -995,6 +1033,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1049,6 +1089,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/typescript/src/legacy/models.ts
+++ b/examples/typescript/src/legacy/models.ts
@@ -24,11 +24,15 @@ export enum OrderHttpStatusEnum {
  */
 export interface Order {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
@@ -49,11 +53,15 @@ export interface Order {
     type: string
   }
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string
@@ -113,6 +121,8 @@ export enum CustomerParamsStatusEnum {
  */
 export interface Customer {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */
@@ -166,6 +176,8 @@ export type UnhappyCustomer = Customer & {
  */
 export interface Category {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */
@@ -182,6 +194,8 @@ export interface Category {
  */
 export interface User {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -218,6 +232,8 @@ export interface User {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */
@@ -229,6 +245,8 @@ export interface User {
  */
 export interface Tag {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint
@@ -294,6 +312,8 @@ export type Pet = (
     })
 ) & {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -350,6 +370,8 @@ export enum AddPetRequestStatusEnum {
  */
 export interface AddPetRequest {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -383,6 +405,8 @@ export interface AddPetRequest {
  */
 export interface ApiResponse {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -401,6 +425,8 @@ export interface ApiResponse {
  */
 export interface PetNotFound {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -485,6 +511,8 @@ export type AddPetStatus200 = Pet
  */
 export interface AddPetStatus405 {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number
@@ -658,6 +686,8 @@ export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsSta
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint
@@ -709,6 +739,8 @@ export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | Get
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint
@@ -774,6 +806,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint
@@ -833,6 +867,8 @@ export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -849,6 +885,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined
@@ -1033,6 +1071,8 @@ export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatch
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint
@@ -1087,6 +1127,8 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/vue-query/src/gen/models/ApiResponse.ts
+++ b/examples/vue-query/src/gen/models/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/vue-query/src/gen/models/Category.ts
+++ b/examples/vue-query/src/gen/models/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/vue-query/src/gen/models/Customer.ts
+++ b/examples/vue-query/src/gen/models/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/vue-query/src/gen/models/DeleteOrder.ts
+++ b/examples/vue-query/src/gen/models/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/vue-query/src/gen/models/DeletePet.ts
+++ b/examples/vue-query/src/gen/models/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/vue-query/src/gen/models/GetOrderById.ts
+++ b/examples/vue-query/src/gen/models/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from './Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/vue-query/src/gen/models/GetPetById.ts
+++ b/examples/vue-query/src/gen/models/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from './Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/vue-query/src/gen/models/Order.ts
+++ b/examples/vue-query/src/gen/models/Order.ts
@@ -16,21 +16,29 @@ export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStat
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/vue-query/src/gen/models/Pet.ts
+++ b/examples/vue-query/src/gen/models/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/vue-query/src/gen/models/Tag.ts
+++ b/examples/vue-query/src/gen/models/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/vue-query/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/vue-query/src/gen/models/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/vue-query/src/gen/models/UploadFile.ts
+++ b/examples/vue-query/src/gen/models/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from './ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -23,6 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined

--- a/examples/vue-query/src/gen/models/User.ts
+++ b/examples/vue-query/src/gen/models/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/zod/src/zod/ts/AddPet.ts
+++ b/examples/zod/src/zod/ts/AddPet.ts
@@ -16,6 +16,8 @@ export type AddPetStatus200 = Pet
  */
 export type AddPetStatus405 = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/zod/src/zod/ts/AddPetRequest.ts
+++ b/examples/zod/src/zod/ts/AddPetRequest.ts
@@ -19,6 +19,8 @@ export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof 
  */
 export type AddPetRequest = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/zod/src/zod/ts/ApiResponse.ts
+++ b/examples/zod/src/zod/ts/ApiResponse.ts
@@ -8,6 +8,8 @@
  */
 export type ApiResponse = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/zod/src/zod/ts/Category.ts
+++ b/examples/zod/src/zod/ts/Category.ts
@@ -8,6 +8,8 @@
  */
 export type Category = {
   /**
+   * @description
+   * Format: `int64`
    * @example 1
    * @type integer | undefined
    */

--- a/examples/zod/src/zod/ts/Customer.ts
+++ b/examples/zod/src/zod/ts/Customer.ts
@@ -10,6 +10,8 @@ import type { Address } from './Address.ts'
  */
 export type Customer = {
   /**
+   * @description
+   * Format: `int64`
    * @example 100000
    * @type integer | undefined
    */

--- a/examples/zod/src/zod/ts/DeleteOrder.ts
+++ b/examples/zod/src/zod/ts/DeleteOrder.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of the order that needs to be deleted
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeleteOrderPathOrderId = bigint

--- a/examples/zod/src/zod/ts/DeletePet.ts
+++ b/examples/zod/src/zod/ts/DeletePet.ts
@@ -10,6 +10,8 @@ export type DeletePetHeaderApiKey = string | undefined
 
 /**
  * @description Pet id to delete
+ *
+ * Format: `int64`
  * @type integer
  */
 export type DeletePetPathPetId = bigint

--- a/examples/zod/src/zod/ts/GetOrderById.ts
+++ b/examples/zod/src/zod/ts/GetOrderById.ts
@@ -7,6 +7,8 @@ import type { Order } from './Order.ts'
 
 /**
  * @description ID of order that needs to be fetched
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetOrderByIdPathOrderId = bigint

--- a/examples/zod/src/zod/ts/GetPetById.ts
+++ b/examples/zod/src/zod/ts/GetPetById.ts
@@ -7,6 +7,8 @@ import type { Pet } from './Pet.ts'
 
 /**
  * @description ID of pet to return
+ *
+ * Format: `int64`
  * @type integer
  */
 export type GetPetByIdPathPetId = bigint

--- a/examples/zod/src/zod/ts/Order.ts
+++ b/examples/zod/src/zod/ts/Order.ts
@@ -35,21 +35,29 @@ export type OrderValueEnumKey = (typeof orderValueEnum)[keyof typeof orderValueE
  */
 export type Order = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
   id?: bigint
   /**
+   * @description
+   * Format: `int64`
    * @example 198772
    * @type integer | undefined
    */
   petId?: bigint
   /**
+   * @description
+   * Format: `int32`
    * @example 7
    * @type integer | undefined
    */
   quantity?: number
   /**
+   * @description
+   * Format: `date-time`
    * @type string | undefined
    */
   shipDate?: string

--- a/examples/zod/src/zod/ts/Pet.ts
+++ b/examples/zod/src/zod/ts/Pet.ts
@@ -19,6 +19,8 @@ export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum
  */
 export type Pet = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */

--- a/examples/zod/src/zod/ts/PetNotFound.ts
+++ b/examples/zod/src/zod/ts/PetNotFound.ts
@@ -8,6 +8,8 @@
  */
 export type PetNotFound = {
   /**
+   * @description
+   * Format: `int32`
    * @type integer | undefined
    */
   code?: number

--- a/examples/zod/src/zod/ts/Tag.ts
+++ b/examples/zod/src/zod/ts/Tag.ts
@@ -8,6 +8,8 @@
  */
 export type Tag = {
   /**
+   * @description
+   * Format: `int64`
    * @type integer | undefined
    */
   id?: bigint

--- a/examples/zod/src/zod/ts/UpdatePetWithForm.ts
+++ b/examples/zod/src/zod/ts/UpdatePetWithForm.ts
@@ -5,6 +5,8 @@
 
 /**
  * @description ID of pet that needs to be updated
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UpdatePetWithFormPathPetId = bigint

--- a/examples/zod/src/zod/ts/UploadFile.ts
+++ b/examples/zod/src/zod/ts/UploadFile.ts
@@ -7,6 +7,8 @@ import type { ApiResponse } from './ApiResponse.ts'
 
 /**
  * @description ID of pet to update
+ *
+ * Format: `int64`
  * @type integer
  */
 export type UploadFilePathPetId = bigint
@@ -23,6 +25,8 @@ export type UploadFileQueryAdditionalMetadata = string | undefined
 export type UploadFileStatus200 = ApiResponse
 
 /**
+ * @description
+ * Format: `binary`
  * @type string | undefined
  */
 export type UploadFileData = Blob | undefined

--- a/examples/zod/src/zod/ts/User.ts
+++ b/examples/zod/src/zod/ts/User.ts
@@ -8,6 +8,8 @@
  */
 export type User = {
   /**
+   * @description
+   * Format: `int64`
    * @example 10
    * @type integer | undefined
    */
@@ -44,6 +46,8 @@ export type User = {
   phone?: string
   /**
    * @description User Status
+   *
+   * Format: `int32`
    * @example 1
    * @type integer | undefined
    */

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -62,7 +62,7 @@ function getOperationLink(node: ast.OperationNode, link: OperationCommentLink): 
     return node.path ? `{@link ${new URLPath(node.path).URL}}` : null
   }
 
-  return `{@link ${node.path!.replaceAll('{', ':').replaceAll('}', '')}}`
+  return node.path ? `{@link ${node.path.replaceAll('{', ':').replaceAll('}', '')}}` : null
 }
 
 export function getContentTypeInfo(node: ast.OperationNode): ContentTypeInfo {

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -62,7 +62,7 @@ function getOperationLink(node: ast.OperationNode, link: OperationCommentLink): 
     return node.path ? `{@link ${new URLPath(node.path).URL}}` : null
   }
 
-  return `{@link ${node.path.replaceAll('{', ':').replaceAll('}', '')}}`
+  return `{@link ${node.path!.replaceAll('{', ':').replaceAll('}', '')}}`
 }
 
 export function getContentTypeInfo(node: ast.OperationNode): ContentTypeInfo {

--- a/internals/tanstack-query/src/components/MutationKey.tsx
+++ b/internals/tanstack-query/src/components/MutationKey.tsx
@@ -16,7 +16,7 @@ type Props = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export const mutationKeyTransformer: Transformer = ({ node, casing }) => {
-  const path = new URLPath(node.path, { casing })
+  const path = new URLPath(node.path!, { casing })
   return [`{ url: '${path.toURLPath()}' }`]
 }
 

--- a/internals/tanstack-query/src/components/MutationKey.tsx
+++ b/internals/tanstack-query/src/components/MutationKey.tsx
@@ -7,7 +7,7 @@ import type { Transformer } from '../types.ts'
 
 type Props = {
   name: string
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   paramsCasing: 'camelcase' | undefined
   pathParamsType: 'object' | 'inline'
   transformer: Transformer | null | undefined
@@ -16,7 +16,8 @@ type Props = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export const mutationKeyTransformer: Transformer = ({ node, casing }) => {
-  const path = new URLPath(node.path!, { casing })
+  if (!node.path) return []
+  const path = new URLPath(node.path, { casing })
   return [`{ url: '${path.toURLPath()}' }`]
 }
 

--- a/internals/tanstack-query/src/components/MutationKey.tsx
+++ b/internals/tanstack-query/src/components/MutationKey.tsx
@@ -7,7 +7,7 @@ import type { Transformer } from '../types.ts'
 
 type Props = {
   name: string
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   paramsCasing: 'camelcase' | undefined
   pathParamsType: 'object' | 'inline'
   transformer: Transformer | null | undefined

--- a/internals/tanstack-query/src/components/QueryKey.tsx
+++ b/internals/tanstack-query/src/components/QueryKey.tsx
@@ -11,7 +11,7 @@ import { buildQueryKeyParams } from '../utils.ts'
 type Props = {
   name: string
   typeName: string
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   tsResolver: PluginTs['resolver']
   paramsCasing: 'camelcase' | undefined
   pathParamsType: 'object' | 'inline'
@@ -21,7 +21,8 @@ type Props = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export const queryKeyTransformer: Transformer = ({ node, casing }) => {
-  const path = new URLPath(node.path!, { casing })
+  if (!node.path) return []
+  const path = new URLPath(node.path, { casing })
   const hasQueryParams = getOperationParameters(node).query.length > 0
   const hasRequestBody = !!node.requestBody?.content?.[0]?.schema
 

--- a/internals/tanstack-query/src/components/QueryKey.tsx
+++ b/internals/tanstack-query/src/components/QueryKey.tsx
@@ -21,7 +21,7 @@ type Props = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export const queryKeyTransformer: Transformer = ({ node, casing }) => {
-  const path = new URLPath(node.path, { casing })
+  const path = new URLPath(node.path!, { casing })
   const hasQueryParams = getOperationParameters(node).query.length > 0
   const hasRequestBody = !!node.requestBody?.content?.[0]?.schema
 

--- a/internals/tanstack-query/src/components/QueryKey.tsx
+++ b/internals/tanstack-query/src/components/QueryKey.tsx
@@ -11,7 +11,7 @@ import { buildQueryKeyParams } from '../utils.ts'
 type Props = {
   name: string
   typeName: string
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   tsResolver: PluginTs['resolver']
   paramsCasing: 'camelcase' | undefined
   pathParamsType: 'object' | 'inline'

--- a/internals/tanstack-query/src/utils.ts
+++ b/internals/tanstack-query/src/utils.ts
@@ -16,8 +16,8 @@ function matchesPattern(node: ast.OperationNode, ov: { type: string; pattern: st
   const matches = (value: string) => (typeof pattern === 'string' ? value === pattern : pattern.test(value))
   if (type === 'operationId') return matches(node.operationId)
   if (type === 'tag') return node.tags.some((t) => matches(t))
-  if (type === 'path') return matches(node.path!)
-  if (type === 'method') return matches(node.method!)
+  if (type === 'path') return node.path !== undefined && matches(node.path)
+  if (type === 'method') return node.method !== undefined && matches(node.method)
   return false
 }
 

--- a/internals/tanstack-query/src/utils.ts
+++ b/internals/tanstack-query/src/utils.ts
@@ -16,8 +16,8 @@ function matchesPattern(node: ast.OperationNode, ov: { type: string; pattern: st
   const matches = (value: string) => (typeof pattern === 'string' ? value === pattern : pattern.test(value))
   if (type === 'operationId') return matches(node.operationId)
   if (type === 'tag') return node.tags.some((t) => matches(t))
-  if (type === 'path') return matches(node.path)
-  if (type === 'method') return matches(node.method)
+  if (type === 'path') return matches(node.path!)
+  if (type === 'method') return matches(node.method!)
   return false
 }
 

--- a/packages/plugin-client/src/components/ClassClient.tsx
+++ b/packages/plugin-client/src/components/ClassClient.tsx
@@ -58,7 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
-  const path = new URLPath(node.path, { casing: paramsCasing })
+  const path = new URLPath(node.path!, { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
   const { header: headerParams } = getOperationParameters(node)

--- a/packages/plugin-client/src/components/ClassClient.tsx
+++ b/packages/plugin-client/src/components/ClassClient.tsx
@@ -11,7 +11,7 @@ import { buildClassClientParams, buildFormDataLine, buildGenerics, buildHeaders,
 import { buildClientParamsNode } from './Client.tsx'
 
 type OperationData = {
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -32,7 +32,7 @@ type Props = {
 }
 
 type GenerateMethodProps = {
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -58,7 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
-  const path = new URLPath(node.path!, { casing: paramsCasing })
+  const path = new URLPath(node.path, { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
   const { header: headerParams } = getOperationParameters(node)

--- a/packages/plugin-client/src/components/ClassClient.tsx
+++ b/packages/plugin-client/src/components/ClassClient.tsx
@@ -1,6 +1,6 @@
 import { buildOperationComments, getContentTypeInfo, getOperationParameters } from '@internals/shared'
 import { buildJSDoc, URLPath } from '@internals/utils'
-import type { ast } from '@kubb/core'
+import { ast } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import { functionPrinter } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
@@ -11,7 +11,7 @@ import { buildClassClientParams, buildFormDataLine, buildGenerics, buildHeaders,
 import { buildClientParamsNode } from './Client.tsx'
 
 type OperationData = {
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -32,7 +32,7 @@ type Props = {
 }
 
 type GenerateMethodProps = {
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -58,6 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
+  if (!ast.isHttpOperationNode(node)) return ''
   const path = new URLPath(node.path, { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'

--- a/packages/plugin-client/src/components/Client.tsx
+++ b/packages/plugin-client/src/components/Client.tsx
@@ -31,7 +31,7 @@ type Props = {
   paramsType: PluginClient['resolvedOptions']['pathParamsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
   parser: PluginClient['resolvedOptions']['parser'] | undefined
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
   children?: KubbReactNode
@@ -41,7 +41,7 @@ type GetParamsProps = {
   paramsCasing: PluginClient['resolvedOptions']['paramsCasing']
   paramsType: PluginClient['resolvedOptions']['paramsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   tsResolver: ResolverTs
   isConfigurable: boolean
 }
@@ -96,6 +96,7 @@ export function Client({
   children,
   isConfigurable = true,
 }: Props): KubbReactNode {
+  if (!ast.isHttpOperationNode(node)) return null
   const path = new URLPath(node.path)
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'

--- a/packages/plugin-client/src/components/Client.tsx
+++ b/packages/plugin-client/src/components/Client.tsx
@@ -96,7 +96,7 @@ export function Client({
   children,
   isConfigurable = true,
 }: Props): KubbReactNode {
-  const path = new URLPath(node.path)
+  const path = new URLPath(node.path!)
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
 
@@ -156,7 +156,7 @@ export function Client({
       mode: 'object',
       children: {
         method: {
-          value: JSON.stringify(node.method.toUpperCase()),
+          value: JSON.stringify(node.method!.toUpperCase()),
         },
         url: {
           value: urlName ? `${urlName}(${urlParamsCall}).url.toString()` : path.template,

--- a/packages/plugin-client/src/components/Client.tsx
+++ b/packages/plugin-client/src/components/Client.tsx
@@ -31,7 +31,7 @@ type Props = {
   paramsType: PluginClient['resolvedOptions']['pathParamsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
   parser: PluginClient['resolvedOptions']['parser'] | undefined
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
   children?: KubbReactNode
@@ -41,7 +41,7 @@ type GetParamsProps = {
   paramsCasing: PluginClient['resolvedOptions']['paramsCasing']
   paramsType: PluginClient['resolvedOptions']['paramsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   tsResolver: ResolverTs
   isConfigurable: boolean
 }
@@ -96,7 +96,7 @@ export function Client({
   children,
   isConfigurable = true,
 }: Props): KubbReactNode {
-  const path = new URLPath(node.path!)
+  const path = new URLPath(node.path)
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
 
@@ -156,7 +156,7 @@ export function Client({
       mode: 'object',
       children: {
         method: {
-          value: JSON.stringify(node.method!.toUpperCase()),
+          value: JSON.stringify(node.method.toUpperCase()),
         },
         url: {
           value: urlName ? `${urlName}(${urlParamsCall}).url.toString()` : path.template,

--- a/packages/plugin-client/src/components/Operations.tsx
+++ b/packages/plugin-client/src/components/Operations.tsx
@@ -13,8 +13,8 @@ export function Operations({ name, nodes }: OperationsProps): KubbReactNode {
 
   nodes.forEach((node) => {
     operationsObject[node.operationId] = {
-      path: new URLPath(node.path).URL,
-      method: node.method.toLowerCase(),
+      path: new URLPath(node.path!).URL,
+      method: node.method!.toLowerCase(),
     }
   })
 

--- a/packages/plugin-client/src/components/Operations.tsx
+++ b/packages/plugin-client/src/components/Operations.tsx
@@ -1,17 +1,18 @@
 import { URLPath } from '@internals/utils'
-import type { ast } from '@kubb/core'
+import { ast } from '@kubb/core'
 import { Const, File } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 
 type OperationsProps = {
   name: string
-  nodes: Array<ast.HttpOperationNode>
+  nodes: Array<ast.OperationNode>
 }
 
 export function Operations({ name, nodes }: OperationsProps): KubbReactNode {
   const operationsObject: Record<string, { path: string; method: string }> = {}
 
   nodes.forEach((node) => {
+    if (!ast.isHttpOperationNode(node)) return
     operationsObject[node.operationId] = {
       path: new URLPath(node.path).URL,
       method: node.method.toLowerCase(),

--- a/packages/plugin-client/src/components/Operations.tsx
+++ b/packages/plugin-client/src/components/Operations.tsx
@@ -5,7 +5,7 @@ import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 
 type OperationsProps = {
   name: string
-  nodes: Array<ast.OperationNode>
+  nodes: Array<ast.HttpOperationNode>
 }
 
 export function Operations({ name, nodes }: OperationsProps): KubbReactNode {
@@ -13,8 +13,8 @@ export function Operations({ name, nodes }: OperationsProps): KubbReactNode {
 
   nodes.forEach((node) => {
     operationsObject[node.operationId] = {
-      path: new URLPath(node.path!).URL,
-      method: node.method!.toLowerCase(),
+      path: new URLPath(node.path).URL,
+      method: node.method.toLowerCase(),
     }
   })
 

--- a/packages/plugin-client/src/components/StaticClassClient.tsx
+++ b/packages/plugin-client/src/components/StaticClassClient.tsx
@@ -58,7 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
-  const path = new URLPath(node.path, { casing: paramsCasing })
+  const path = new URLPath(node.path!, { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
   const { header: headerParams } = getOperationParameters(node)

--- a/packages/plugin-client/src/components/StaticClassClient.tsx
+++ b/packages/plugin-client/src/components/StaticClassClient.tsx
@@ -11,7 +11,7 @@ import { buildClassClientParams, buildFormDataLine, buildGenerics, buildHeaders,
 import { buildClientParamsNode } from './Client.tsx'
 
 type OperationData = {
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -32,7 +32,7 @@ type Props = {
 }
 
 type GenerateMethodProps = {
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -58,7 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
-  const path = new URLPath(node.path!, { casing: paramsCasing })
+  const path = new URLPath(node.path, { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
   const { header: headerParams } = getOperationParameters(node)

--- a/packages/plugin-client/src/components/StaticClassClient.tsx
+++ b/packages/plugin-client/src/components/StaticClassClient.tsx
@@ -1,6 +1,6 @@
 import { buildOperationComments, getContentTypeInfo, getOperationParameters } from '@internals/shared'
 import { buildJSDoc, URLPath } from '@internals/utils'
-import type { ast } from '@kubb/core'
+import { ast } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import { functionPrinter } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
@@ -11,7 +11,7 @@ import { buildClassClientParams, buildFormDataLine, buildGenerics, buildHeaders,
 import { buildClientParamsNode } from './Client.tsx'
 
 type OperationData = {
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -32,7 +32,7 @@ type Props = {
 }
 
 type GenerateMethodProps = {
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver?: ResolverZod | null
@@ -58,6 +58,7 @@ function generateMethod({
   paramsCasing,
   pathParamsType,
 }: GenerateMethodProps): string {
+  if (!ast.isHttpOperationNode(node)) return ''
   const path = new URLPath(node.path, { casing: paramsCasing })
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'

--- a/packages/plugin-client/src/components/Url.tsx
+++ b/packages/plugin-client/src/components/Url.tsx
@@ -57,7 +57,7 @@ export function Url({
   node,
   tsResolver,
 }: Props): KubbReactNode {
-  const path = new URLPath(node.path)
+  const path = new URLPath(node.path!)
 
   const paramsNode = buildUrlParamsNode({
     paramsType,
@@ -81,7 +81,7 @@ export function Url({
             .map(([originalName, camelCaseName]) => `const ${originalName} = ${camelCaseName}`)
             .join('\n')}
         {pathParamsMapping && Object.keys(pathParamsMapping).length > 0 && <br />}
-        <Const name={'res'}>{`{ method: '${node.method.toUpperCase()}', url: ${path.toTemplateString({ prefix: baseURL })} as const }`}</Const>
+        <Const name={'res'}>{`{ method: '${node.method!.toUpperCase()}', url: ${path.toTemplateString({ prefix: baseURL })} as const }`}</Const>
         <br />
         return res
       </Function>

--- a/packages/plugin-client/src/components/Url.tsx
+++ b/packages/plugin-client/src/components/Url.tsx
@@ -16,7 +16,7 @@ type Props = {
   paramsCasing: PluginClient['resolvedOptions']['paramsCasing']
   paramsType: PluginClient['resolvedOptions']['pathParamsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   tsResolver: ResolverTs
 }
 
@@ -24,7 +24,7 @@ type GetParamsProps = {
   paramsCasing: PluginClient['resolvedOptions']['paramsCasing']
   paramsType: PluginClient['resolvedOptions']['paramsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   tsResolver: ResolverTs
 }
 
@@ -32,7 +32,7 @@ const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export function buildUrlParamsNode({ paramsType, paramsCasing, pathParamsType, node, tsResolver }: GetParamsProps): ast.FunctionParametersNode {
   // Build a URL-only node with only path params (no body, query, header)
-  const urlNode: ast.OperationNode = {
+  const urlNode: ast.HttpOperationNode = {
     ...node,
     parameters: node.parameters.filter((p) => p.in === 'path'),
     requestBody: undefined,
@@ -57,7 +57,7 @@ export function Url({
   node,
   tsResolver,
 }: Props): KubbReactNode {
-  const path = new URLPath(node.path!)
+  const path = new URLPath(node.path)
 
   const paramsNode = buildUrlParamsNode({
     paramsType,
@@ -81,7 +81,7 @@ export function Url({
             .map(([originalName, camelCaseName]) => `const ${originalName} = ${camelCaseName}`)
             .join('\n')}
         {pathParamsMapping && Object.keys(pathParamsMapping).length > 0 && <br />}
-        <Const name={'res'}>{`{ method: '${node.method!.toUpperCase()}', url: ${path.toTemplateString({ prefix: baseURL })} as const }`}</Const>
+        <Const name={'res'}>{`{ method: '${node.method.toUpperCase()}', url: ${path.toTemplateString({ prefix: baseURL })} as const }`}</Const>
         <br />
         return res
       </Function>

--- a/packages/plugin-client/src/components/Url.tsx
+++ b/packages/plugin-client/src/components/Url.tsx
@@ -16,7 +16,7 @@ type Props = {
   paramsCasing: PluginClient['resolvedOptions']['paramsCasing']
   paramsType: PluginClient['resolvedOptions']['pathParamsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   tsResolver: ResolverTs
 }
 
@@ -24,7 +24,7 @@ type GetParamsProps = {
   paramsCasing: PluginClient['resolvedOptions']['paramsCasing']
   paramsType: PluginClient['resolvedOptions']['paramsType']
   pathParamsType: PluginClient['resolvedOptions']['pathParamsType']
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   tsResolver: ResolverTs
 }
 
@@ -32,7 +32,7 @@ const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export function buildUrlParamsNode({ paramsType, paramsCasing, pathParamsType, node, tsResolver }: GetParamsProps): ast.FunctionParametersNode {
   // Build a URL-only node with only path params (no body, query, header)
-  const urlNode: ast.HttpOperationNode = {
+  const urlNode: ast.OperationNode = {
     ...node,
     parameters: node.parameters.filter((p) => p.in === 'path'),
     requestBody: undefined,
@@ -57,6 +57,7 @@ export function Url({
   node,
   tsResolver,
 }: Props): KubbReactNode {
+  if (!ast.isHttpOperationNode(node)) return null
   const path = new URLPath(node.path)
 
   const paramsNode = buildUrlParamsNode({

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -1,8 +1,7 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
 import { camelCase } from '@internals/utils'
-import type { ast } from '@kubb/core'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import { pluginTsName } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
@@ -13,7 +12,7 @@ import { WrapperClient } from '../components/WrapperClient'
 import type { PluginClient } from '../types'
 
 type OperationData = {
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver: ResolverZod | null
@@ -61,7 +60,7 @@ export const classClientGenerator = defineGenerator<PluginClient>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
 
-    function buildOperationData(node: ast.OperationNode): OperationData {
+    function buildOperationData(node: ast.HttpOperationNode): OperationData {
       const typeFile = tsResolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
         { root, output: tsPluginOptions?.output ?? output, group: tsPluginOptions?.group },
@@ -85,6 +84,7 @@ export const classClientGenerator = defineGenerator<PluginClient>({
     }
 
     const controllers = nodes.reduce((acc, operationNode) => {
+      if (!ast.isHttpOperationNode(operationNode)) return acc
       const tag = operationNode.tags[0]
       const groupName = tag ? (group?.name?.({ group: camelCase(tag) }) ?? resolver.resolveGroupName(tag)) : resolver.resolveGroupName('Client')
 

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -12,7 +12,7 @@ import { WrapperClient } from '../components/WrapperClient'
 import type { PluginClient } from '../types'
 
 type OperationData = {
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver: ResolverZod | null
@@ -60,7 +60,7 @@ export const classClientGenerator = defineGenerator<PluginClient>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
 
-    function buildOperationData(node: ast.HttpOperationNode): OperationData {
+    function buildOperationData(node: ast.OperationNode): OperationData {
       const typeFile = tsResolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
         { root, output: tsPluginOptions?.output ?? output, group: tsPluginOptions?.group },

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
@@ -17,6 +17,7 @@ export const clientGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, urlType, dataReturnType, paramsCasing, paramsType, pathParamsType, parser, importPath, group } = ctx.options
     const baseURL = ctx.options.baseURL ?? ctx.meta.baseURL

--- a/packages/plugin-client/src/generators/operationsGenerator.tsx
+++ b/packages/plugin-client/src/generators/operationsGenerator.tsx
@@ -1,4 +1,4 @@
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { Operations } from '../components/Operations'
 import type { PluginClient } from '../types'
@@ -27,7 +27,7 @@ export const operationsGenerator = defineGenerator<PluginClient>({
         banner={resolver.resolveBanner(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
         footer={resolver.resolveFooter(ctx.meta, { output, config, file: { path: file.path, baseName: file.baseName } })}
       >
-        <Operations name={name} nodes={nodes} />
+        <Operations name={name} nodes={nodes.filter(ast.isHttpOperationNode)} />
       </File>
     )
   },

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -1,8 +1,7 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
 import { camelCase } from '@internals/utils'
-import type { ast } from '@kubb/core'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import { pluginTsName } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
@@ -12,7 +11,7 @@ import { StaticClassClient } from '../components/StaticClassClient'
 import type { PluginClient } from '../types'
 
 type OperationData = {
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver: ResolverZod | null
@@ -60,7 +59,7 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
 
-    function buildOperationData(node: ast.OperationNode): OperationData {
+    function buildOperationData(node: ast.HttpOperationNode): OperationData {
       const typeFile = tsResolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
         { root, output: tsPluginOptions?.output ?? output, group: tsPluginOptions?.group },
@@ -84,6 +83,7 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
     }
 
     const controllers = nodes.reduce((acc, operationNode) => {
+      if (!ast.isHttpOperationNode(operationNode)) return acc
       const tag = operationNode.tags[0]
       const groupName = tag ? (group?.name?.({ group: camelCase(tag) }) ?? resolver.resolveGroupName(tag)) : resolver.resolveGroupName('Client')
 

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -11,7 +11,7 @@ import { StaticClassClient } from '../components/StaticClassClient'
 import type { PluginClient } from '../types'
 
 type OperationData = {
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   name: string
   tsResolver: ResolverTs
   zodResolver: ResolverZod | null
@@ -59,7 +59,7 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
 
-    function buildOperationData(node: ast.HttpOperationNode): OperationData {
+    function buildOperationData(node: ast.OperationNode): OperationData {
       const typeFile = tsResolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
         { root, output: tsPluginOptions?.output ?? output, group: tsPluginOptions?.group },

--- a/packages/plugin-client/src/utils.ts
+++ b/packages/plugin-client/src/utils.ts
@@ -65,7 +65,7 @@ export function buildClassClientParams({
           mode: 'inlineSpread',
         },
         method: {
-          value: JSON.stringify(node.method.toUpperCase()),
+          value: JSON.stringify(node.method!.toUpperCase()),
         },
         url: {
           value: path.template,

--- a/packages/plugin-client/src/utils.ts
+++ b/packages/plugin-client/src/utils.ts
@@ -1,6 +1,6 @@
 import { getOperationParameters, resolveSuccessNames } from '@internals/shared'
 import type { URLPath } from '@internals/utils'
-import type { ast } from '@kubb/core'
+import { ast } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
 import { createFunctionParams } from './functionParams.ts'
@@ -44,7 +44,7 @@ export function buildClassClientParams({
   hasFormData,
   headers,
 }: {
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   path: URLPath
   baseURL: string | null | undefined
   tsResolver: ResolverTs
@@ -65,7 +65,7 @@ export function buildClassClientParams({
           mode: 'inlineSpread',
         },
         method: {
-          value: JSON.stringify(node.method.toUpperCase()),
+          value: JSON.stringify(ast.isHttpOperationNode(node) ? node.method.toUpperCase() : ''),
         },
         url: {
           value: path.template,

--- a/packages/plugin-client/src/utils.ts
+++ b/packages/plugin-client/src/utils.ts
@@ -44,7 +44,7 @@ export function buildClassClientParams({
   hasFormData,
   headers,
 }: {
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   path: URLPath
   baseURL: string | null | undefined
   tsResolver: ResolverTs
@@ -65,7 +65,7 @@ export function buildClassClientParams({
           mode: 'inlineSpread',
         },
         method: {
-          value: JSON.stringify(node.method!.toUpperCase()),
+          value: JSON.stringify(node.method.toUpperCase()),
         },
         url: {
           value: path.template,

--- a/packages/plugin-cypress/src/components/Request.tsx
+++ b/packages/plugin-cypress/src/components/Request.tsx
@@ -54,7 +54,7 @@ export function Request({ baseURL = '', name, dataReturnType, resolver, node, pa
   // even when the OpenAPI spec has inconsistent casing between the two.
   const pathParamNameMap = new Map(casedPathParams.map((p) => [camelCase(p.name), p.name]))
 
-  const urlPath = new URLPath(node.path, { casing: paramsCasing })
+  const urlPath = new URLPath(node.path!, { casing: paramsCasing })
   const urlTemplate = urlPath.toTemplateString({
     prefix: baseURL,
     replacer: (param) => pathParamNameMap.get(camelCase(param)) ?? param,

--- a/packages/plugin-cypress/src/components/Request.tsx
+++ b/packages/plugin-cypress/src/components/Request.tsx
@@ -15,7 +15,7 @@ type Props = {
   /**
    * AST operation node
    */
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   /**
    * TypeScript resolver for resolving param/data/response type names
    */
@@ -54,7 +54,7 @@ export function Request({ baseURL = '', name, dataReturnType, resolver, node, pa
   // even when the OpenAPI spec has inconsistent casing between the two.
   const pathParamNameMap = new Map(casedPathParams.map((p) => [camelCase(p.name), p.name]))
 
-  const urlPath = new URLPath(node.path!, { casing: paramsCasing })
+  const urlPath = new URLPath(node.path, { casing: paramsCasing })
   const urlTemplate = urlPath.toTemplateString({
     prefix: baseURL,
     replacer: (param) => pathParamNameMap.get(camelCase(param)) ?? param,

--- a/packages/plugin-cypress/src/components/Request.tsx
+++ b/packages/plugin-cypress/src/components/Request.tsx
@@ -15,7 +15,7 @@ type Props = {
   /**
    * AST operation node
    */
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   /**
    * TypeScript resolver for resolving param/data/response type names
    */
@@ -30,6 +30,7 @@ type Props = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export function Request({ baseURL = '', name, dataReturnType, resolver, node, paramsType, pathParamsType, paramsCasing }: Props): KubbReactNode {
+  if (!ast.isHttpOperationNode(node)) return null
   const paramsNode = ast.createOperationParams(node, {
     paramsType,
     pathParamsType,

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -1,5 +1,5 @@
 import { resolveOperationTypeNames } from '@internals/shared'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { Request } from '../components/Request.tsx'
@@ -14,6 +14,7 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
   name: 'cypress',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, resolver, driver, root } = ctx
     const { output, baseURL, dataReturnType, paramsCasing, paramsType, pathParamsType, group } = ctx.options
 

--- a/packages/plugin-mcp/src/components/McpHandler.tsx
+++ b/packages/plugin-mcp/src/components/McpHandler.tsx
@@ -15,7 +15,7 @@ type Props = {
   /**
    * AST operation node.
    */
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
   /**
    * TypeScript resolver for resolving param/data/response type names.
    */
@@ -50,7 +50,7 @@ function buildRemappingCode(mapping: Record<string, string>, varName: string, so
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export function McpHandler({ name, node, resolver, baseURL, dataReturnType, paramsCasing }: Props): KubbReactNode {
-  const urlPath = new URLPath(node.path!)
+  const urlPath = new URLPath(node.path)
   const contentType = node.requestBody?.content?.[0]?.contentType
   const isFormData = contentType === 'multipart/form-data'
 
@@ -86,7 +86,7 @@ export function McpHandler({ name, node, resolver, baseURL, dataReturnType, para
   const headers = [headerParams.length ? (headerParamsMapping ? '...mappedHeaders' : '...headers') : null, contentTypeHeader].filter(Boolean)
 
   const fetchConfig: Array<string> = []
-  fetchConfig.push(`method: ${JSON.stringify(node.method!.toUpperCase())}`)
+  fetchConfig.push(`method: ${JSON.stringify(node.method.toUpperCase())}`)
   fetchConfig.push(`url: ${urlPath.template}`)
   if (baseURL) fetchConfig.push(`baseURL: \`${baseURL}\``)
   if (queryParams.length) fetchConfig.push(queryParamsMapping ? 'params: mappedParams' : 'params')

--- a/packages/plugin-mcp/src/components/McpHandler.tsx
+++ b/packages/plugin-mcp/src/components/McpHandler.tsx
@@ -15,7 +15,7 @@ type Props = {
   /**
    * AST operation node.
    */
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
   /**
    * TypeScript resolver for resolving param/data/response type names.
    */
@@ -50,6 +50,7 @@ function buildRemappingCode(mapping: Record<string, string>, varName: string, so
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export function McpHandler({ name, node, resolver, baseURL, dataReturnType, paramsCasing }: Props): KubbReactNode {
+  if (!ast.isHttpOperationNode(node)) return null
   const urlPath = new URLPath(node.path)
   const contentType = node.requestBody?.content?.[0]?.contentType
   const isFormData = contentType === 'multipart/form-data'

--- a/packages/plugin-mcp/src/components/McpHandler.tsx
+++ b/packages/plugin-mcp/src/components/McpHandler.tsx
@@ -50,7 +50,7 @@ function buildRemappingCode(mapping: Record<string, string>, varName: string, so
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 export function McpHandler({ name, node, resolver, baseURL, dataReturnType, paramsCasing }: Props): KubbReactNode {
-  const urlPath = new URLPath(node.path)
+  const urlPath = new URLPath(node.path!)
   const contentType = node.requestBody?.content?.[0]?.contentType
   const isFormData = contentType === 'multipart/form-data'
 
@@ -86,7 +86,7 @@ export function McpHandler({ name, node, resolver, baseURL, dataReturnType, para
   const headers = [headerParams.length ? (headerParamsMapping ? '...mappedHeaders' : '...headers') : null, contentTypeHeader].filter(Boolean)
 
   const fetchConfig: Array<string> = []
-  fetchConfig.push(`method: ${JSON.stringify(node.method.toUpperCase())}`)
+  fetchConfig.push(`method: ${JSON.stringify(node.method!.toUpperCase())}`)
   fetchConfig.push(`url: ${urlPath.template}`)
   if (baseURL) fetchConfig.push(`baseURL: \`${baseURL}\``)
   if (queryParams.length) fetchConfig.push(queryParamsMapping ? 'params: mappedParams' : 'params')

--- a/packages/plugin-mcp/src/generators/mcpGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/mcpGenerator.tsx
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { McpHandler } from '../components/McpHandler.tsx'
@@ -16,6 +16,7 @@ export const mcpGenerator = defineGenerator<PluginMcp>({
   name: 'mcp',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { resolver, driver, root } = ctx
     const { output, client, paramsCasing, group } = ctx.options
 

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -70,7 +70,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
         tool: {
           name: node.operationId,
           title: node.summary || undefined,
-          description: node.description || `Make a ${node.method.toUpperCase()} request to ${node.path}`,
+          description: node.description || `Make a ${node.method!.toUpperCase()} request to ${node.path}`,
         },
         mcp: {
           name: resolver.resolveHandlerName(node),

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { findSuccessStatusCode, getOperationParameters } from '@internals/shared'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 import { Server } from '../components/Server.tsx'
@@ -43,7 +43,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
       meta: { pluginName: plugin.name },
     }
 
-    const operationsMapped = nodes.map((node) => {
+    const operationsMapped = nodes.filter(ast.isHttpOperationNode).map((node) => {
       const { path: pathParams, query: queryParams, header: headerParams } = getOperationParameters(node, { paramsCasing })
 
       const mcpFile = resolver.resolveFile(
@@ -70,7 +70,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
         tool: {
           name: node.operationId,
           title: node.summary || undefined,
-          description: node.description || `Make a ${node.method!.toUpperCase()} request to ${node.path}`,
+          description: node.description || `Make a ${node.method.toUpperCase()} request to ${node.path}`,
         },
         mcp: {
           name: resolver.resolveHandlerName(node),

--- a/packages/plugin-msw/src/components/Mock.tsx
+++ b/packages/plugin-msw/src/components/Mock.tsx
@@ -11,7 +11,7 @@ type Props = {
   typeName: string
   requestTypeName?: string | null
   baseURL: string | null | undefined
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
 }
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })

--- a/packages/plugin-msw/src/components/Mock.tsx
+++ b/packages/plugin-msw/src/components/Mock.tsx
@@ -11,7 +11,7 @@ type Props = {
   typeName: string
   requestTypeName?: string | null
   baseURL: string | null | undefined
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
 }
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })

--- a/packages/plugin-msw/src/components/MockWithFaker.tsx
+++ b/packages/plugin-msw/src/components/MockWithFaker.tsx
@@ -12,7 +12,7 @@ type Props = {
   requestTypeName?: string | null
   fakerName: string
   baseURL: string | null | undefined
-  node: ast.OperationNode
+  node: ast.HttpOperationNode
 }
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })

--- a/packages/plugin-msw/src/components/MockWithFaker.tsx
+++ b/packages/plugin-msw/src/components/MockWithFaker.tsx
@@ -12,7 +12,7 @@ type Props = {
   requestTypeName?: string | null
   fakerName: string
   baseURL: string | null | undefined
-  node: ast.HttpOperationNode
+  node: ast.OperationNode
 }
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -1,5 +1,5 @@
 import { getOperationSuccessResponses, resolveResponseTypes } from '@internals/shared'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { pluginFakerName } from '@kubb/plugin-faker'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
@@ -17,6 +17,7 @@ export const mswGenerator = defineGenerator<PluginMsw>({
   name: 'msw',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { driver, resolver, config, root } = ctx
     const { output, parser, baseURL, group } = ctx.options
 

--- a/packages/plugin-msw/src/utils.ts
+++ b/packages/plugin-msw/src/utils.ts
@@ -1,4 +1,4 @@
-import type { ast } from '@kubb/core'
+import { ast } from '@kubb/core'
 import type { ResolverFaker } from '@kubb/plugin-faker'
 import type { PluginMsw } from './types.ts'
 
@@ -29,15 +29,15 @@ function getResponseContentType(response: ast.ResponseNode | null | undefined): 
 /**
  * Converts an HTTP method to its lowercase MSW equivalent (e.g., 'POST' → 'post').
  */
-export function getMswMethod(node: ast.HttpOperationNode): string {
-  return node.method.toLowerCase()
+export function getMswMethod(node: ast.OperationNode): string {
+  return ast.isHttpOperationNode(node) ? node.method.toLowerCase() : ''
 }
 
 /**
  * Converts an OpenAPI-style path to an Express/MSW-style path by replacing `{param}` with `:param`.
  */
-export function getMswUrl(node: ast.HttpOperationNode): string {
-  return node.path.replaceAll('{', ':').replaceAll('}', '')
+export function getMswUrl(node: ast.OperationNode): string {
+  return ast.isHttpOperationNode(node) ? node.path.replaceAll('{', ':').replaceAll('}', '') : ''
 }
 
 /**

--- a/packages/plugin-msw/src/utils.ts
+++ b/packages/plugin-msw/src/utils.ts
@@ -29,15 +29,15 @@ function getResponseContentType(response: ast.ResponseNode | null | undefined): 
 /**
  * Converts an HTTP method to its lowercase MSW equivalent (e.g., 'POST' → 'post').
  */
-export function getMswMethod(node: ast.OperationNode): string {
-  return node.method!.toLowerCase()
+export function getMswMethod(node: ast.HttpOperationNode): string {
+  return node.method.toLowerCase()
 }
 
 /**
  * Converts an OpenAPI-style path to an Express/MSW-style path by replacing `{param}` with `:param`.
  */
-export function getMswUrl(node: ast.OperationNode): string {
-  return node.path!.replaceAll('{', ':').replaceAll('}', '')
+export function getMswUrl(node: ast.HttpOperationNode): string {
+  return node.path.replaceAll('{', ':').replaceAll('}', '')
 }
 
 /**

--- a/packages/plugin-msw/src/utils.ts
+++ b/packages/plugin-msw/src/utils.ts
@@ -30,14 +30,14 @@ function getResponseContentType(response: ast.ResponseNode | null | undefined): 
  * Converts an HTTP method to its lowercase MSW equivalent (e.g., 'POST' → 'post').
  */
 export function getMswMethod(node: ast.OperationNode): string {
-  return node.method.toLowerCase()
+  return node.method!.toLowerCase()
 }
 
 /**
  * Converts an OpenAPI-style path to an Express/MSW-style path by replacing `{param}` with `:param`.
  */
 export function getMswUrl(node: ast.OperationNode): string {
-  return node.path.replaceAll('{', ':').replaceAll('}', '')
+  return node.path!.replaceAll('{', ':').replaceAll('}', '')
 }
 
 /**

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -1,5 +1,5 @@
 import { getOperationParameters } from '@internals/shared'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { File, jsxRendererSync, Type } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import { difference } from 'remeda'
@@ -36,6 +36,7 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
     const hookOptions: Record<string, string> = {}
 
     for (const node of nodes) {
+      if (!ast.isHttpOperationNode(node)) continue
       const opOverrides = resolveOperationOverrides(node, override)
       const nodeQuery: QueryOption = 'query' in opOverrides ? (opOverrides.query as QueryOption) : query
       const nodeMutation: MutationOption = 'mutation' in opOverrides ? (opOverrides.mutation as MutationOption) : mutation
@@ -45,12 +46,12 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       // query: false means "still a query but skip the useQuery hook"
       const isQueryOp =
         nodeQuery === false
-          ? !!query && query.methods.some((m) => node.method!.toLowerCase() === m.toLowerCase())
-          : !!nodeQuery && nodeQuery.methods.some((m) => node.method!.toLowerCase() === m.toLowerCase())
+          ? !!query && query.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
+          : !!nodeQuery && nodeQuery.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
       const isMutationOp =
         nodeMutation !== false &&
         !isQueryOp &&
-        difference(nodeMutation ? nodeMutation.methods : [], nodeQuery ? nodeQuery.methods : []).some((m) => node.method!.toLowerCase() === m.toLowerCase())
+        difference(nodeMutation ? nodeMutation.methods : [], nodeQuery ? nodeQuery.methods : []).some((m) => node.method.toLowerCase() === m.toLowerCase())
       const isSuspenseOp = !!suspense
       const isInfiniteOp = !!nodeInfiniteOptions
 

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -45,12 +45,12 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       // query: false means "still a query but skip the useQuery hook"
       const isQueryOp =
         nodeQuery === false
-          ? !!query && query.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
-          : !!nodeQuery && nodeQuery.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
+          ? !!query && query.methods.some((m) => node.method!.toLowerCase() === m.toLowerCase())
+          : !!nodeQuery && nodeQuery.methods.some((m) => node.method!.toLowerCase() === m.toLowerCase())
       const isMutationOp =
         nodeMutation !== false &&
         !isQueryOp &&
-        difference(nodeMutation ? nodeMutation.methods : [], nodeQuery ? nodeQuery.methods : []).some((m) => node.method.toLowerCase() === m.toLowerCase())
+        difference(nodeMutation ? nodeMutation.methods : [], nodeQuery ? nodeQuery.methods : []).some((m) => node.method!.toLowerCase() === m.toLowerCase())
       const isSuspenseOp = !!suspense
       const isInfiniteOp = !!nodeInfiniteOptions
 

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -27,11 +27,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { getOperationParameters, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -20,6 +20,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-infinite-query',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
@@ -27,11 +28,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -19,6 +19,7 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query-mutation',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
@@ -26,11 +27,11 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -26,11 +26,11 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -27,11 +27,11 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     // query: false means "this IS a query op, but skip the useQuery hook"
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -19,6 +19,7 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-query',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
@@ -27,11 +28,11 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     // query: false means "this IS a query op, but skip the useQuery hook"
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { getOperationParameters, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -20,6 +20,7 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
   name: 'react-suspense-infinite-query',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const {
       output,
@@ -40,11 +41,11 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -40,11 +40,11 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -28,11 +28,11 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     // query: false means "this IS a query op" (suspense hooks still generate)
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
 
     if (!isQuery || isMutation || !isSuspense) return null

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -20,6 +20,7 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
   name: 'react-suspense-query',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, query, mutation, suspense, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group, customOptions } = ctx.options
 
@@ -28,11 +29,11 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     // query: false means "this IS a query op" (suspense hooks still generate)
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
 
     if (!isQuery || isMutation || !isSuspense) return null

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { getOperationParameters, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -20,6 +20,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-infinite',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, query, mutation, infinite, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
@@ -27,11 +28,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -27,11 +27,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -19,6 +19,7 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query-mutation',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
@@ -26,11 +27,11 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -26,11 +26,11 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import { resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -19,6 +19,7 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
   name: 'vue-query',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver, root } = ctx
     const { output, query, mutation, paramsCasing, paramsType, pathParamsType, parser, client: clientOptions, group } = ctx.options
 
@@ -26,11 +27,11 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -26,11 +26,11 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     if (!pluginTs) return null
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const isQuery = query === false || (!!query && query.methods.some((method) => node.method!.toLowerCase() === method.toLowerCase()))
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method!.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-zod/src/components/Operations.tsx
+++ b/packages/plugin-zod/src/components/Operations.tsx
@@ -32,7 +32,7 @@ export function Operations({ name, operations }: Props): KubbReactNode {
   const pathsJSON = operations.reduce<Record<string, Record<string, string>>>((prev, acc) => {
     prev[`"${acc.node.path}"`] = {
       ...(prev[`"${acc.node.path}"`] ?? {}),
-      [acc.node.method]: `operations["${acc.node.operationId}"]`,
+      [acc.node.method!]: `operations["${acc.node.operationId}"]`,
     }
 
     return prev

--- a/packages/plugin-zod/src/components/Operations.tsx
+++ b/packages/plugin-zod/src/components/Operations.tsx
@@ -1,5 +1,5 @@
 import { stringifyObject } from '@internals/utils'
-import type { ast } from '@kubb/core'
+import { ast } from '@kubb/core'
 import { Const, File, Type } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 
@@ -16,7 +16,7 @@ type SchemaNames = {
 
 type Props = {
   name: string
-  operations: Array<{ node: ast.HttpOperationNode; data: SchemaNames }>
+  operations: Array<{ node: ast.OperationNode; data: SchemaNames }>
 }
 
 export function Operations({ name, operations }: Props): KubbReactNode {
@@ -30,6 +30,7 @@ export function Operations({ name, operations }: Props): KubbReactNode {
   )
 
   const pathsJSON = operations.reduce<Record<string, Record<string, string>>>((prev, acc) => {
+    if (!ast.isHttpOperationNode(acc.node)) return prev
     prev[`"${acc.node.path}"`] = {
       ...(prev[`"${acc.node.path}"`] ?? {}),
       [acc.node.method]: `operations["${acc.node.operationId}"]`,

--- a/packages/plugin-zod/src/components/Operations.tsx
+++ b/packages/plugin-zod/src/components/Operations.tsx
@@ -16,7 +16,7 @@ type SchemaNames = {
 
 type Props = {
   name: string
-  operations: Array<{ node: ast.OperationNode; data: SchemaNames }>
+  operations: Array<{ node: ast.HttpOperationNode; data: SchemaNames }>
 }
 
 export function Operations({ name, operations }: Props): KubbReactNode {
@@ -32,7 +32,7 @@ export function Operations({ name, operations }: Props): KubbReactNode {
   const pathsJSON = operations.reduce<Record<string, Record<string, string>>>((prev, acc) => {
     prev[`"${acc.node.path}"`] = {
       ...(prev[`"${acc.node.path}"`] ?? {}),
-      [acc.node.method!]: `operations["${acc.node.operationId}"]`,
+      [acc.node.method]: `operations["${acc.node.operationId}"]`,
     }
 
     return prev

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -88,6 +88,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
     )
   },
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { adapter, config, resolver, root } = ctx
     const { output, coercion, guidType, mini, wrapOutput, inferred, importPath, group, paramsCasing, printer } = ctx.options
     const dateType = (adapter as Adapter<AdapterOas>).options.dateType
@@ -225,7 +226,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
       file: resolver.resolveFile({ name: 'operations', extname: '.ts' }, { root, output, group: group ?? undefined }),
     } as const
 
-    const transformedOperations = nodes.map((node) => {
+    const transformedOperations = nodes.filter(ast.isHttpOperationNode).map((node) => {
       const params = ast.caseParams(node.parameters, paramsCasing)
 
       return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,23 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     '@kubb/agent':
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     '@kubb/core':
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     '@kubb/middleware-barrel':
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     '@kubb/parser-ts':
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     '@kubb/renderer-jsx':
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     '@size-limit/file':
       specifier: ^12.1.0
       version: 12.1.0
@@ -40,8 +40,8 @@ catalogs:
       specifier: ^4.1.7
       version: 4.1.7
     kubb:
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     oxfmt:
       specifier: ^0.47.0
       version: 0.47.0
@@ -64,8 +64,8 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     unplugin-kubb:
-      specifier: 5.0.0-beta.29
-      version: 5.0.0-beta.29
+      specifier: 5.0.0-beta.30
+      version: 5.0.0-beta.30
     vitest:
       specifier: ^4.1.7
       version: 4.1.7
@@ -82,16 +82,16 @@ importers:
         version: 2.31.0(@types/node@22.19.19)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/middleware-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))
+        version: 5.0.0-beta.30(@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -227,16 +227,16 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/agent':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -245,13 +245,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -260,13 +260,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -288,7 +288,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -307,7 +307,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -322,7 +322,7 @@ importers:
         version: 1.11.20
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -335,7 +335,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -344,7 +344,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
     devDependencies:
       react:
         specifier: ^19.2.6
@@ -357,13 +357,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -372,13 +372,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
       axios:
         specifier: ^1.16.1
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -394,7 +394,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-mcp':
         specifier: workspace:*
         version: link:../../packages/plugin-mcp
@@ -412,7 +412,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -428,7 +428,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -446,7 +446,7 @@ importers:
         version: 0.10.3(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -465,7 +465,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -486,7 +486,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -495,7 +495,7 @@ importers:
         version: 19.2.6(react@19.2.6)
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(@kubb/renderer-jsx@5.0.0-beta.29)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 5.0.0-beta.30(@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(@kubb/renderer-jsx@5.0.0-beta.30)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -520,7 +520,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -529,7 +529,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -539,7 +539,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -563,7 +563,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -578,7 +578,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -587,7 +587,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -597,7 +597,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -618,7 +618,7 @@ importers:
         version: 1.16.1
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(@kubb/renderer-jsx@5.0.0-beta.29)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 5.0.0-beta.30(@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(@kubb/renderer-jsx@5.0.0-beta.30)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       vue:
         specifier: ^3.5.34
         version: 3.5.34(typescript@6.0.3)
@@ -652,7 +652,7 @@ importers:
         version: 1.16.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -670,7 +670,7 @@ importers:
         version: link:../utils
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -686,13 +686,13 @@ importers:
         version: link:../utils
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -708,7 +708,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
@@ -717,7 +717,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -733,13 +733,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -752,13 +752,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -768,7 +768,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -780,7 +780,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -793,7 +793,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../plugin-faker
@@ -802,7 +802,7 @@ importers:
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -815,7 +815,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -827,7 +827,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -846,10 +846,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       handlebars:
         specifier: ^4.7.9
         version: 4.7.9
@@ -862,13 +862,13 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -887,7 +887,7 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -899,7 +899,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -918,10 +918,10 @@ importers:
     dependencies:
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29
+        version: 5.0.0-beta.30
       remeda:
         specifier: 'catalog:'
         version: 2.34.1
@@ -937,13 +937,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -989,7 +989,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1025,7 +1025,7 @@ importers:
         version: 15.15.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -1056,10 +1056,10 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+        version: 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1074,7 +1074,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3)
+        version: 5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1713,26 +1713,26 @@ packages:
     peerDependencies:
       jsep: ^0.4.0||^1.0.0
 
-  '@kubb/adapter-oas@5.0.0-beta.29':
-    resolution: {integrity: sha512-QSRhA22fR6veOaYXq4RYSQMVWA+lNHxc6MiSXD5r9Hoi7csgNpY7zCsMk5odNpgb5fW4r5jINPGCXyPsX4XShg==}
+  '@kubb/adapter-oas@5.0.0-beta.30':
+    resolution: {integrity: sha512-sfL+qkVPiACBA0FnPShcQ6/EWbJR+cgWZrkgVq4+0gld9ZIJAVk0CgyiQusWRzycLkkgzysR6vg4/veSSR7iig==}
     engines: {node: '>=22'}
 
-  '@kubb/agent@5.0.0-beta.29':
-    resolution: {integrity: sha512-fsdHuEa628HxzDUos2qGGDlpLrBExyDkKM4SVEGPjQ/VhbbDfKTP+2owQWepnwH3vwLdA+mMYDvCFQNLKEJjkA==}
+  '@kubb/agent@5.0.0-beta.30':
+    resolution: {integrity: sha512-GnMs/YfjxODO37rJ1S8YgxlpVqZXrHRKEJ1tWu/6yXFM+gBZgS5Vv4Z86+mx2XH9savzfyVZdEuFqPBPbWOasA==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-beta.29':
-    resolution: {integrity: sha512-skgLK95EUlDH9CgMreq/3aH8JLcSkQk0X2VJfun2cRIlj44uAxKafxv0mFqLbz4DrPv+cmmv29FvEZiwgSVvkA==}
+  '@kubb/ast@5.0.0-beta.30':
+    resolution: {integrity: sha512-PiQ0mINKe4fbaOJsyiDarQ/1NM153R8Aro2BLTr7O2Er2LHVBYvMfPoPeWDSMucCn8YWFHM/aaibQJ5D3T65hA==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-beta.29':
-    resolution: {integrity: sha512-7XtHIv/4BD8YsOBafSQUbs39DzwUkcPjNukqSQSaIPOgXF0bHc2kFJZsUr24Y8r8EGSVC6grloRnW5mmT8dE3w==}
+  '@kubb/cli@5.0.0-beta.30':
+    resolution: {integrity: sha512-B8ByfaYusd9IHQBUp7tLMJ5LPGv8OWO00XOYW+XwPWH4/rf/trlnsh7JNLvH93cDgB35fMGmqmij0/UHuWVEvA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.29
-      '@kubb/agent': 5.0.0-beta.29
-      '@kubb/mcp': 5.0.0-beta.29
+      '@kubb/adapter-oas': 5.0.0-beta.30
+      '@kubb/agent': 5.0.0-beta.30
+      '@kubb/mcp': 5.0.0-beta.30
     peerDependenciesMeta:
       '@kubb/adapter-oas':
         optional: true
@@ -1741,35 +1741,35 @@ packages:
       '@kubb/mcp':
         optional: true
 
-  '@kubb/core@5.0.0-beta.29':
-    resolution: {integrity: sha512-igQgRaPkd4i0npAJgKXT1BpfIeHI9HSsn+Dll3WorDcBrM2c1GWsW7dC3qSQ4tfWc7FKP61aZu3B1x/mM39ZNQ==}
+  '@kubb/core@5.0.0-beta.30':
+    resolution: {integrity: sha512-RyqRck1gq9uebyFVxA0AOuAnaBOxiUd46Q5rKzRATjRtSOrcz2e/jFDE20sAOYvaezJbxR1n5Tw8dG83d3HADw==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.29
+      '@kubb/renderer-jsx': 5.0.0-beta.30
 
-  '@kubb/mcp@5.0.0-beta.29':
-    resolution: {integrity: sha512-llFqlWY5xMuj9rTKXqh8lOlRy9+oJZenbmYaIyj6mzF3xNRycXkrbAb1zN+LiAVNXrstXDQpvN33HLvK7q3rOA==}
+  '@kubb/mcp@5.0.0-beta.30':
+    resolution: {integrity: sha512-L/XaIiRFufHts44yuYJT97xHUYJRGg58ijUYLVOc8qoMY6eZ6oEkruMZMA6gGA8QCln7UnMmYunCh5GdHw57wg==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.29
+      '@kubb/renderer-jsx': 5.0.0-beta.30
 
-  '@kubb/middleware-barrel@5.0.0-beta.29':
-    resolution: {integrity: sha512-RPpsp9HBz3XTllwj1wFf6zrDua9G31pw/SVBJZbrK5PJOFbyo2lUrpShL5b3gY5rK4NmhH8M3gJUOuccacIMkg==}
+  '@kubb/middleware-barrel@5.0.0-beta.30':
+    resolution: {integrity: sha512-NR+Le8jg4JWmB9Q3Mm+uM+CfgmQS+G/wC6h5Divltk/1arfFQ8dwffXnJn0NY/Vawg26XlXKTM5jLFrBNuWNWA==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-beta.29
+      '@kubb/core': 5.0.0-beta.30
 
-  '@kubb/parser-md@5.0.0-beta.29':
-    resolution: {integrity: sha512-FzRXB5mrInQ/rqxFuE0rYKtV0YWsnhHAuOYd8ozVgkjZHZ1NqqgPSaW9x1T7HuUdcTl5eChCg3WaySii6MCEeg==}
+  '@kubb/parser-md@5.0.0-beta.30':
+    resolution: {integrity: sha512-RYatEeqG3jHi9agdsx/tdUYVZljfZgesrwCxkR6N+Bp4Szb2ftbLMVtBjy6cHhRZIaQ59wvh+CWYhrvvX60dLA==}
     engines: {node: '>=22'}
 
-  '@kubb/parser-ts@5.0.0-beta.29':
-    resolution: {integrity: sha512-hqBXD7COcT/1u1SzhpyPcCp4fcT0WV1AsLKCz+MXTGVYYYgZulH5s1AzN2pheGqxA0gY3+pRGPofY9BENILTZA==}
+  '@kubb/parser-ts@5.0.0-beta.30':
+    resolution: {integrity: sha512-wuu6r83m4CD5vLaEOtQ4OAV428r0hbt5KTm8LdcaxEpNiyZwAnvafDAsyoQhC3SUcgBsFMiOK7zsU3Mk2CCmkw==}
     engines: {node: '>=22'}
 
-  '@kubb/renderer-jsx@5.0.0-beta.29':
-    resolution: {integrity: sha512-ny19E8IAh0138exAsrlSsbj8s4GDeQdRv5wOzFEEXInUNcxYD3qAO8dMaAfJ90CKyPmBNDWPeuNgnoyU+Wn22w==}
+  '@kubb/renderer-jsx@5.0.0-beta.30':
+    resolution: {integrity: sha512-3rhKuNOdfed0EHhcotAXD9sbkRzF7qeuWXv2T9fbBuEVpHTO4j/H0WTYC5glOcuaP2hzlyn0SNJBkhZHGlyfpw==}
     engines: {node: '>=22'}
 
   '@logtail/core@0.5.8':
@@ -3777,12 +3777,12 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-beta.29:
-    resolution: {integrity: sha512-vsEGFSCtGbbHoDfQlBR9quH3/zo0ME3BVE+oRvqN8HEW9aHIgC1DtoXzX3xLlZjVvZT++XKR/wNUT2SvSDKyVw==}
+  kubb@5.0.0-beta.30:
+    resolution: {integrity: sha512-40c9MoekgkiaiKkjv5YhRa4+EGr3u5IpaG708mY7Rng0Y7pcTQOaqRlRpiNYVDVMD/6Lvo3D8SfuDrdhN7MHhQ==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/agent': 5.0.0-beta.29
+      '@kubb/agent': 5.0.0-beta.30
     peerDependenciesMeta:
       '@kubb/agent':
         optional: true
@@ -4869,8 +4869,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-beta.29:
-    resolution: {integrity: sha512-/AEda32UpfMlV0qWmhkcRPkpFXZV6PUhFDDTPgnizY+7mjBnUlp/lpN6jZqAx9yjxSiO8pRuUkfRsnjAevDkIg==}
+  unplugin-kubb@5.0.0-beta.30:
+    resolution: {integrity: sha512-d2XFnjfj/UxU2/j1fklPbgDfMiG+q+DTpmEvIPxKBA+QD8CQHXaui8Q3WNlmmmG0ERXJgX+Hi8STSTNbMVDaOA==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -5888,9 +5888,9 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@kubb/adapter-oas@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)':
+  '@kubb/adapter-oas@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@redocly/openapi-core': 2.31.2
       oas: 32.1.18
       oas-normalize: 16.0.4
@@ -5899,10 +5899,10 @@ snapshots:
       - '@kubb/renderer-jsx'
       - encoding
 
-  '@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)':
+  '@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.29
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/ast': 5.0.0-beta.30
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       '@logtail/node': 0.5.8
       consola: 3.4.2
       jiti: 2.7.0
@@ -5934,36 +5934,36 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@kubb/ast@5.0.0-beta.29': {}
+  '@kubb/ast@5.0.0-beta.30': {}
 
-  '@kubb/cli@5.0.0-beta.29(@kubb/adapter-oas@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(@kubb/mcp@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.29)(typescript@6.0.3)':
+  '@kubb/cli@5.0.0-beta.30(@kubb/adapter-oas@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(@kubb/mcp@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.30)(typescript@6.0.3)':
     dependencies:
       '@clack/prompts': 1.4.0
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       chokidar: 5.0.0
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.7.0
       tinyexec: 1.1.2
     optionalDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/agent': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/mcp': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)(typescript@6.0.3)
+      '@kubb/adapter-oas': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/agent': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/mcp': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
       - typescript
 
-  '@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)':
+  '@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.29
-      '@kubb/renderer-jsx': 5.0.0-beta.29
+      '@kubb/ast': 5.0.0-beta.30
+      '@kubb/renderer-jsx': 5.0.0-beta.30
       fflate: 0.8.3
       tinyexec: 1.1.2
 
-  '@kubb/mcp@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)(typescript@6.0.3)':
+  '@kubb/mcp@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)(typescript@6.0.3)':
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/renderer-jsx': 5.0.0-beta.29
+      '@kubb/adapter-oas': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/renderer-jsx': 5.0.0-beta.30
       '@remix-run/node-fetch-server': 0.13.2
       '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.0(typescript@6.0.3))
       '@tmcp/transport-http': 0.8.6(tmcp@1.19.4(typescript@6.0.3))
@@ -5976,28 +5976,28 @@ snapshots:
       - encoding
       - typescript
 
-  '@kubb/middleware-barrel@5.0.0-beta.29(@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))':
+  '@kubb/middleware-barrel@5.0.0-beta.30(@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.29
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/ast': 5.0.0-beta.30
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
 
-  '@kubb/parser-md@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)':
+  '@kubb/parser-md@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/parser-ts@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)':
+  '@kubb/parser-ts@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/renderer-jsx@5.0.0-beta.29':
+  '@kubb/renderer-jsx@5.0.0-beta.30':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.29
+      '@kubb/ast': 5.0.0-beta.30
       yaml: 2.9.0
 
   '@logtail/core@0.5.8':
@@ -7961,18 +7961,18 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-beta.29(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(typescript@6.0.3):
+  kubb@5.0.0-beta.30(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(typescript@6.0.3):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/cli': 5.0.0-beta.29(@kubb/adapter-oas@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(@kubb/agent@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(@kubb/mcp@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.29)(typescript@6.0.3)
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/mcp': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)(typescript@6.0.3)
-      '@kubb/middleware-barrel': 5.0.0-beta.29(@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))
-      '@kubb/parser-md': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/parser-ts': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/renderer-jsx': 5.0.0-beta.29
+      '@kubb/adapter-oas': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/cli': 5.0.0-beta.30(@kubb/adapter-oas@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(@kubb/agent@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(@kubb/mcp@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.30)(typescript@6.0.3)
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/mcp': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)(typescript@6.0.3)
+      '@kubb/middleware-barrel': 5.0.0-beta.30(@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))
+      '@kubb/parser-md': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/parser-ts': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/renderer-jsx': 5.0.0-beta.30
     optionalDependencies:
-      '@kubb/agent': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/agent': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - encoding
@@ -9120,12 +9120,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-beta.29(@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))(@kubb/renderer-jsx@5.0.0-beta.29)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.30(@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))(@kubb/renderer-jsx@5.0.0-beta.30)(esbuild@0.28.0)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.6.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/core': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
-      '@kubb/middleware-barrel': 5.0.0-beta.29(@kubb/core@5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29))
-      '@kubb/parser-ts': 5.0.0-beta.29(@kubb/renderer-jsx@5.0.0-beta.29)
+      '@kubb/adapter-oas': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/core': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
+      '@kubb/middleware-barrel': 5.0.0-beta.30(@kubb/core@5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30))
+      '@kubb/parser-ts': 5.0.0-beta.30(@kubb/renderer-jsx@5.0.0-beta.30)
       unplugin: 3.0.0
     optionalDependencies:
       esbuild: 0.28.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,18 +12,18 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.29
-  '@kubb/agent': 5.0.0-beta.29
-  '@kubb/core': 5.0.0-beta.29
-  '@kubb/middleware-barrel': 5.0.0-beta.29
-  '@kubb/parser-ts': 5.0.0-beta.29
-  '@kubb/renderer-jsx': 5.0.0-beta.29
+  '@kubb/adapter-oas': 5.0.0-beta.30
+  '@kubb/agent': 5.0.0-beta.30
+  '@kubb/core': 5.0.0-beta.30
+  '@kubb/middleware-barrel': 5.0.0-beta.30
+  '@kubb/parser-ts': 5.0.0-beta.30
+  '@kubb/renderer-jsx': 5.0.0-beta.30
   '@size-limit/file': ^12.1.0
   '@types/node': ^22.19.19
   '@types/react': ^19.2.15
   '@vitest/coverage-v8': ^4.1.7
   '@vitest/ui': ^4.1.7
-  kubb: 5.0.0-beta.29
+  kubb: 5.0.0-beta.30
   oxfmt: ^0.47.0
   oxlint: ^1.66.0
   prettier: ^3.8.3
@@ -31,7 +31,7 @@ catalog:
   'size-limit': ^12.1.0
   tsdown: ^0.22.0
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.29
+  unplugin-kubb: 5.0.0-beta.30
   vitest: ^4.1.7
 
 minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age


### PR DESCRIPTION
## Summary

Adopts the `HttpOperationNode` discriminated union from [kubb-labs/kubb#3382](https://github.com/kubb-labs/kubb/pull/3382). Each operation generator narrows the incoming node once with `ast.isHttpOperationNode` (these are all HTTP/OpenAPI plugins), and shared helpers/components are typed as `ast.HttpOperationNode` — so `method`/`path` are non-nullable with **no manual `!` assertions**. OpenAPI output is unchanged.

- **Generators** (`operation` hooks) early-return on a non-HTTP node via `ast.isHttpOperationNode`; `operations` hooks filter with `nodes.filter(ast.isHttpOperationNode)`. Covers react-query, vue-query, client, cypress, mcp, msw, zod.
- **Helpers/components** retyped to `ast.HttpOperationNode`: client components + utils, cypress `Request`, mcp `McpHandler`/`serverGenerator`, msw `Mock`/`MockWithFaker`/utils, zod `Operations`, tanstack-query `QueryKey`/`MutationKey`, and the `OperationData` types in the class-client generators.
- **Intentionally-generic shared utils** (`getOperationLink`, tanstack `matchesPattern`, the key transformers) keep accepting the union and guard `method`/`path` locally.

This replaces the temporary non-null assertions from the previous commit on this branch.

## ⚠️ Depends on kubb#3382

These plugins now call `ast.isHttpOperationNode`, which ships in `@kubb/ast` via kubb#3382 (unreleased). **CI is red until the catalog points at a kubb build that includes the union** — bump `@kubb/*` in `pnpm-workspace.yaml` once `5.0.0-beta.30` is published, or temporarily install the PR snapshot (`https://pkg.pr.new/@kubb/core@3382`, etc.).

## Verification

Verified locally by patching the installed `@kubb/ast` declaration (and runtime guard) to the union shape, then `tsc --noEmit` per package — **all packages typecheck clean**. Non-generator unit tests pass (e.g. plugin-msw, 59 client tests, 216 zod tests); the `*Generator.test` suites can't run in this sandbox due to an unrelated `#mocks` subpath-resolution quirk and will run in CI once the dependency gate is lifted. Runtime behaviour is unchanged: `isHttpOperationNode` returns `true` for every OpenAPI operation (it also accepts a present `method`+`path`).

## Test plan

- [ ] `pnpm typecheck` (after catalog points at kubb#3382/beta.30)
- [ ] `pnpm test`
- [ ] `pnpm lint`

https://claude.ai/code/session_01QZYnpQmHutzDUkJ1KxJ5nW