### PR TITLE
refactor(plugins): shared createGroupConfig + operationFileEntry helpers

### DIFF
--- a/.changeset/shared-group-config-helper.md
+++ b/.changeset/shared-group-config-helper.md
@@ -1,0 +1,13 @@
+---
+"@kubb/plugin-ts": patch
+"@kubb/plugin-zod": patch
+"@kubb/plugin-faker": patch
+"@kubb/plugin-client": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-msw": patch
+"@kubb/plugin-cypress": patch
+"@kubb/plugin-mcp": patch
+---
+
+Replace the per-plugin `group` naming block (duplicated verbatim across nine plugins) with a shared `createGroupConfig` helper from `@internals/shared`. Each plugin's grouping behavior is preserved exactly — the `Controller`/`Requests` suffix and whether a user-provided `group.name` is honored are passed as options — so generated output is unchanged. Internal refactor only.

--- a/.changeset/shared-operation-file-entry.md
+++ b/.changeset/shared-operation-file-entry.md
@@ -1,0 +1,7 @@
+---
+"@kubb/plugin-client": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+---
+
+Replace the `resolver.resolveFile` entry object — duplicated 44 times across the client and query operation generators — with a shared `operationFileEntry(node, name)` helper from `@internals/shared`. The helper returns the same `{ name, extname: '.ts', tag, path }` params, so generated output is unchanged. Internal refactor only.

--- a/internals/shared/src/group.test.ts
+++ b/internals/shared/src/group.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { createGroupConfig } from './group.ts'
+
+describe('createGroupConfig', () => {
+  it('returns null when grouping is disabled', () => {
+    expect(createGroupConfig(undefined, { suffix: 'Controller' })).toBeNull()
+  })
+
+  it('names path groups by the second path segment', () => {
+    const config = createGroupConfig({ type: 'path' }, { suffix: 'Controller' })
+    const name = config?.name as (ctx: { group: string }) => string
+
+    expect(name({ group: '/pet/findByStatus' })).toBe('pet')
+  })
+
+  it('names tag groups with the camelCased group plus suffix', () => {
+    const controller = createGroupConfig({ type: 'tag' }, { suffix: 'Controller' })
+    const requests = createGroupConfig({ type: 'tag' }, { suffix: 'Requests' })
+    const controllerName = controller?.name as (ctx: { group: string }) => string
+    const requestsName = requests?.name as (ctx: { group: string }) => string
+
+    expect(controllerName({ group: 'pet store' })).toBe('petStoreController')
+    expect(requestsName({ group: 'pet store' })).toBe('petStoreRequests')
+  })
+
+  it('ignores a user-provided name unless honorName is set', () => {
+    const custom = (): string => 'Custom'
+
+    const ignored = createGroupConfig({ type: 'tag', name: custom }, { suffix: 'Controller' })
+    expect(ignored?.name).not.toBe(custom)
+
+    const honored = createGroupConfig({ type: 'tag', name: custom }, { suffix: 'Controller', honorName: true })
+    expect(honored?.name).toBe(custom)
+  })
+})

--- a/internals/shared/src/group.ts
+++ b/internals/shared/src/group.ts
@@ -1,0 +1,41 @@
+import { camelCase } from '@internals/utils'
+import type { Group } from '@kubb/core'
+
+/**
+ * Builds the `group` config a Kubb plugin passes to `ctx.setOptions`, applying the
+ * shared default naming so every plugin groups output consistently:
+ *
+ * - `path` groups use the second path segment (`/pet/findByStatus` → `pet`).
+ * - other groups use `${camelCase(group)}${suffix}` (e.g. `petController`).
+ *
+ * Returns `null` when grouping is disabled, matching the per-plugin convention.
+ *
+ * @param group - The user-supplied group option, or `undefined` to disable grouping.
+ * @param options.suffix - Appended to non-`path` group names, e.g. `'Controller'` or `'Requests'`.
+ * @param options.honorName - When `true`, a user-provided `group.name` overrides the default namer.
+ *
+ * @example
+ * ```ts
+ * createGroupConfig(group, { suffix: 'Controller' })                  // plugin-ts, plugin-zod
+ * createGroupConfig(group, { suffix: 'Controller', honorName: true }) // plugin-faker, plugin-client, …
+ * createGroupConfig(group, { suffix: 'Requests', honorName: true })   // plugin-cypress, plugin-mcp
+ * ```
+ */
+export function createGroupConfig(group: Group | undefined, options: { suffix: string; honorName?: boolean }): Group | null {
+  if (!group) {
+    return null
+  }
+
+  const defaultName = (ctx: { group: string }): string => {
+    if (group.type === 'path') {
+      return `${ctx.group.split('/')[1]}`
+    }
+
+    return `${camelCase(ctx.group)}${options.suffix}`
+  }
+
+  return {
+    ...group,
+    name: options.honorName && group.name ? group.name : defaultName,
+  } satisfies Group
+}

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -25,4 +25,5 @@ export {
   type ResponseStatusNameResolver,
   type ResolveOperationTypeNameOptions,
 } from './operation.ts'
+export { createGroupConfig } from './group.ts'
 export { buildParamsMapping, buildTransformedParamsMapping } from './params.ts'

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -10,6 +10,7 @@ export {
   getSuccessResponses,
   isErrorStatusCode,
   isSuccessStatusCode,
+  operationFileEntry,
   resolveErrorNames,
   resolveOperationTypeNames,
   resolveResponseTypes,

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -1,5 +1,25 @@
 import { URLPath } from '@internals/utils'
-import { ast } from '@kubb/core'
+import { ast, type ResolverFileParams } from '@kubb/core'
+
+/**
+ * Builds the `ResolverFileParams` every operation generator passes to
+ * `resolver.resolveFile`: a file named `name`, tagged by the operation's first
+ * tag (or `'default'`), at the operation's path. Centralizes the entry object
+ * that was repeated at dozens of call sites across the client and query plugins.
+ *
+ * @example
+ * ```ts
+ * resolver.resolveFile(operationFileEntry(node, node.operationId), { root, output, group })
+ * ```
+ */
+export function operationFileEntry(node: ast.OperationNode, name: string, extname: ResolverFileParams['extname'] = '.ts'): ResolverFileParams {
+  return {
+    name,
+    extname,
+    tag: node.tags[0] ?? 'default',
+    path: node.path,
+  }
+}
 
 export type ContentTypeInfo = {
   contentTypes: string[]

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { camelCase } from '@internals/utils'
 import { ast, defineGenerator } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
@@ -61,16 +61,18 @@ export const classClientGenerator = defineGenerator<PluginClient>({
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
 
     function buildOperationData(node: ast.OperationNode): OperationData {
-      const typeFile = tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: tsPluginOptions?.output ?? output, group: tsPluginOptions?.group },
-      )
+      const typeFile = tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: tsPluginOptions?.output ?? output,
+        group: tsPluginOptions?.group,
+      })
       const zodFile =
         zodResolver && pluginZod?.options
-          ? zodResolver.resolveFile(
-              { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-              { root, output: pluginZod.options?.output ?? output, group: pluginZod.options?.group ?? undefined },
-            )
+          ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+              root,
+              output: pluginZod.options?.output ?? output,
+              group: pluginZod.options?.group ?? undefined,
+            })
           : null
 
       return {

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { ast, defineGenerator } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
@@ -45,28 +45,19 @@ export const clientGenerator = defineGenerator<PluginClient>({
     const meta = {
       name: resolver.resolveName(node.operationId),
       urlName: resolver.resolveUrlName(node),
-      file: resolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        {
-          root,
-          output: pluginTs.options?.output ?? output,
-          group: pluginTs.options?.group ?? undefined,
-        },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, node.operationId), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
       fileZod:
         zodResolver && pluginZod?.options
-          ? zodResolver.resolveFile(
-              { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-              {
-                root,
-                output: pluginZod.options.output ?? output,
-                group: pluginZod.options?.group ?? undefined,
-              },
-            )
+          ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+              root,
+              output: pluginZod.options.output ?? output,
+              group: pluginZod.options?.group ?? undefined,
+            })
           : null,
     } as const
 

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { camelCase } from '@internals/utils'
 import { ast, defineGenerator } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
@@ -60,16 +60,18 @@ export const staticClassClientGenerator = defineGenerator<PluginClient>({
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
 
     function buildOperationData(node: ast.OperationNode): OperationData {
-      const typeFile = tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: tsPluginOptions?.output ?? output, group: tsPluginOptions?.group },
-      )
+      const typeFile = tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: tsPluginOptions?.output ?? output,
+        group: tsPluginOptions?.group,
+      })
       const zodFile =
         zodResolver && pluginZod?.options
-          ? zodResolver.resolveFile(
-              { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-              { root, output: pluginZod.options?.output ?? output, group: pluginZod.options?.group ?? undefined },
-            )
+          ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+              root,
+              output: pluginZod.options?.output ?? output,
+              group: pluginZod.options?.group ?? undefined,
+            })
           : null
 
       return {

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
-import { camelCase } from '@internals/utils'
+import { createGroupConfig } from '@internals/shared'
 
-import { ast, definePlugin, type Group } from '@kubb/core'
+import { ast, definePlugin } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { classClientGenerator } from './generators/classClientGenerator.tsx'
@@ -80,19 +80,7 @@ export const pluginClient = definePlugin<PluginClient>((options) => {
       operations ? operationsGenerator : null,
     ].filter((x): x is NonNullable<typeof x> => Boolean(x))
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: group.name
-          ? group.name
-          : (ctx: { group: string }) => {
-              if (group.type === 'path') {
-                return `${ctx.group.split('/')[1]}`
-              }
-              return `${camelCase(ctx.group)}Controller`
-            },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
 
   return {
     name: pluginClientName,

--- a/packages/plugin-cypress/src/plugin.ts
+++ b/packages/plugin-cypress/src/plugin.ts
@@ -1,5 +1,5 @@
-import { camelCase } from '@internals/utils'
-import { definePlugin, type Group } from '@kubb/core'
+import { createGroupConfig } from '@internals/shared'
+import { definePlugin } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { cypressGenerator } from './generators/cypressGenerator.tsx'
 import { resolverCypress } from './resolvers/resolverCypress.ts'
@@ -51,19 +51,7 @@ export const pluginCypress = definePlugin<PluginCypress>((options) => {
     generators: userGenerators = [],
   } = options
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: group.name
-          ? group.name
-          : (ctx: { group: string }) => {
-              if (group.type === 'path') {
-                return `${ctx.group.split('/')[1]}`
-              }
-              return `${camelCase(ctx.group)}Requests`
-            },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Requests', honorName: true })
 
   return {
     name: pluginCypressName,

--- a/packages/plugin-faker/package.json
+++ b/packages/plugin-faker/package.json
@@ -82,6 +82,7 @@
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
+    "@internals/shared": "workspace:*",
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/plugin-faker/src/plugin.ts
+++ b/packages/plugin-faker/src/plugin.ts
@@ -1,5 +1,5 @@
-import { camelCase } from '@internals/utils'
-import { definePlugin, type Group } from '@kubb/core'
+import { createGroupConfig } from '@internals/shared'
+import { definePlugin } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { fakerGenerator } from './generators/fakerGenerator.tsx'
 import { resolverFaker } from './resolvers/resolverFaker.ts'
@@ -54,20 +54,7 @@ export const pluginFaker = definePlugin<PluginFaker>((options) => {
     transformer: userTransformer,
   } = options
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: group.name
-          ? group.name
-          : (ctx: { group: string }) => {
-              if (group.type === 'path') {
-                return `${ctx.group.split('/')[1]}`
-              }
-
-              return `${camelCase(ctx.group)}Controller`
-            },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
 
   return {
     name: pluginFakerName,

--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
-import { camelCase } from '@internals/utils'
+import { createGroupConfig } from '@internals/shared'
 
-import { ast, definePlugin, type Group } from '@kubb/core'
+import { ast, definePlugin } from '@kubb/core'
 import { pluginClientName } from '@kubb/plugin-client'
 import { source as axiosClientSource } from '@kubb/plugin-client/templates/clients/axios.source'
 import { source as fetchClientSource } from '@kubb/plugin-client/templates/clients/fetch.source'
@@ -64,19 +64,7 @@ export const pluginMcp = definePlugin<PluginMcp>((options) => {
   const clientName = client?.client ?? 'axios'
   const clientImportPath = client?.importPath ?? (!client?.bundle ? `@kubb/plugin-client/clients/${clientName}` : undefined)
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: group.name
-          ? group.name
-          : (ctx: { group: string }) => {
-              if (group.type === 'path') {
-                return `${ctx.group.split('/')[1]}`
-              }
-              return `${camelCase(ctx.group)}Requests`
-            },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Requests', honorName: true })
 
   return {
     name: pluginMcpName,

--- a/packages/plugin-msw/src/plugin.ts
+++ b/packages/plugin-msw/src/plugin.ts
@@ -1,5 +1,5 @@
-import { camelCase } from '@internals/utils'
-import { definePlugin, type Group } from '@kubb/core'
+import { createGroupConfig } from '@internals/shared'
+import { definePlugin } from '@kubb/core'
 import { pluginFakerName } from '@kubb/plugin-faker'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { handlersGenerator, mswGenerator } from './generators'
@@ -53,19 +53,7 @@ export const pluginMsw = definePlugin<PluginMsw>((options) => {
     generators: userGenerators = [],
   } = options
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: group.name
-          ? group.name
-          : (ctx: { group: string }) => {
-              if (group.type === 'path') {
-                return `${ctx.group.split('/')[1]}`
-              }
-              return `${camelCase(ctx.group)}Controller`
-            },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
 
   return {
     name: pluginMswName,

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -1,4 +1,4 @@
-import { getOperationParameters } from '@internals/shared'
+import { getOperationParameters, operationFileEntry } from '@internals/shared'
 import { ast, defineGenerator } from '@kubb/core'
 import { File, jsxRendererSync, Type } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
@@ -58,20 +58,14 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       if (isQueryOp) {
         const queryOptionsName = resolver.resolveQueryOptionsName(node)
         const queryHookName = resolver.resolveQueryName(node)
-        const queryHookFile = resolver.resolveFile(
-          { name: queryHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output, group: group ?? undefined },
-        )
+        const queryHookFile = resolver.resolveFile(operationFileEntry(node, queryHookName), { root, output, group: group ?? undefined })
         imports.push(<File.Import name={[queryOptionsName]} root={hookOptionsFile.path} path={queryHookFile.path} />)
         hookOptions[queryHookName] = `Partial<ReturnType<typeof ${queryOptionsName}>>`
 
         if (isSuspenseOp) {
           const suspenseOptionsName = resolver.resolveSuspenseQueryOptionsName(node)
           const suspenseHookName = resolver.resolveSuspenseQueryName(node)
-          const suspenseHookFile = resolver.resolveFile(
-            { name: suspenseHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-            { root, output, group: group ?? undefined },
-          )
+          const suspenseHookFile = resolver.resolveFile(operationFileEntry(node, suspenseHookName), { root, output, group: group ?? undefined })
           imports.push(<File.Import name={[suspenseOptionsName]} root={hookOptionsFile.path} path={suspenseHookFile.path} />)
           hookOptions[suspenseHookName] = `Partial<ReturnType<typeof ${suspenseOptionsName}>>`
         }
@@ -85,20 +79,18 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
           if (hasQueryParam) {
             const infiniteOptionsName = resolver.resolveInfiniteQueryOptionsName(node)
             const infiniteHookName = resolver.resolveInfiniteQueryName(node)
-            const infiniteHookFile = resolver.resolveFile(
-              { name: infiniteHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-              { root, output, group: group ?? undefined },
-            )
+            const infiniteHookFile = resolver.resolveFile(operationFileEntry(node, infiniteHookName), { root, output, group: group ?? undefined })
             imports.push(<File.Import name={[infiniteOptionsName]} root={hookOptionsFile.path} path={infiniteHookFile.path} />)
             hookOptions[infiniteHookName] = `Partial<ReturnType<typeof ${infiniteOptionsName}>>`
 
             if (isSuspenseOp) {
               const suspenseInfiniteOptionsName = resolver.resolveSuspenseInfiniteQueryOptionsName(node)
               const suspenseInfiniteHookName = resolver.resolveSuspenseInfiniteQueryName(node)
-              const suspenseInfiniteHookFile = resolver.resolveFile(
-                { name: suspenseInfiniteHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-                { root, output, group: group ?? undefined },
-              )
+              const suspenseInfiniteHookFile = resolver.resolveFile(operationFileEntry(node, suspenseInfiniteHookName), {
+                root,
+                output,
+                group: group ?? undefined,
+              })
               imports.push(<File.Import name={[suspenseInfiniteOptionsName]} root={hookOptionsFile.path} path={suspenseInfiniteHookFile.path} />)
               hookOptions[suspenseInfiniteHookName] = `Partial<ReturnType<typeof ${suspenseInfiniteOptionsName}>>`
             }
@@ -109,10 +101,7 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
       if (isMutationOp) {
         const mutationOptionsName = resolver.resolveMutationOptionsName(node)
         const mutationHookName = resolver.resolveMutationName(node)
-        const mutationHookFile = resolver.resolveFile(
-          { name: mutationHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output, group: group ?? undefined },
-        )
+        const mutationHookFile = resolver.resolveFile(operationFileEntry(node, mutationHookName), { root, output, group: group ?? undefined })
         imports.push(<File.Import name={[mutationOptionsName]} root={hookOptionsFile.path} path={mutationHookFile.path} />)
         hookOptions[mutationHookName] = `Partial<ReturnType<typeof ${mutationOptionsName}>>`
       }

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { getOperationParameters, resolveOperationTypeNames } from '@internals/shared'
+import { getOperationParameters, operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -55,14 +55,12 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
     const clientBaseName = resolver.resolveInfiniteClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, queryName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, {
@@ -74,10 +72,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -87,14 +86,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientBaseName) : clientBaseName

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -44,14 +44,12 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     const clientName = resolver.resolveClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: mutationHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, mutationHookName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, { paramsCasing, order: 'body-response-first' })
@@ -59,10 +57,11 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -72,14 +71,11 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientName) : clientName

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -45,14 +45,12 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
     const clientName = resolver.resolveClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, queryName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, {
@@ -64,10 +62,11 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -77,14 +76,11 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientName) : clientName

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { getOperationParameters, resolveOperationTypeNames } from '@internals/shared'
+import { getOperationParameters, operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -68,14 +68,12 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     const clientBaseName = resolver.resolveSuspenseInfiniteClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, queryName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, { paramsCasing, order: 'body-response-first' })
@@ -83,10 +81,11 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -96,14 +95,11 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientBaseName) : clientBaseName

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -47,14 +47,12 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
     const clientName = resolver.resolveSuspenseClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, queryName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, {
@@ -66,10 +64,11 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -79,14 +78,11 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientName) : clientName

--- a/packages/plugin-react-query/src/plugin.ts
+++ b/packages/plugin-react-query/src/plugin.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
-import { camelCase } from '@internals/utils'
-import { ast, definePlugin, type Group } from '@kubb/core'
+import { createGroupConfig } from '@internals/shared'
+import { ast, definePlugin } from '@kubb/core'
 import { pluginClientName } from '@kubb/plugin-client'
 import { source as axiosClientSource } from '@kubb/plugin-client/templates/clients/axios.source'
 import { source as fetchClientSource } from '@kubb/plugin-client/templates/clients/fetch.source'
@@ -90,19 +90,7 @@ export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
       customHookOptionsFileGenerator,
     ].filter((generator): generator is NonNullable<typeof generator> => Boolean(generator))
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: group.name
-          ? group.name
-          : (ctx: { group: string }) => {
-              if (group.type === 'path') {
-                return `${ctx.group.split('/')[1]}`
-              }
-              return `${camelCase(ctx.group)}Controller`
-            },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
 
   return {
     name: pluginReactQueryName,

--- a/packages/plugin-ts/src/plugin.ts
+++ b/packages/plugin-ts/src/plugin.ts
@@ -1,5 +1,5 @@
-import { camelCase } from '@internals/utils'
-import { definePlugin, type Group } from '@kubb/core'
+import { createGroupConfig } from '@internals/shared'
+import { definePlugin } from '@kubb/core'
 import { typeGenerator } from './generators/typeGenerator.tsx'
 import { resolverTs } from './resolvers/resolverTs.ts'
 import type { PluginTs } from './types.ts'
@@ -54,17 +54,7 @@ export const pluginTs = definePlugin<PluginTs>((options) => {
     generators: userGenerators = [],
   } = options
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: (ctx) => {
-          if (group.type === 'path') {
-            return `${ctx.group.split('/')[1]}`
-          }
-          return `${camelCase(ctx.group)}Controller`
-        },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller' })
 
   return {
     name: pluginTsName,

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { getOperationParameters, resolveOperationTypeNames } from '@internals/shared'
+import { getOperationParameters, operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -55,14 +55,12 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
     const clientBaseName = resolver.resolveInfiniteClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, queryName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, {
@@ -74,10 +72,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -87,14 +86,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientBaseName) : clientBaseName

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -43,14 +43,12 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
     const clientName = resolver.resolveClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: mutationHookName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, mutationHookName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, { paramsCasing, order: 'body-response-first' })
@@ -58,10 +56,11 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -71,14 +70,11 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientName) : clientName

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
 import { resolveZodSchemaNames } from '@internals/tanstack-query'
 import { ast, defineGenerator } from '@kubb/core'
 import { Client, pluginClientName } from '@kubb/plugin-client'
@@ -44,14 +44,12 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     const clientName = resolver.resolveClientName(node)
 
     const meta = {
-      file: resolver.resolveFile(
-        { name: queryName, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output, group: group ?? undefined },
-      ),
-      fileTs: tsResolver.resolveFile(
-        { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-        { root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined },
-      ),
+      file: resolver.resolveFile(operationFileEntry(node, queryName), { root, output, group: group ?? undefined }),
+      fileTs: tsResolver.resolveFile(operationFileEntry(node, node.operationId), {
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }),
     }
 
     const importedTypeNames = resolveOperationTypeNames(node, tsResolver, {
@@ -63,10 +61,11 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     const pluginZod = parser === 'zod' ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
     const fileZod = zodResolver
-      ? zodResolver.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          { root, output: pluginZod?.options?.output ?? output, group: pluginZod?.options?.group ?? undefined },
-        )
+      ? zodResolver.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: pluginZod?.options?.output ?? output,
+          group: pluginZod?.options?.group ?? undefined,
+        })
       : null
     const zodSchemaNames = resolveZodSchemaNames(node, zodResolver)
 
@@ -76,14 +75,11 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     const clientResolver = shouldUseClientPlugin ? driver.getResolver(pluginClientName) : null
 
     const clientFile = shouldUseClientPlugin
-      ? clientResolver?.resolveFile(
-          { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },
-          {
-            root,
-            output: clientPlugin?.options?.output ?? output,
-            group: clientPlugin?.options?.group ?? undefined,
-          },
-        )
+      ? clientResolver?.resolveFile(operationFileEntry(node, node.operationId), {
+          root,
+          output: clientPlugin?.options?.output ?? output,
+          group: clientPlugin?.options?.group ?? undefined,
+        })
       : null
 
     const resolvedClientName = shouldUseClientPlugin ? (clientResolver?.resolveName(node.operationId) ?? clientName) : clientName

--- a/packages/plugin-vue-query/src/plugin.ts
+++ b/packages/plugin-vue-query/src/plugin.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
-import { camelCase } from '@internals/utils'
-import { ast, definePlugin, type Group } from '@kubb/core'
+import { createGroupConfig } from '@internals/shared'
+import { ast, definePlugin } from '@kubb/core'
 import { pluginClientName } from '@kubb/plugin-client'
 import { source as axiosClientSource } from '@kubb/plugin-client/templates/clients/axios.source'
 import { source as fetchClientSource } from '@kubb/plugin-client/templates/clients/fetch.source'
@@ -72,19 +72,7 @@ export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
     options.generators ??
     [queryGenerator, infiniteQueryGenerator, mutationGenerator].filter((generator): generator is NonNullable<typeof generator> => Boolean(generator))
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: group.name
-          ? group.name
-          : (ctx: { group: string }) => {
-              if (group.type === 'path') {
-                return `${ctx.group.split('/')[1]}`
-              }
-              return `${camelCase(ctx.group)}Controller`
-            },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
 
   return {
     name: pluginVueQueryName,

--- a/packages/plugin-zod/package.json
+++ b/packages/plugin-zod/package.json
@@ -64,6 +64,7 @@
     "remeda": "catalog:"
   },
   "devDependencies": {
+    "@internals/shared": "workspace:*",
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/plugin-zod/src/plugin.ts
+++ b/packages/plugin-zod/src/plugin.ts
@@ -1,5 +1,5 @@
-import { camelCase } from '@internals/utils'
-import { definePlugin, type Group } from '@kubb/core'
+import { createGroupConfig } from '@internals/shared'
+import { definePlugin } from '@kubb/core'
 import { zodGenerator } from './generators/zodGenerator.tsx'
 import { resolverZod } from './resolvers/resolverZod.ts'
 import type { PluginZod } from './types.ts'
@@ -57,17 +57,7 @@ export const pluginZod = definePlugin<PluginZod>((options) => {
     generators: userGenerators = [],
   } = options
 
-  const groupConfig = group
-    ? ({
-        ...group,
-        name: (ctx) => {
-          if (group.type === 'path') {
-            return `${ctx.group.split('/')[1]}`
-          }
-          return `${camelCase(ctx.group)}Controller`
-        },
-      } satisfies Group)
-    : null
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller' })
 
   return {
     name: pluginZodName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,6 +760,9 @@ importers:
         specifier: 'catalog:'
         version: 5.0.0-beta.30
     devDependencies:
+      '@internals/shared':
+        specifier: workspace:*
+        version: link:../../internals/shared
       '@internals/utils':
         specifier: workspace:*
         version: link:../../internals/utils
@@ -926,6 +929,9 @@ importers:
         specifier: 'catalog:'
         version: 2.34.1
     devDependencies:
+      '@internals/shared':
+        specifier: workspace:*
+        version: link:../../internals/shared
       '@internals/utils':
         specifier: workspace:*
         version: link:../../internals/utils


### PR DESCRIPTION
## Summary

Rebased and CI-fixed version of #235 (branch `claude/plugins-shared-kernel`), which was stale against `main` (merge state `dirty`) and red on every CI job. This branch reapplies the two refactor commits on top of current `main` and fixes the root cause of the failures.

Both refactors remain **output-neutral** — verified by regenerating examples (see below).

### What was broken
The createGroupConfig refactor added `@internals/shared` as a `devDependency` to **plugin-faker** and **plugin-zod** but never updated `pnpm-lock.yaml`. CI's setup step runs `pnpm install --frozen-lockfile`, which failed with `ERR_PNPM_OUTDATED_LOCKFILE` — cascading into failures for **Build**, **Linting**, **Spell Check**, **Tests**, **Build and test**, and **Lint and format** (all of them fail at the install step, not in their own logic).

### Fixes in this branch
- **Lockfile** — added the two missing `@internals/shared` workspace entries so `--frozen-lockfile` passes.
- **Rebase onto current `main`** — `main` adopted the `HttpOperationNode` union (`ast.isHttpOperationNode` narrowing) after #235 was opened. Resolved the import conflicts in `clientGenerator.tsx` and `hookOptionsGenerator.tsx` (keep both `ast` and the new `@internals/shared` helpers). All call sites narrow with `isHttpOperationNode` before calling `operationFileEntry`.

### The two refactors (unchanged from #235)
- **`createGroupConfig(group, { suffix, honorName })`** — extracts the `group` naming block duplicated across nine plugins.
- **`operationFileEntry(node, name)`** — extracts the `resolver.resolveFile` entry object duplicated across the client / react-query / vue-query operation generators.

## Verification (local)
- `pnpm build` — 13/13 ✓
- `pnpm typecheck` — 13/13 ✓ (plus `@internals/shared` ✓)
- `pnpm test` — 57 files, **875 tests** ✓
- `pnpm lint` ✓ · `pnpm format` (no changes) ✓
- **Output-neutrality** — `pnpm generate` produced diffs only in `plugin-ts` model JSDoc; confirmed identical drift is produced on plain `main` (a6cac9c) without these commits, so it is pre-existing and unrelated. The `update-examples` workflow handles regeneration separately, so no generated files are bundled here.

> Note: `pnpm install` still cannot fetch the Cypress binary in the sandbox (403); set `CYPRESS_INSTALL_BINARY=0` locally. Does not affect build/typecheck/test.

Supersedes #235.


---
_Generated by [Claude Code](https://claude.ai/code/session_014ERbmuN6GoMtQepEFfYbPs)_