### PR TITLE
fix(examples): narrow OperationNode in custom generators

### DIFF
--- a/examples/client/src/generators/clientOperationGenerator.tsx
+++ b/examples/client/src/generators/clientOperationGenerator.tsx
@@ -6,6 +6,7 @@ const toURL = (path: string) => path.replaceAll('{', ':').replaceAll('}', '')
 export const clientOperationGenerator = defineGenerator<PluginClient>({
   name: 'client-operation',
   async operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { resolver, root } = ctx
     const { output } = ctx.options
     const file = resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output })

--- a/examples/client/src/generators/clientOperationReactGenerator.tsx
+++ b/examples/client/src/generators/clientOperationReactGenerator.tsx
@@ -1,4 +1,4 @@
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import type { PluginClient } from '@kubb/plugin-client'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 
@@ -8,6 +8,7 @@ export const clientOperationReactGenerator = defineGenerator<PluginClient>({
   name: 'client-operation',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { resolver, root } = ctx
     const { output } = ctx.options
     const file = resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output })

--- a/examples/client/src/generators/clientStaticGenerator.tsx
+++ b/examples/client/src/generators/clientStaticGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import type { PluginClient } from '@kubb/plugin-client'
 import { Client } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
@@ -11,6 +11,7 @@ export const clientStaticGenerator = defineGenerator<PluginClient>({
   name: 'client',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { config, driver, resolver } = ctx
     const { output, importPath, dataReturnType, pathParamsType, paramsType, paramsCasing, parser } = ctx.options
     const baseURL = ctx.meta.baseURL

--- a/examples/generators/src/generators/example1.tsx
+++ b/examples/generators/src/generators/example1.tsx
@@ -6,6 +6,7 @@ const toURL = (path: string) => path.replaceAll('{', ':').replaceAll('}', '')
 export const example1 = defineGenerator<PluginClient>({
   name: 'client-operation',
   async operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { resolver, root } = ctx
     const { output } = ctx.options
     const file = resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output })

--- a/examples/generators/src/generators/example2.tsx
+++ b/examples/generators/src/generators/example2.tsx
@@ -1,4 +1,4 @@
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import type { PluginClient } from '@kubb/plugin-client'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
 
@@ -8,6 +8,7 @@ export const example2 = defineGenerator<PluginClient>({
   name: 'client-operation',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { resolver, root } = ctx
     const { output } = ctx.options
     const file = resolver.resolveFile({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path }, { root, output })

--- a/examples/generators/src/generators/example3.tsx
+++ b/examples/generators/src/generators/example3.tsx
@@ -1,4 +1,4 @@
-import { defineGenerator } from '@kubb/core'
+import { ast, defineGenerator } from '@kubb/core'
 import type { PluginClient } from '@kubb/plugin-client'
 import { Const, File, Function, Jsx, jsxRendererSync } from '@kubb/renderer-jsx'
 
@@ -14,6 +14,7 @@ export const example3 = defineGenerator<PluginClient>({
   name: 'client-operation',
   renderer: jsxRendererSync,
   operation(node, ctx) {
+    if (!ast.isHttpOperationNode(node)) return null
     const { resolver, root } = ctx
     const { output } = ctx.options
     const file = resolver.resolveFile({ name: node.operationId, extname: '.tsx', tag: node.tags[0] ?? 'default', path: node.path }, { root, output })


### PR DESCRIPTION
## Summary

The beta.30 `OperationNode` union made `method`/`path` optional (only guaranteed on `HttpOperationNode`). Several example custom generators read `node.method` / `node.path` directly, producing `string | undefined` type warnings under `typecheck:examples`.

This narrows the node with `ast.isHttpOperationNode(node)` at the top of each `operation()` — the same convention already used across the plugin source (e.g. `clientGenerator.tsx`, `mswGenerator.tsx`, ref commit `fa268d7`). For non-HTTP operations the generator now bails with `return null`, which is a valid generator return.

Files touched:
- `examples/generators/src/generators/example1.tsx`
- `examples/generators/src/generators/example2.tsx`
- `examples/generators/src/generators/example3.tsx`
- `examples/client/src/generators/clientOperationGenerator.tsx`
- `examples/client/src/generators/clientOperationReactGenerator.tsx`
- `examples/client/src/generators/clientStaticGenerator.tsx`

No changeset: examples are private packages, no published behavior changes.

## Test plan

- [x] `pnpm build`
- [x] `turbo run typecheck --filter=./examples/generators --filter=./examples/client` passes (was flagging `string | undefined`)
- [x] `pnpm generate` in `examples/generators` exits 0 with byte-identical output (petStore spec is all HTTP operations)

Note: other examples (`advanced`, `sdk`, etc.) still fail `typecheck:examples` due to a pre-existing, unrelated issue — generated `src/gen/` code referencing `@kubb/plugin-client/clients/axios`. Out of scope here.

https://claude.ai/code/session_01AxDSnjUMMDL8pRVTTgH5AQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxDSnjUMMDL8pRVTTgH5AQ)_