### PR TITLE
fix(plugin-react-query): drop invalid `enabled` guard from suspense query options

### DIFF
--- a/.changeset/react-query-suspense-no-enabled.md
+++ b/.changeset/react-query-suspense-no-enabled.md
@@ -1,0 +1,12 @@
+---
+"@kubb/plugin-react-query": patch
+---
+
+Don't emit an `enabled` guard in generated suspense query options.
+
+`useSuspenseQuery`/`useSuspenseInfiniteQuery` always run, and TanStack Query
+types `UseSuspenseQueryOptions` as `Omit<UseQueryOptions, 'enabled' | ...>`, so
+an `enabled` option is invalid for suspense hooks. The generated
+`<op>SuspenseQueryOptions` and `<op>SuspenseInfiniteQueryOptions` functions no
+longer include `enabled`. Regular `useQuery`/`useInfiniteQuery` options are
+unchanged.

--- a/examples/react-query/src/gen/hooks/pet/useGetPetByIdSuspenseHook.ts
+++ b/examples/react-query/src/gen/hooks/pet/useGetPetByIdSuspenseHook.ts
@@ -34,7 +34,6 @@ export async function getPetByIdSuspenseHook({ pet_id }: { pet_id: GetPetByIdPat
 export function getPetByIdSuspenseQueryOptionsHook({ pet_id }: { pet_id: GetPetByIdPathPetId }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey({ pet_id })
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-    enabled: !!pet_id,
     queryKey,
     queryFn: async ({ signal }) => {
       return getPetByIdSuspenseHook({ pet_id }, { ...config, signal: config.signal ?? signal })

--- a/examples/react-query/src/gen/hooks/pet/useUpdatePetWithFormSuspenseHook.ts
+++ b/examples/react-query/src/gen/hooks/pet/useUpdatePetWithFormSuspenseHook.ts
@@ -51,7 +51,6 @@ export function updatePetWithFormSuspenseQueryOptionsHook(
 ) {
   const queryKey = updatePetWithFormSuspenseQueryKey(pet_id, params)
   return queryOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, UpdatePetWithFormResponse, typeof queryKey>({
-    enabled: !!pet_id,
     queryKey,
     queryFn: async ({ signal }) => {
       return updatePetWithFormSuspenseHook(pet_id, params, { ...config, signal: config.signal ?? signal })

--- a/examples/react-query/src/gen/hooks/store/useGetOrderByIdSuspenseHook.ts
+++ b/examples/react-query/src/gen/hooks/store/useGetOrderByIdSuspenseHook.ts
@@ -38,7 +38,6 @@ export function getOrderByIdSuspenseQueryOptionsHook(
 ) {
   const queryKey = getOrderByIdSuspenseQueryKey({ orderId })
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-    enabled: !!orderId,
     queryKey,
     queryFn: async ({ signal }) => {
       return getOrderByIdSuspenseHook({ orderId }, { ...config, signal: config.signal ?? signal })

--- a/examples/react-query/src/gen/hooks/user/useGetUserByNameSuspenseHook.ts
+++ b/examples/react-query/src/gen/hooks/user/useGetUserByNameSuspenseHook.ts
@@ -40,7 +40,6 @@ export function getUserByNameSuspenseQueryOptionsHook(
 ) {
   const queryKey = getUserByNameSuspenseQueryKey({ username })
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-    enabled: !!username,
     queryKey,
     queryFn: async ({ signal }) => {
       return getUserByNameSuspenseHook({ username }, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/components/QueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/QueryOptions.tsx
@@ -17,6 +17,7 @@ type Props = {
   paramsType: PluginReactQuery['resolvedOptions']['paramsType']
   pathParamsType: PluginReactQuery['resolvedOptions']['pathParamsType']
   dataReturnType: PluginReactQuery['resolvedOptions']['client']['dataReturnType']
+  suspense?: boolean
 }
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
@@ -62,6 +63,7 @@ export function QueryOptions({
   paramsType,
   pathParamsType,
   queryKeyName,
+  suspense,
 }: Props): KubbReactNode {
   const successNames = resolveSuccessNames(node, tsResolver)
   const responseName = successNames.length > 0 ? successNames.join(' | ') : tsResolver.resolveResponseName(node)
@@ -79,7 +81,7 @@ export function QueryOptions({
   const queryKeyParamsCall = callPrinter.print(queryKeyParamsNode) ?? ''
 
   const enabledSource = buildEnabledCheck(queryKeyParamsNode)
-  const enabledText = enabledSource ? `enabled: !!(${enabledSource}),` : ''
+  const enabledText = suspense ? '' : enabledSource ? `enabled: !!(${enabledSource}),` : ''
 
   return (
     <File.Source name={name} isExportable isIndexable>

--- a/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
@@ -7,7 +7,6 @@ import { File, Function } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import type { Infinite, PluginReactQuery } from '../types.ts'
 import { buildQueryKeyParams, resolveErrorNames, resolveSuccessNames } from '../utils.ts'
-import { buildEnabledCheck } from '@internals/tanstack-query'
 import { getQueryOptionsParams } from './QueryOptions.tsx'
 
 type Props = {
@@ -88,9 +87,6 @@ export function SuspenseInfiniteQueryOptions({
   const queryKeyParamsNode = buildQueryKeyParams(node, { pathParamsType, paramsCasing, resolver: tsResolver })
   const queryKeyParamsCall = callPrinter.print(queryKeyParamsNode) ?? ''
 
-  const enabledSource = buildEnabledCheck(queryKeyParamsNode)
-  const enabledText = enabledSource ? `enabled: !!(${enabledSource}),` : ''
-
   const hasNewParams = nextParam != null || previousParam != null
 
   const [getNextPageParamExpr, getPreviousPageParamExpr] = (() => {
@@ -135,7 +131,6 @@ export function SuspenseInfiniteQueryOptions({
           {`
       const queryKey = ${queryKeyName}(${queryKeyParamsCall})
       return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({
-       ${enabledText}
        queryKey,
        queryFn: async ({ signal, pageParam }) => {
           ${infiniteOverrideParams}
@@ -155,7 +150,6 @@ export function SuspenseInfiniteQueryOptions({
         {`
       const queryKey = ${queryKeyName}(${queryKeyParamsCall})
       return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({
-       ${enabledText}
        queryKey,
        queryFn: async ({ signal }) => {
           return ${clientName}(${clientCallStr})

--- a/packages/plugin-react-query/src/generators/__snapshots__/clientPostImportPath/useFindPetsByTagsSuspense.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/clientPostImportPath/useFindPetsByTagsSuspense.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, FindPetsByTagsStatus200, typeof queryKey>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/clientPostImportPath/useFindPetsByTagsSuspenseInfinite.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/clientPostImportPath/useFindPetsByTagsSuspenseInfinite.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseInfiniteQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseInfiniteQueryKey(params)
   return infiniteQueryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, InfiniteData<FindPetsByTagsStatus200>, typeof queryKey, number>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspenseInfinite(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTags/useFindPetsByTagsSuspense.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTags/useFindPetsByTagsSuspense.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, FindPetsByTagsStatus200, typeof queryKey>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTags/useFindPetsByTagsSuspenseInfinite.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTags/useFindPetsByTagsSuspenseInfinite.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseInfiniteQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseInfiniteQueryKey(params)
   return infiniteQueryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, InfiniteData<FindPetsByTagsStatus200>, typeof queryKey, number>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspenseInfinite(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTagsFull/useFindPetsByTagsSuspense.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTagsFull/useFindPetsByTagsSuspense.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<ResponseConfig<FindPetsByTagsStatus200>, ResponseErrorConfig<Error>, ResponseConfig<FindPetsByTagsStatus200>, typeof queryKey>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTagsFull/useFindPetsByTagsSuspenseInfinite.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTagsFull/useFindPetsByTagsSuspenseInfinite.ts
@@ -50,7 +50,6 @@ export function findPetsByTagsSuspenseInfiniteQueryOptions(
     typeof queryKey,
     number
   >({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspenseInfinite(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTagsObject/useFindPetsByTagsSuspense.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTagsObject/useFindPetsByTagsSuspense.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, FindPetsByTagsStatus200, typeof queryKey>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense({ params }, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTagsObject/useFindPetsByTagsSuspenseInfinite.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTagsObject/useFindPetsByTagsSuspenseInfinite.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseInfiniteQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseInfiniteQueryKey(params)
   return infiniteQueryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, InfiniteData<FindPetsByTagsStatus200>, typeof queryKey, number>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspenseInfinite({ params }, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTagsWithZod/useFindPetsByTagsSuspense.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTagsWithZod/useFindPetsByTagsSuspense.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, FindPetsByTagsStatus200, typeof queryKey>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/findByTagsWithZod/useFindPetsByTagsSuspenseInfinite.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/findByTagsWithZod/useFindPetsByTagsSuspenseInfinite.ts
@@ -44,7 +44,6 @@ export function findPetsByTagsSuspenseInfiniteQueryOptions(
 ) {
   const queryKey = findPetsByTagsSuspenseInfiniteQueryKey(params)
   return infiniteQueryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<Error>, InfiniteData<FindPetsByTagsStatus200>, typeof queryKey, number>({
-    enabled: !!params,
     queryKey,
     queryFn: async ({ signal }) => {
       return findPetsByTagsSuspenseInfinite(params, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/__snapshots__/getPetIdCamelCase/useGetPetByIdSuspense.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/getPetIdCamelCase/useGetPetByIdSuspense.ts
@@ -28,7 +28,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400>, GetPetByIdStatus200, typeof queryKey>({
-    enabled: !!petId,
     queryKey,
     queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -160,6 +160,7 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
           paramsType={paramsType}
           pathParamsType={pathParamsType}
           dataReturnType={clientOptions.dataReturnType || 'data'}
+          suspense
         />
 
         {suspense && (

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions({ orderId }: { orderId: GetOrde
 
         const queryKey = getOrderByIdSuspenseQueryKey({ orderId })
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense({ orderId }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions({ petId }: { petId: GetPetByIdPat
 
         const queryKey = getPetByIdSuspenseQueryKey({ petId })
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense({ petId }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions({ username }: { username: GetU
 
         const queryKey = getUserByNameSuspenseQueryKey({ username })
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense({ username }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetOrderByIdSuspense.ts
@@ -34,7 +34,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetPetByIdSuspense.ts
@@ -34,7 +34,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetUserByNameSuspense.ts
@@ -33,7 +33,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions({ orderId }: { orderId: GetOrde
 
         const queryKey = getOrderByIdSuspenseQueryKey({ orderId })
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense({ orderId }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions({ petId }: { petId: GetPetByIdPat
 
         const queryKey = getPetByIdSuspenseQueryKey({ petId })
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense({ petId }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions({ username }: { username: GetU
 
         const queryKey = getUserByNameSuspenseQueryKey({ username })
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense({ username }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetOrderByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetPetByIdSuspense.ts
@@ -33,7 +33,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetUserByNameSuspense.ts
@@ -32,7 +32,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetOrderByIdSuspense.ts
@@ -17,7 +17,7 @@ export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderI
 
         const queryKey = getOrderByIdSuspenseQueryKey(orderId)
         return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-         enabled: !!(orderId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getOrderById(orderId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetPetByIdSuspense.ts
@@ -17,7 +17,7 @@ export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, confi
 
         const queryKey = getPetByIdSuspenseQueryKey(petId)
         return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-         enabled: !!(petId),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getPetById(petId, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetUserByNameSuspense.ts
@@ -17,7 +17,7 @@ export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUse
 
         const queryKey = getUserByNameSuspenseQueryKey(username)
         return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-         enabled: !!(username),
+
          queryKey,
          queryFn: async ({ signal }) => {
             return getUserByName(username, { ...config, signal: config.signal ?? signal })


### PR DESCRIPTION
## Summary

Fixes #134.

`@kubb/plugin-react-query` with `suspense: {}` generated suspense query-options functions containing an `enabled: !!(...)` field. TanStack Query types `UseSuspenseQueryOptions = Omit<UseQueryOptions, 'enabled' | 'throwOnError' | 'placeholderData'>`, so `enabled` is invalid for `useSuspenseQuery`/`useSuspenseInfiniteQuery` — it's semantically wrong (suspense queries always run) and only type-checked because of the `as unknown as UseSuspenseQueryOptions` cast in the hook body.

### Changes

- `QueryOptions.tsx`: added an optional `suspense` prop; when set, the `enabled` output is suppressed. The shared component is reused by the suspense query generator.
- `suspenseQueryGenerator.tsx`: passes `suspense` to `<QueryOptions>`.
- `SuspenseInfiniteQueryOptions.tsx` (suspense-only): removed the `enabled` output and the now-unused `buildEnabledCheck` import.

Regular `useQuery`/`useInfiniteQuery` options are unchanged and keep their `enabled` guard.

### Note on the other reported symptoms

The issue also mentioned `petId | undefined` path params and `petId!` assertions (from the v4.37.3 #3022 fix). Those are already resolved in the current codebase — `ast.createOperationParams` types required params as required with no `| undefined`, confirmed by the committed snapshots. The only remaining defect was the stray `enabled` field.

## Test plan

- [x] `pnpm --filter @kubb/plugin-react-query test` (snapshots updated; regular query files keep `enabled`, suspense files don't)
- [x] e2e snapshots regenerated (`tests/3.0.x/__snapshots__/pluginReactQuery/**`)
- [x] examples regenerated (`pnpm generate` for `examples/react-query`); the example's own typecheck hook passes
- [x] `pnpm typecheck` and `pnpm typecheck:examples` pass — generated suspense options no longer pass `enabled` into `UseSuspenseQueryOptions`
- [x] `pnpm lint`

https://claude.ai/code/session_01Ke6dUkSNMboPnEZAPtxQiU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke6dUkSNMboPnEZAPtxQiU)_