### PR TITLE
test(plugin-ts,plugin-cypress): enable tsconfigPaths so #mocks resolves per-package

### DIFF
--- a/packages/plugin-cypress/vitest.config.ts
+++ b/packages/plugin-cypress/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/packages/plugin-ts/vitest.config.ts
+++ b/packages/plugin-ts/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })


### PR DESCRIPTION
## Summary

`#mocks` is a tsconfig-only alias (`"#mocks": ["./configs/mocks.ts"]` in the root `tsconfig.json`) with no `imports` field backing it. The only thing that resolves it at runtime is Vitest's `resolve.tsconfigPaths: true`.

- The root test script (`vitest run --config ./configs/vitest.config.ts`) sets `tsconfigPaths`, so root runs work.
- `plugin-ts` (`src/factory.test.ts`, `src/generators/typeGenerator.test.ts`, `src/printers/printerTs.test.ts`) and `plugin-cypress` (`src/generators/cypressGenerator.test.ts`) import `#mocks`, but their `vitest.config.ts` lacked `resolve.tsconfigPaths`, so `pnpm test` inside those folders failed to resolve the alias.

This adds the `resolve: { tsconfigPaths: true }` block to both configs, matching the root config and `plugin-msw`.

No changeset: `vitest.config.ts` is not part of the published packages, so nothing user-facing ships.

## Test plan

- [x] `cd packages/plugin-ts && pnpm test` — 5 files, 191 tests pass
- [x] `cd packages/plugin-cypress && pnpm test` — 1 file, 17 tests pass
- [ ] Root `pnpm test` stays green in CI

https://claude.ai/code/session_01Stqn82JTs4yKJaSxBr3jfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Stqn82JTs4yKJaSxBr3jfu)_