### PR TITLE
Update kubb dependencies to n-1 version

### DIFF
--- a/packages/plugin-client/package.json
+++ b/packages/plugin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-client",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate type-safe HTTP clients from your OpenAPI specification. Supports Axios, Fetch, and custom client adapters with full TypeScript inference and zero boilerplate.",
   "keywords": [
     "api-client",

--- a/packages/plugin-cypress/package.json
+++ b/packages/plugin-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-cypress",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate Cypress request commands and e2e test fixtures from your OpenAPI specification, enabling automated API testing with zero manual setup.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-faker/package.json
+++ b/packages/plugin-faker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-faker",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate Faker.js mock data factories from your OpenAPI schemas. Produces realistic seed data, test fixtures, and datasets for development and testing.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-mcp",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate Model Context Protocol (MCP) tool definitions from your OpenAPI specification. Expose your REST APIs as AI-callable tools for LLMs, Claude, ChatGPT, and other AI assistants.",
   "keywords": [
     "ai",

--- a/packages/plugin-msw/package.json
+++ b/packages/plugin-msw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-msw",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate Mock Service Worker (MSW) request handlers from your OpenAPI specification. Intercept HTTP requests in the browser or Node.js for seamless frontend development and testing.",
   "keywords": [
     "api-mocking",

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-react-query",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate type-safe TanStack Query (React Query) hooks from your OpenAPI specification. Covers useQuery, useMutation, useInfiniteQuery, and queryOptions with full TypeScript support.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-redoc/package.json
+++ b/packages/plugin-redoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-redoc",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate a beautiful, interactive ReDoc API reference page from your OpenAPI specification. Produces a standalone HTML file with a responsive, developer-friendly UI.",
   "keywords": [
     "api-docs",

--- a/packages/plugin-ts/package.json
+++ b/packages/plugin-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-ts",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate TypeScript types, interfaces, and enums from your OpenAPI specification. The foundational plugin that powers type safety across the entire Kubb ecosystem.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-vue-query/package.json
+++ b/packages/plugin-vue-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-vue-query",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate type-safe TanStack Query (Vue Query) composables from your OpenAPI specification. Covers useQuery, useMutation, useInfiniteQuery, and queryOptions with Vue 3 Composition API support.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-zod/package.json
+++ b/packages/plugin-zod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-zod",
-  "version": "5.0.0-beta.31",
+  "version": "5.0.0-beta.30",
   "description": "Generate Zod validation schemas from your OpenAPI specification for runtime data parsing and type safety. Pairs perfectly with @kubb/plugin-ts for end-to-end type coverage.",
   "keywords": [
     "code-generation",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,18 +12,18 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.31
-  '@kubb/agent': 5.0.0-beta.31
-  '@kubb/core': 5.0.0-beta.31
-  '@kubb/middleware-barrel': 5.0.0-beta.31
-  '@kubb/parser-ts': 5.0.0-beta.31
-  '@kubb/renderer-jsx': 5.0.0-beta.31
+  '@kubb/adapter-oas': 5.0.0-beta.30
+  '@kubb/agent': 5.0.0-beta.30
+  '@kubb/core': 5.0.0-beta.30
+  '@kubb/middleware-barrel': 5.0.0-beta.30
+  '@kubb/parser-ts': 5.0.0-beta.30
+  '@kubb/renderer-jsx': 5.0.0-beta.30
   '@size-limit/file': ^12.1.0
   '@types/node': ^22.19.19
   '@types/react': ^19.2.15
   '@vitest/coverage-v8': ^4.1.7
   '@vitest/ui': ^4.1.7
-  kubb: 5.0.0-beta.31
+  kubb: 5.0.0-beta.30
   oxfmt: ^0.47.0
   oxlint: ^1.66.0
   prettier: ^3.8.3
@@ -31,7 +31,7 @@ catalog:
   'size-limit': ^12.1.0
   tsdown: ^0.22.0
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.31
+  unplugin-kubb: 5.0.0-beta.30
   vitest: ^4.1.7
 
 minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age


### PR DESCRIPTION
## Summary
Updates the plugins repository to use Kubb core packages at version n-1 (5.0.0-beta.30), enabling a new changeset to sync all packages to the same release version as the latest Kubb release (5.0.0-beta.31).

## Changes
- Updated `pnpm-workspace.yaml` catalog to reference kubb v5.0.0-beta.30
- Downgraded all 10 plugin packages to v5.0.0-beta.30
- Executed `pnpm install` to update dependencies

## Next Steps
A new changeset should be created to bump all packages to match the latest Kubb release version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAGYkY5LZRuiRFGYX8Bb1z)_