### PR TITLE
test: standardize on toStrictEqual

### DIFF
--- a/internals/utils/src/names.test.ts
+++ b/internals/utils/src/names.test.ts
@@ -7,21 +7,21 @@ describe('uniqueName', () => {
       const data: Record<string, number> = {}
       const result = getUniqueName('test', data)
       expect(result).toBe('test')
-      expect(data).toEqual({ test: 1 })
+      expect(data).toStrictEqual({ test: 1 })
     })
 
     it('should append number for duplicate names', () => {
       const data: Record<string, number> = { test: 1 }
       const result = getUniqueName('test', data)
       expect(result).toBe('test2')
-      expect(data).toEqual({ test: 2, test2: 1 })
+      expect(data).toStrictEqual({ test: 2, test2: 1 })
     })
 
     it('should increment number for multiple duplicates', () => {
       const data: Record<string, number> = { test: 2, test2: 1 }
       const result = getUniqueName('test', data)
       expect(result).toBe('test3')
-      expect(data).toEqual({ test: 3, test2: 1, test3: 1 })
+      expect(data).toStrictEqual({ test: 3, test2: 1, test3: 1 })
     })
 
     it('should handle different names independently', () => {
@@ -33,7 +33,7 @@ describe('uniqueName', () => {
       expect(result1).toBe('foo')
       expect(result2).toBe('bar')
       expect(result3).toBe('foo2')
-      expect(data).toEqual({ foo: 2, bar: 1, foo2: 1 })
+      expect(data).toStrictEqual({ foo: 2, bar: 1, foo2: 1 })
     })
   })
 })

--- a/packages/plugin-client/src/clients/fetch.test.ts
+++ b/packages/plugin-client/src/clients/fetch.test.ts
@@ -150,7 +150,7 @@ describe('fetch client', () => {
           method: 'GET',
         }),
       )
-      expect(response.data).toEqual({ data: 'test' })
+      expect(response.data).toStrictEqual({ data: 'test' })
     })
 
     it('should handle query parameters', async () => {
@@ -215,7 +215,7 @@ describe('fetch client', () => {
         }),
       )
 
-      expect(getConfig()).toEqual({
+      expect(getConfig()).toStrictEqual({
         baseURL: 'https://api.example.com',
         headers: { Authorization: 'Bearer token' },
       })
@@ -234,7 +234,7 @@ describe('fetch client', () => {
         method: 'DELETE',
       })
 
-      expect(response.data).toEqual({})
+      expect(response.data).toStrictEqual({})
       expect(response.status).toBe(204)
     })
 
@@ -370,7 +370,7 @@ describe('fetch client', () => {
 
       const response = await client({ url: '/api/unknown', method: 'GET' })
 
-      expect(response.data).toEqual({ parsed: true })
+      expect(response.data).toStrictEqual({ parsed: true })
     })
   })
 })

--- a/packages/plugin-client/templates/config.test.ts
+++ b/packages/plugin-client/templates/config.test.ts
@@ -74,7 +74,7 @@ describe('buildFormData', () => {
 
       const tags = formData.getAll('tags')
       expect(tags).toHaveLength(3)
-      expect(tags).toEqual(['javascript', 'typescript', 'kubb'])
+      expect(tags).toStrictEqual(['javascript', 'typescript', 'kubb'])
     })
 
     it('should handle number arrays', () => {
@@ -83,7 +83,7 @@ describe('buildFormData', () => {
 
       const scores = formData.getAll('scores')
       expect(scores).toHaveLength(3)
-      expect(scores).toEqual(['10', '20', '30'])
+      expect(scores).toStrictEqual(['10', '20', '30'])
     })
 
     it('should handle boolean arrays', () => {
@@ -92,7 +92,7 @@ describe('buildFormData', () => {
 
       const flags = formData.getAll('flags')
       expect(flags).toHaveLength(3)
-      expect(flags).toEqual(['true', 'false', 'true'])
+      expect(flags).toStrictEqual(['true', 'false', 'true'])
     })
 
     it('should handle File arrays', () => {
@@ -115,7 +115,7 @@ describe('buildFormData', () => {
 
       const items = formData.getAll('items')
       expect(items).toHaveLength(3)
-      expect(items).toEqual(['string', '123', 'true'])
+      expect(items).toStrictEqual(['string', '123', 'true'])
     })
 
     it('should handle empty arrays', () => {
@@ -132,7 +132,7 @@ describe('buildFormData', () => {
 
       const tags = formData.getAll('tags')
       expect(tags).toHaveLength(2)
-      expect(tags).toEqual(['valid', 'another'])
+      expect(tags).toStrictEqual(['valid', 'another'])
     })
 
     it('should filter out undefined values in arrays', () => {
@@ -141,7 +141,7 @@ describe('buildFormData', () => {
 
       const tags = formData.getAll('tags')
       expect(tags).toHaveLength(2)
-      expect(tags).toEqual(['valid', 'another'])
+      expect(tags).toStrictEqual(['valid', 'another'])
     })
 
     it('should filter out both null and undefined in arrays', () => {
@@ -150,7 +150,7 @@ describe('buildFormData', () => {
 
       const tags = formData.getAll('tags')
       expect(tags).toHaveLength(3)
-      expect(tags).toEqual(['first', 'middle', 'last'])
+      expect(tags).toStrictEqual(['first', 'middle', 'last'])
     })
   })
 
@@ -199,7 +199,7 @@ describe('buildFormData', () => {
       expect(formData.get('isPublic')).toBe('true')
       expect(formData.get('file')).toBe(file)
       expect(formData.get('createdAt')).toBe('2024-01-15T10:30:00.000Z')
-      expect(formData.getAll('tags')).toEqual(['tag1', 'tag2'])
+      expect(formData.getAll('tags')).toStrictEqual(['tag1', 'tag2'])
       expect(formData.get('metadata')).toBeInstanceOf(Blob)
       expect(await (formData.get('metadata') as Blob).text()).toBe('{"author":"John"}')
     })
@@ -336,7 +336,7 @@ describe('buildFormData', () => {
       expect(formData.get('file')).toBe(file)
       expect(formData.get('title')).toBe('Important Document')
       expect(formData.get('description')).toBe('This is a test document')
-      expect(formData.getAll('tags')).toEqual(['work', 'important'])
+      expect(formData.getAll('tags')).toStrictEqual(['work', 'important'])
       expect(formData.get('isPublic')).toBe('false')
       expect(formData.get('uploadDate')).toBe('2024-01-15T10:30:00.000Z')
     })
@@ -377,7 +377,7 @@ describe('buildFormData', () => {
 
       expect(formData.get('title')).toBe('Post Title')
       expect(formData.get('content')).toBe('Post content here')
-      expect(formData.getAll('tags')).toEqual(['blog', 'tech'])
+      expect(formData.getAll('tags')).toStrictEqual(['blog', 'tech'])
       expect(formData.has('publishDate')).toBe(false)
       expect(formData.get('isDraft')).toBe('false')
       expect(formData.has('metadata')).toBe(false)
@@ -399,7 +399,7 @@ describe('buildFormData', () => {
       expect(attachments[1]).toBe(file2)
 
       const labels = formData.getAll('labels')
-      expect(labels).toEqual(['urgent', 'review-needed'])
+      expect(labels).toStrictEqual(['urgent', 'review-needed'])
       expect(formData.get('priority')).toBe('1')
     })
 
@@ -417,7 +417,7 @@ describe('buildFormData', () => {
 
       const tags = formData.getAll('tags')
       expect(tags).toHaveLength(3)
-      expect(tags).toEqual(['tag1', 'tag2', 'tag3'])
+      expect(tags).toStrictEqual(['tag1', 'tag2', 'tag3'])
     })
   })
 


### PR DESCRIPTION
## Summary

Standardizes test assertions on `toStrictEqual` (intent-revealing, catches extra/`undefined` keys and prototype mismatches, no `-u` drift). Converts the remaining 20 `toEqual` object/array comparisons in test files; the repo already used `toStrictEqual` in 33 places.

## Test plan
- [x] `vitest run` full suite — 60 files / 920 tests pass (no assertion failures from the swap)
- [x] `oxfmt` applied to changed files
- [x] `oxlint ./packages` clean
- No changeset (test-only change)

https://claude.ai/code/session_01LCWTRTc4rLP97tk1GxHTKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCWTRTc4rLP97tk1GxHTKJ)_