### PR TITLE
build: add missing Kubb core packages to catalog

### DIFF
--- a/.changeset/many-cameras-sink.md
+++ b/.changeset/many-cameras-sink.md
@@ -1,0 +1,18 @@
+---
+'@kubb/plugin-client': patch
+'@kubb/plugin-cypress': patch
+'@kubb/plugin-faker': patch
+'@kubb/plugin-mcp': patch
+'@kubb/plugin-msw': patch
+'@kubb/plugin-react-query': patch
+'@kubb/plugin-redoc': patch
+'@kubb/plugin-swr': patch
+'@kubb/plugin-ts': patch
+'@kubb/plugin-vue-query': patch
+'@kubb/plugin-zod': patch
+---
+
+build: prepare for next Kubb core package release
+
+Update Kubb core packages catalog to align with latest versions, ensuring all plugins
+remain in sync with the next Kubb core release.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,8 +14,12 @@ allowBuilds:
 catalog:
   '@kubb/adapter-oas': 5.0.0-beta.31
   '@kubb/agent': 5.0.0-beta.31
+  '@kubb/ast': 5.0.0-beta.31
+  '@kubb/cli': 5.0.0-beta.31
   '@kubb/core': 5.0.0-beta.31
   '@kubb/middleware-barrel': 5.0.0-beta.31
+  '@kubb/mcp': 5.0.0-beta.31
+  '@kubb/parser-md': 5.0.0-beta.31
   '@kubb/parser-ts': 5.0.0-beta.31
   '@kubb/renderer-jsx': 5.0.0-beta.31
   '@size-limit/file': ^12.1.0


### PR DESCRIPTION
## Summary
Add missing Kubb core packages to pnpm-workspace.yaml catalog to align with latest Kubb core package releases and prepare for version synchronization.

## Changes
- Added `@kubb/ast`, `@kubb/cli`, `@kubb/mcp`, and `@kubb/parser-md` to catalog at version 5.0.0-beta.31
- Ensures all available Kubb packages are available in the catalog for future use
- Prepares the plugins repo for the next Kubb release where all packages will sync versions

## Test plan
- [x] pnpm install completes successfully
- [x] All dependencies resolved
- [x] pnpm-workspace.yaml is valid YAML

---
_Generated by [Claude Code](https://claude.ai/code/session_018oj47Ey52AENSxHmtNw9Q6)_