### PR TITLE
docs: standardize plugin readmes with og banner header

### DIFF
--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-client</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,10 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/sdk" target="_blank">View SDK Demo</a>
-<span> · </span>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/client" target="_blank">View Client Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/client" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -23,13 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-client
+
+### Generate type-safe HTTP clients from OpenAPI
+
 `@kubb/plugin-client` generates HTTP clients from your OpenAPI specification. It supports Axios, Fetch, and custom adapters, with request and response types inferred directly from the spec.
-
-## Features
-
-- Supports Axios, Fetch, and custom HTTP adapters
-- Infers request params, request body, and response types from the spec
-- Works with `@kubb/plugin-ts` and `@kubb/plugin-zod`
 
 ## Installation
 
@@ -47,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/client) for configuration 
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -56,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-cypress</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/cypress" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/cypress" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,13 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-cypress
+
+### Generate Cypress commands from OpenAPI
+
 `@kubb/plugin-cypress` generates Cypress request commands from your OpenAPI specification. Each operation in the spec becomes a typed Cypress command, ready to use in your test files.
-
-## Features
-
-- Generates Cypress request commands for each OpenAPI operation
-- Infers request and response types from OpenAPI schemas
-- Works with `@kubb/plugin-ts` for typed test utilities
 
 ## Installation
 
@@ -45,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/cypress) for configuration
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -54,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-faker</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/faker" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/faker" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,14 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-faker
+
+### Generate Faker mock data from OpenAPI
+
 `@kubb/plugin-faker` generates Faker.js factory functions from your OpenAPI schemas. Each schema produces a function that returns realistic mock data matching the schema's structure.
-
-## Features
-
-- Creates one factory function per schema with optional field overrides
-- Uses Faker.js to produce realistic values for common field types
-- Handles recursive schemas with lazy getters to avoid circular reference errors
-- Works with `@kubb/plugin-msw` to serve mock responses in the browser or Node.js
 
 ## Installation
 
@@ -46,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/faker) for configuration o
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -55,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-mcp</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/mcp" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/mcp" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,13 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-mcp
+
+### Generate MCP tool definitions from OpenAPI
+
 `@kubb/plugin-mcp` generates Model Context Protocol (MCP) tool definitions from your OpenAPI specification. Each API operation becomes a typed MCP tool that AI assistants can call directly.
-
-## Features
-
-- Converts OpenAPI operations to MCP-compatible tool definitions
-- Derives input and output schemas directly from the spec
-- Works with Claude, ChatGPT, and any MCP-compatible runtime
 
 ## Installation
 
@@ -45,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/mcp) for configuration opt
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -54,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-msw</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/msw" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/msw" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,14 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-msw
+
+### Generate MSW request handlers from OpenAPI
+
 `@kubb/plugin-msw` generates Mock Service Worker (MSW) request handlers from your OpenAPI specification. The handlers work in both browser and Node.js environments via MSW v2.
-
-## Features
-
-- Generates one handler per OpenAPI operation
-- Infers request and response types from the spec
-- Works in both browser (via service worker) and Node.js test environments
-- Works with `@kubb/plugin-faker` to serve realistic response data
 
 ## Installation
 
@@ -46,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/msw) for configuration opt
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -55,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-react-query</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/react-query" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/react-query" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,14 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-react-query
+
+### Generate TanStack Query hooks from OpenAPI
+
 `@kubb/plugin-react-query` generates TanStack Query hooks from your OpenAPI specification. Each operation becomes a typed `useQuery`, `useMutation`, or `useInfiniteQuery` hook.
-
-## Features
-
-- Generates `useQuery`, `useMutation`, `useInfiniteQuery`, and `queryOptions` hooks
-- Infers request, response, and error types from the spec
-- Groups output files by tag, operation, or a custom strategy
-- Works with `@kubb/plugin-ts`, `@kubb/plugin-zod`, and `@kubb/plugin-client`
 
 ## Installation
 
@@ -46,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/react-query) for configura
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -55,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-redoc</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/typescript" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/redoc" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,13 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-redoc
+
+### Generate a ReDoc API reference from OpenAPI
+
 `@kubb/plugin-redoc` generates a ReDoc API reference page from your OpenAPI specification. The output is a standalone HTML file you can host without a build step or server.
-
-## Features
-
-- Produces a self-contained HTML file with the ReDoc three-panel layout
-- Supports theming and branding via ReDoc configuration options
-- Works with any valid OpenAPI 3.0 or 3.1 specification
 
 ## Installation
 
@@ -45,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/redoc) for configuration o
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -54,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-swr</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/swr" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/swr" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/plugins/issues/" target="_blank">Report Bug</a>
@@ -21,14 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-swr
+
+### Generate SWR hooks from OpenAPI
+
 `@kubb/plugin-swr` generates SWR hooks from your OpenAPI specification. Each operation becomes a typed `useSWR` or `useSWRMutation` hook.
-
-## Features
-
-- Generates `useSWR` and `useSWRMutation` hooks
-- Infers request, response, and error types from the spec
-- Groups output files by tag, operation, or a custom strategy
-- Works with `@kubb/plugin-ts`, `@kubb/plugin-zod`, and `@kubb/plugin-client`
 
 ## Installation
 
@@ -44,9 +40,21 @@ npm install @kubb/plugin-swr
 
 See the [full documentation](https://kubb.dev/plugins/swr) for configuration options and examples.
 
+## Supporting Kubb
+
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
+
+- [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+
+<p align="center">
+  <a href="https://github.com/sponsors/stijnvanhulle">
+    <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
+  </a>
+</p>
+
 ## License
 
-Made with ♥ published under [MIT](LICENSE).
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-ts</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/typescript" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/ts" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,14 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-ts
+
+### Generate TypeScript types from OpenAPI
+
 `@kubb/plugin-ts` generates TypeScript types from your OpenAPI specification. It produces interfaces, enums, union types, and string literals that other Kubb plugins import and build on.
-
-## Features
-
-- Generates interfaces, enums, union types, and string literals from OpenAPI schemas
-- Other plugins — `@kubb/plugin-client`, `@kubb/plugin-zod`, and the query plugins — import from its output
-- Supports strict typing mode for required vs optional fields
-- Controls output organization by tag, operation, or a custom grouping
 
 ## Installation
 
@@ -46,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/ts) for configuration opti
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -55,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-vue-query</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/vue-query" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/vue-query" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,14 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-vue-query
+
+### Generate Vue Query composables from OpenAPI
+
 `@kubb/plugin-vue-query` generates TanStack Query composables from your OpenAPI specification. Each operation becomes a typed `useQuery`, `useMutation`, or `useInfiniteQuery` composable for Vue 3.
-
-## Features
-
-- Generates `useQuery`, `useMutation`, `useInfiniteQuery`, and `queryOptions` composables
-- Infers request, response, and error types from the spec
-- Uses Vue 3 Composition API types, including `MaybeRef` and `MaybeRefOrGetter`
-- Works with `@kubb/plugin-ts`, `@kubb/plugin-zod`, and `@kubb/plugin-client`
 
 ## Installation
 
@@ -46,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/vue-query) for configurati
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -55,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -1,7 +1,6 @@
 <div align="center">
-  <h1>@kubb/plugin-zod</h1>
   <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
-    <img width="180" src="https://raw.githubusercontent.com/kubb-labs/kubb/main/assets/logo.png" alt="Kubb logo">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
 [![npm version][npm-version-src]][npm-version-href]
@@ -11,8 +10,6 @@
 [![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
-<a href="https://codesandbox.io/s/github/kubb-labs/plugins/tree/main/examples/zod" target="_blank">View Demo</a>
-<span> · </span>
 <a href="https://kubb.dev/plugins/zod" target="_blank">Documentation</a>
 <span> · </span>
 <a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
@@ -21,13 +18,13 @@
 </h4>
 </div>
 
+<br />
+
+# @kubb/plugin-zod
+
+### Generate Zod schemas from OpenAPI
+
 `@kubb/plugin-zod` generates Zod validation schemas from your OpenAPI specification. Each schema becomes a Zod object you can use to parse and validate data at runtime.
-
-## Features
-
-- Generates one Zod schema per OpenAPI schema
-- Supports both `.parse()` for strict validation and `.safeParse()` for error handling
-- Derives schemas from the same OpenAPI source as `@kubb/plugin-ts`, so types stay in sync
 
 ## Installation
 
@@ -45,7 +42,7 @@ See the [full documentation](https://kubb.dev/plugins/zod) for configuration opt
 
 ## Supporting Kubb
 
-Kubb is an MIT-licensed open source project with its ongoing development made possible entirely by the support of Sponsors. If you would like to become a sponsor, please consider:
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
 
@@ -54,6 +51,10 @@ Kubb is an MIT-licensed open source project with its ongoing development made po
     <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
   </a>
 </p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
 
 <!-- Badges -->
 


### PR DESCRIPTION
## Summary

Standardizes every plugin readme to follow the structure of `kubb-labs/kubb`'s `packages/kubb/README.md`, while keeping each one minimal.

For each plugin (`plugin-client`, `plugin-cypress`, `plugin-faker`, `plugin-mcp`, `plugin-msw`, `plugin-react-query`, `plugin-redoc`, `plugin-swr`, `plugin-ts`, `plugin-vue-query`, `plugin-zod`):

- The `og.png` banner now sits on top of the header, with the package title placed **below** the header block, followed by a short `###` tagline and the package description.
- Dropped the per-package **Features** sections (no features / star history, per the reference layout).
- Footer trimmed to a minimal **Supporting Kubb** + **License** block, plus the existing badge definitions.

https://claude.ai/code/session_015rgyZXqRCMraAtCJYLPJwg

---
_Generated by [Claude Code](https://claude.ai/code/session_015rgyZXqRCMraAtCJYLPJwg)_