### PR TITLE
Add missing Kubb core packages to workspace catalog

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,8 +14,12 @@ allowBuilds:
 catalog:
   '@kubb/adapter-oas': 5.0.0-beta.33
   '@kubb/agent': 5.0.0-beta.33
+  '@kubb/ast': 5.0.0-beta.33
+  '@kubb/cli': 5.0.0-beta.33
   '@kubb/core': 5.0.0-beta.33
+  '@kubb/mcp': 5.0.0-beta.33
   '@kubb/middleware-barrel': 5.0.0-beta.33
+  '@kubb/parser-md': 5.0.0-beta.33
   '@kubb/parser-ts': 5.0.0-beta.33
   '@kubb/renderer-jsx': 5.0.0-beta.33
   '@size-limit/file': ^12.1.0


### PR DESCRIPTION
## Summary

Align the plugins repository's `pnpm-workspace.yaml` catalog with all Kubb core packages. This adds catalog entries for packages that are now part of the Kubb monorepo.

## Changes

Added 4 missing Kubb core packages to the catalog, all at **5.0.0-beta.33** (n-1 versioning strategy):
- `@kubb/ast`: 5.0.0-beta.33
- `@kubb/cli`: 5.0.0-beta.33
- `@kubb/mcp`: 5.0.0-beta.33
- `@kubb/parser-md`: 5.0.0-beta.33

## Validation

- ✅ `pnpm install` runs successfully
- ✅ Lockfile passes supply-chain policies
- ✅ All dependencies resolve correctly
- ✅ No version conflicts detected

## Next Steps

Consider creating a changeset to bump plugin versions for the next release if these packages will be actively used by plugins.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbJfipbRdJ5tmXP3seTUqD)_