### PR TITLE
ci: fix staged release publish command for changesets/action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,12 +64,14 @@ jobs:
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         if: ${{ github.event.inputs.tag == '' }}
         with:
-          # `changeset tag` prints the same `New tag:` lines as changeset
-          # publish and creates the local git tags. The action parses those
-          # lines, pushes the tags, and creates a GitHub Release per package
-          # with the CHANGELOG section as the body (changeset's own logic).
-          # `stage publish` only stages on npm, so it has to run too.
-          publish: pnpm release:stage && pnpm exec changeset tag && echo "staged=true" >> "$GITHUB_OUTPUT"
+          # `release:stage:ci` chains three steps: `release:stage` stages every
+          # package on npm (no publish to `latest`), `changeset tag` creates the
+          # local git tags and prints the `New tag:` lines the action parses to
+          # push tags and create a GitHub Release per package, and the final echo
+          # records that staging ran. It must be a single script: the action
+          # splits `publish` on whitespace and spawns it directly (no shell), so
+          # `&&` and `>>` only work when wrapped in a script pnpm runs via a shell.
+          publish: pnpm release:stage:ci
           commit: 'ci(changesets): version packages'
           setupGitUser: false
         env:

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "release": "changeset publish",
     "release:canary": "changeset publish --no-git-tag",
     "release:stage": "turbo run release:stage --filter=./packages/* --concurrency=1 --",
+    "release:stage:ci": "pnpm release:stage && pnpm exec changeset tag && echo \"staged=true\" >> \"${GITHUB_OUTPUT:-/dev/null}\"",
     "start": "turbo run start --filter=./packages/*",
     "test": "vitest run --config ./configs/vitest.config.ts",
     "test:bench": "vitest bench --config ./configs/vitest.bench.config.ts",


### PR DESCRIPTION
## Problem

The release workflow failed with:

```
$ pnpm stage publish --no-git-check && pnpm exec changeset tag && echo "staged=true" >> "$GITHUB_OUTPUT"
[ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND] No package.json (or package.yaml, or package.json5) was found in "&&".
```

`pnpm stage publish` itself is valid (pnpm 11.5 staged publishing). The real bug is the **`&&` chaining in the `publish:` input of `changesets/action`**.

`changesets/action` splits the `publish` string on whitespace and spawns the first token directly via `@actions/exec` — **it does not run through a shell**. So `&&`, `>>`, and `$GITHUB_OUTPUT` were passed as literal arguments. They flowed through `pnpm release:stage` → turbo's `--` passthrough → each package's `pnpm stage publish`, which then treated `&&` as a workspace path and errored.

## Fix

- Add a single root script `release:stage:ci` that performs the full pipeline (`release:stage` → `changeset tag` → write `staged=true`). pnpm runs npm scripts through a real shell, so `&&` / `>>` work as intended.
- Point the workflow `publish:` at `pnpm release:stage:ci` (two tokens, so the action's whitespace split keeps it intact).
- Guard the `GITHUB_OUTPUT` redirect with `${GITHUB_OUTPUT:-/dev/null}` so the script is safe to run locally.

`changeset tag` still prints its `New tag:` lines to stdout, which the action parses to push tags and create the per-package GitHub Releases.

https://claude.ai/code/session_017AJnkxC2zDyrjvgJcSSXkU

---
_Generated by [Claude Code](https://claude.ai/code/session_017AJnkxC2zDyrjvgJcSSXkU)_