### PR TITLE
ci: use shared reusable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
         description: 'Release mode'
         type: choice
         options: [staged, publish]
-        default: staged
+        default: publish
   push:
     branches: ['main', 'alpha', 'beta', 'rc']
     paths:
@@ -29,8 +29,10 @@ jobs:
       issues: write
     uses: kubb-labs/config/.github/workflows/release.yml@main
     with:
-      mode: ${{ inputs.mode || 'staged' }}
+      # Beta phase: publish to the npm `beta` dist-tag instead of `latest`.
+      mode: ${{ inputs.mode || 'publish' }}
       owner: 'kubb-labs'
+      tag: beta
       test: 'pnpm run test --coverage'
       codecov: true
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
         type: choice
         options: [staged, publish]
         default: publish
+      dry-run:
+        description: 'Validate without publishing to npm'
+        type: boolean
+        default: false
   push:
     branches: ['main', 'alpha', 'beta', 'rc']
     paths:
@@ -33,6 +37,7 @@ jobs:
       mode: ${{ inputs.mode || 'publish' }}
       owner: 'kubb-labs'
       tag: beta
+      dry-run: ${{ inputs.dry-run || false }}
       publish: 'pnpm release'
       stage: 'pnpm release:stage:ci'
       build: 'pnpm run build'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       mode: ${{ inputs.mode || 'publish' }}
       owner: 'kubb-labs'
       tag: beta
+      publish: 'pnpm release'
+      stage: 'pnpm release:stage:ci'
+      build: 'pnpm run build'
       test: 'pnpm run test --coverage'
       codecov: true
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     with:
       mode: ${{ inputs.mode || 'staged' }}
       owner: 'kubb-labs'
-      test-command: 'pnpm run test --coverage'
+      test: 'pnpm run test --coverage'
       codecov: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,17 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: 'Optional: Custom tag for canary release'
-        required: false
-        type: string
+      mode:
+        description: 'Release mode'
+        type: choice
+        options: [staged, publish]
+        default: staged
   push:
     branches: ['main', 'alpha', 'beta', 'rc']
     paths:
       - '.changeset/**'
       - 'packages/**'
+
 permissions: {}
 
 concurrency:
@@ -19,76 +21,17 @@ concurrency:
 
 jobs:
   release:
-    name: Release
-    if: github.repository_owner == 'kubb-labs'
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
     permissions:
-      actions: write
       contents: write
       id-token: write
       packages: write
       pull-requests: write
       issues: write
-    steps:
-      - name: Check out code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
-        with:
-          node-version: '22'
-          cache: 'false'
-
-      - name: Reinstall dependencies (release hardening)
-        # Defense-in-depth: re-install so the release build does not implicitly
-        # trust a pnpm store restored from cache by the composite Setup Tools
-        # step. Lockfile integrity hashes still gate content.
-        run: pnpm install --frozen-lockfile --force
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Test
-        run: pnpm run test --coverage
-
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Stage publish
-        id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
-        if: ${{ github.event.inputs.tag == '' }}
-        with:
-          # `release:stage:ci` chains three steps: `release:stage` stages every
-          # package on npm (no publish to `latest`), `changeset tag` creates the
-          # local git tags and prints the `New tag:` lines the action parses to
-          # push tags and create a GitHub Release per package, and the final echo
-          # records that staging ran. It must be a single script: the action
-          # splits `publish` on whitespace and spawns it directly (no shell), so
-          # `&&` and `>>` only work when wrapped in a script pnpm runs via a shell.
-          publish: pnpm release:stage:ci
-          commit: 'ci(changesets): version packages'
-          setupGitUser: false
-        env:
-          NPM_CONFIG_PROVENANCE: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish ${{ inputs.tag || 'canary' }}
-        id: canary
-        if: steps.changesets.outputs.staged != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          RELEASE_TAG: ${{ inputs.tag || 'canary' }}
-        # Canaries auto-publish straight to npm under their dist-tag via OIDC,
-        # no stage + 2FA approval. They never land on `latest`, so the staging
-        # gate isn't needed and a canary you'd have to approve by hand is useless.
-        run: |
-          git checkout main
-          pnpm version:canary
-          pnpm release:canary --tag "$RELEASE_TAG"
+    uses: kubb-labs/config/.github/workflows/release.yml@main
+    with:
+      mode: ${{ inputs.mode || 'staged' }}
+      owner: 'kubb-labs'
+      test-command: 'pnpm run test --coverage'
+      codecov: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/examples/typescript/src/gen/models.ts
+++ b/examples/typescript/src/gen/models.ts
@@ -304,9 +304,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen10/models/Pet.ts
+++ b/examples/typescript/src/gen10/models/Pet.ts
@@ -39,9 +39,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
+++ b/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
@@ -304,9 +304,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
+++ b/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
@@ -304,9 +304,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen2/modelsConst.ts
+++ b/examples/typescript/src/gen2/modelsConst.ts
@@ -304,9 +304,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen3/modelsPascalConst.ts
+++ b/examples/typescript/src/gen3/modelsPascalConst.ts
@@ -304,9 +304,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen4/modelsConstEnum.ts
+++ b/examples/typescript/src/gen4/modelsConstEnum.ts
@@ -294,9 +294,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen5/modelsLiteral.ts
+++ b/examples/typescript/src/gen5/modelsLiteral.ts
@@ -277,9 +277,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen6/ts/models/Pet.ts
+++ b/examples/typescript/src/gen6/ts/models/Pet.ts
@@ -46,9 +46,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen7/modelsInlineLiteral.ts
+++ b/examples/typescript/src/gen7/modelsInlineLiteral.ts
@@ -280,9 +280,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array

--- a/examples/typescript/src/gen8/modelsOptionalUndefined.ts
+++ b/examples/typescript/src/gen8/modelsOptionalUndefined.ts
@@ -280,9 +280,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category: Category | undefined
   /**
    * @type array

--- a/examples/typescript/src/gen9/modelsOptionalBoth.ts
+++ b/examples/typescript/src/gen9/modelsOptionalBoth.ts
@@ -280,9 +280,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category | undefined
   /**
    * @type array

--- a/examples/typescript/src/legacy/models.ts
+++ b/examples/typescript/src/legacy/models.ts
@@ -294,9 +294,6 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
   /**
    * @type array


### PR DESCRIPTION
## What

Replace the inlined release job with a call to the shared reusable workflow `kubb-labs/config/.github/workflows/release.yml`, passing `test-command: pnpm run test --coverage` and `codecov: true` so coverage uploads are preserved. The `workflow_dispatch` gains a `mode` choice (`staged`/`publish`) that maps onto the shared publish/staged enum, replacing the previous canary path.

## Dependency

References the shared workflow at `@main`, so it only runs green after **kubb-labs/config#14** merges.

https://claude.ai/code/session_01Ng1TJ3j2L6Wr7g4Wh7B4kT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ng1TJ3j2L6Wr7g4Wh7B4kT)_