### PR TITLE
chore: downgrade plugins to n-1 kubb core version

### DIFF
--- a/packages/plugin-client/package.json
+++ b/packages/plugin-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-client",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate type-safe HTTP clients from your OpenAPI specification. Supports Axios, Fetch, and custom client adapters with full TypeScript inference and zero boilerplate.",
   "keywords": [
     "api-client",

--- a/packages/plugin-cypress/package.json
+++ b/packages/plugin-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-cypress",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate Cypress request commands and e2e test fixtures from your OpenAPI specification, enabling automated API testing with zero manual setup.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-faker/package.json
+++ b/packages/plugin-faker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-faker",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate Faker.js mock data factories from your OpenAPI schemas. Produces realistic seed data, test fixtures, and datasets for development and testing.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-mcp",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate Model Context Protocol (MCP) tool definitions from your OpenAPI specification. Expose your REST APIs as AI-callable tools for LLMs, Claude, ChatGPT, and other AI assistants.",
   "keywords": [
     "ai",

--- a/packages/plugin-msw/package.json
+++ b/packages/plugin-msw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-msw",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate Mock Service Worker (MSW) request handlers from your OpenAPI specification. Intercept HTTP requests in the browser or Node.js for seamless frontend development and testing.",
   "keywords": [
     "api-mocking",

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-react-query",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate type-safe TanStack Query (React Query) hooks from your OpenAPI specification. Covers useQuery, useMutation, useInfiniteQuery, and queryOptions with full TypeScript support.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-redoc/package.json
+++ b/packages/plugin-redoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-redoc",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate a beautiful, interactive ReDoc API reference page from your OpenAPI specification. Produces a standalone HTML file with a responsive, developer-friendly UI.",
   "keywords": [
     "api-docs",

--- a/packages/plugin-swr/package.json
+++ b/packages/plugin-swr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-swr",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate type-safe SWR hooks from your OpenAPI specification. Covers useSWR and useSWRMutation with full TypeScript support.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-ts/package.json
+++ b/packages/plugin-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-ts",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate TypeScript types, interfaces, and enums from your OpenAPI specification. The foundational plugin that powers type safety across the entire Kubb ecosystem.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-vue-query/package.json
+++ b/packages/plugin-vue-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-vue-query",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate type-safe TanStack Query (Vue Query) composables from your OpenAPI specification. Covers useQuery, useMutation, useInfiniteQuery, and queryOptions with Vue 3 Composition API support.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-zod/package.json
+++ b/packages/plugin-zod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-zod",
-  "version": "5.0.0-beta.35",
+  "version": "5.0.0-beta.34",
   "description": "Generate Zod validation schemas from your OpenAPI specification for runtime data parsing and type safety. Pairs perfectly with @kubb/plugin-ts for end-to-end type coverage.",
   "keywords": [
     "code-generation",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,18 +12,18 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.35
-  '@kubb/agent': 5.0.0-beta.35
-  '@kubb/core': 5.0.0-beta.35
-  '@kubb/middleware-barrel': 5.0.0-beta.35
-  '@kubb/parser-ts': 5.0.0-beta.35
-  '@kubb/renderer-jsx': 5.0.0-beta.35
+  '@kubb/adapter-oas': 5.0.0-beta.34
+  '@kubb/agent': 5.0.0-beta.34
+  '@kubb/core': 5.0.0-beta.34
+  '@kubb/middleware-barrel': 5.0.0-beta.34
+  '@kubb/parser-ts': 5.0.0-beta.34
+  '@kubb/renderer-jsx': 5.0.0-beta.34
   '@size-limit/file': ^12.1.0
   '@types/node': ^22.19.19
   '@types/react': ^19.2.15
   '@vitest/coverage-v8': ^4.1.7
   '@vitest/ui': ^4.1.7
-  kubb: 5.0.0-beta.35
+  kubb: 5.0.0-beta.34
   oxfmt: ^0.47.0
   oxlint: ^1.67.0
   prettier: ^3.8.3
@@ -31,7 +31,7 @@ catalog:
   'size-limit': ^12.1.0
   tsdown: ^0.22.1
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.35
+  unplugin-kubb: 5.0.0-beta.34
   vitest: ^4.1.7
 
 minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age


### PR DESCRIPTION
## Summary

Downgrade all plugins from `5.0.0-beta.35` to `5.0.0-beta.34` (n-1) to prepare for sync with Kubb's next release.

## Changes

- **11 plugin packages** downgraded: plugin-client, plugin-cypress, plugin-faker, plugin-mcp, plugin-msw, plugin-react-query, plugin-redoc, plugin-swr, plugin-ts, plugin-vue-query, plugin-zod
- **pnpm-workspace.yaml** catalog updated with n-1 versions for all Kubb core packages:
  - `@kubb/adapter-oas`, `@kubb/agent`, `@kubb/core`, `@kubb/middleware-barrel`, `@kubb/parser-ts`, `@kubb/renderer-jsx`, `kubb`, `unplugin-kubb`
- **Lock file** updated via `pnpm install`

## Why This Pattern?

By keeping plugins at n-1 version, the next changeset will synchronize all packages to the same release version, ensuring version consistency across the ecosystem.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSeKgFbzgHehK652KhLvhb)_