### PR TITLE
fix(plugin-ts,plugin-zod): honor user-provided group.name callback

### DIFF
--- a/.changeset/fix-group-name-callback-ts-zod.md
+++ b/.changeset/fix-group-name-callback-ts-zod.md
@@ -1,0 +1,6 @@
+---
+"@kubb/plugin-ts": patch
+"@kubb/plugin-zod": patch
+---
+
+Honor a user-provided `group.name` callback in `pluginTs` and `pluginZod`. Both plugins ignored the callback and always fell back to the default `${camelCase(tag)}Controller` naming, unlike every other plugin. The `honorName` flag on the shared `createGroupConfig` helper that caused this discrepancy has been removed so a user-provided `group.name` always wins.

--- a/internals/shared/src/group.test.ts
+++ b/internals/shared/src/group.test.ts
@@ -23,13 +23,10 @@ describe('createGroupConfig', () => {
     expect(requestsName({ group: 'pet store' })).toBe('petStoreRequests')
   })
 
-  it('ignores a user-provided name unless honorName is set', () => {
+  it('honors a user-provided name over the default namer', () => {
     const custom = (): string => 'Custom'
 
-    const ignored = createGroupConfig({ type: 'tag', name: custom }, { suffix: 'Controller' })
-    expect(ignored?.name).not.toBe(custom)
-
-    const honored = createGroupConfig({ type: 'tag', name: custom }, { suffix: 'Controller', honorName: true })
+    const honored = createGroupConfig({ type: 'tag', name: custom }, { suffix: 'Controller' })
     expect(honored?.name).toBe(custom)
   })
 })

--- a/internals/shared/src/group.ts
+++ b/internals/shared/src/group.ts
@@ -8,20 +8,20 @@ import type { Group } from '@kubb/core'
  * - `path` groups use the second path segment (`/pet/findByStatus` → `pet`).
  * - other groups use `${camelCase(group)}${suffix}` (e.g. `petController`).
  *
- * Returns `null` when grouping is disabled, matching the per-plugin convention.
+ * A user-provided `group.name` always wins over the default namer, so callers stay in
+ * control of their output folders. Returns `null` when grouping is disabled, matching the
+ * per-plugin convention.
  *
  * @param group - The user-supplied group option, or `undefined` to disable grouping.
  * @param options.suffix - Appended to non-`path` group names, e.g. `'Controller'` or `'Requests'`.
- * @param options.honorName - When `true`, a user-provided `group.name` overrides the default namer.
  *
  * @example
  * ```ts
- * createGroupConfig(group, { suffix: 'Controller' })                  // plugin-ts, plugin-zod
- * createGroupConfig(group, { suffix: 'Controller', honorName: true }) // plugin-faker, plugin-client, …
- * createGroupConfig(group, { suffix: 'Requests', honorName: true })   // plugin-cypress, plugin-mcp
+ * createGroupConfig(group, { suffix: 'Controller' }) // plugin-ts, plugin-client, …
+ * createGroupConfig(group, { suffix: 'Requests' })   // plugin-cypress, plugin-mcp
  * ```
  */
-export function createGroupConfig(group: Group | undefined, options: { suffix: string; honorName?: boolean }): Group | null {
+export function createGroupConfig(group: Group | undefined, options: { suffix: string }): Group | null {
   if (!group) {
     return null
   }
@@ -36,6 +36,6 @@ export function createGroupConfig(group: Group | undefined, options: { suffix: s
 
   return {
     ...group,
-    name: options.honorName && group.name ? group.name : defaultName,
+    name: group.name ? group.name : defaultName,
   } satisfies Group
 }

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -80,7 +80,7 @@ export const pluginClient = definePlugin<PluginClient>((options) => {
       operations ? operationsGenerator : null,
     ].filter((x): x is NonNullable<typeof x> => Boolean(x))
 
-  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller' })
 
   return {
     name: pluginClientName,

--- a/packages/plugin-cypress/src/plugin.ts
+++ b/packages/plugin-cypress/src/plugin.ts
@@ -51,7 +51,7 @@ export const pluginCypress = definePlugin<PluginCypress>((options) => {
     generators: userGenerators = [],
   } = options
 
-  const groupConfig = createGroupConfig(group, { suffix: 'Requests', honorName: true })
+  const groupConfig = createGroupConfig(group, { suffix: 'Requests' })
 
   return {
     name: pluginCypressName,

--- a/packages/plugin-faker/src/plugin.ts
+++ b/packages/plugin-faker/src/plugin.ts
@@ -54,7 +54,7 @@ export const pluginFaker = definePlugin<PluginFaker>((options) => {
     transformer: userTransformer,
   } = options
 
-  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller' })
 
   return {
     name: pluginFakerName,

--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -64,7 +64,7 @@ export const pluginMcp = definePlugin<PluginMcp>((options) => {
   const clientName = client?.client ?? 'axios'
   const clientImportPath = client?.importPath ?? (!client?.bundle ? `@kubb/plugin-client/clients/${clientName}` : undefined)
 
-  const groupConfig = createGroupConfig(group, { suffix: 'Requests', honorName: true })
+  const groupConfig = createGroupConfig(group, { suffix: 'Requests' })
 
   return {
     name: pluginMcpName,

--- a/packages/plugin-msw/src/plugin.ts
+++ b/packages/plugin-msw/src/plugin.ts
@@ -53,7 +53,7 @@ export const pluginMsw = definePlugin<PluginMsw>((options) => {
     generators: userGenerators = [],
   } = options
 
-  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller' })
 
   return {
     name: pluginMswName,

--- a/packages/plugin-react-query/src/plugin.ts
+++ b/packages/plugin-react-query/src/plugin.ts
@@ -90,7 +90,7 @@ export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
       customHookOptionsFileGenerator,
     ].filter((generator): generator is NonNullable<typeof generator> => Boolean(generator))
 
-  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller' })
 
   return {
     name: pluginReactQueryName,

--- a/packages/plugin-vue-query/src/plugin.ts
+++ b/packages/plugin-vue-query/src/plugin.ts
@@ -72,7 +72,7 @@ export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
     options.generators ??
     [queryGenerator, infiniteQueryGenerator, mutationGenerator].filter((generator): generator is NonNullable<typeof generator> => Boolean(generator))
 
-  const groupConfig = createGroupConfig(group, { suffix: 'Controller', honorName: true })
+  const groupConfig = createGroupConfig(group, { suffix: 'Controller' })
 
   return {
     name: pluginVueQueryName,


### PR DESCRIPTION
## Problem

Fixes kubb-labs/kubb#3430.

A user-provided `group.name` callback was silently ignored by `pluginTs` and `pluginZod`. Instead of honoring the callback, both plugins always fell back to the default `${camelCase(tag)}Controller` naming, so output landed in e.g. `healthController/` instead of the expected `healthTest/`.

## Root cause

The shared `createGroupConfig` helper in `@internals/shared` exposed a `honorName` flag:

```ts
name: options.honorName && group.name ? group.name : defaultName
```

`pluginClient` and every other plugin passed `honorName: true`, but `pluginTs` and `pluginZod` did not, so their user-provided `group.name` was always overridden. The flag was a footgun: there's no legitimate reason to ignore an explicit user name callback.

## Fix

Remove the `honorName` option entirely and always honor a user-provided `group.name`. This makes grouping behave consistently across all plugins and prevents the same regression from recurring. The default naming (when no `group.name` is supplied) is unchanged, so existing generated output is unaffected.

- `internals/shared/src/group.ts` — drop `honorName`, always prefer `group.name`
- `internals/shared/src/group.test.ts` — assert the user name is honored
- All plugin call sites simplified to `createGroupConfig(group, { suffix })`

## Verification

- `internals/shared/src/group.test.ts` passes (4/4)
- `tsc --noEmit` clean for `@internals/shared`
- Added a changeset bumping `@kubb/plugin-ts` and `@kubb/plugin-zod` (patch)

https://claude.ai/code/session_019PYVTYN7mqZBrk8uS7a7Kk

---
_Generated by [Claude Code](https://claude.ai/code/session_019PYVTYN7mqZBrk8uS7a7Kk)_