### PR TITLE
ci: release workflow — version PR fix, run changeset CLI directly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - '.changeset/**'
       - 'packages/**'
+      - '.github/workflows/release.yml'
 
 permissions: {}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Create Version Packages PR
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
-          version: pnpm version
+          version: pnpm run version
           commit: 'ci(changesets): version packages'
           title: 'ci(changesets): version packages'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Create Version Packages PR
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1
         with:
-          version: pnpm run version
+          version: pnpm exec changeset version
           commit: 'ci(changesets): version packages'
           title: 'ci(changesets): version packages'
         env:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "lint:spell": "cspell \"**/*.{ts,md}\" --config ./cspell.json --no-progress",
     "postgenerate": "pnpm run lint:fix && pnpm run format",
     "release": "changeset publish",
-    "release:canary": "changeset publish --no-git-tag",
     "release:stage": "turbo run release:stage --filter=./packages/* --continue --concurrency=1 --",
     "release:stage:ci": "pnpm release:stage && pnpm exec changeset tag && echo \"staged=true\" >> \"${GITHUB_OUTPUT:-/dev/null}\"",
     "start": "turbo run start --filter=./packages/*",
@@ -41,9 +40,7 @@
     "test:watch": "vitest --config ./configs/vitest.config.ts",
     "typecheck": "turbo run typecheck --continue --filter='./packages/*' --filter='./tests/**'",
     "typecheck:examples": "turbo run typecheck --continue --filter='./examples/*'",
-    "upgrade": "npx taze -r -w --exclude pnpm --maturity-period 3",
-    "version": "changeset version",
-    "version:canary": "changeset version --snapshot canary"
+    "upgrade": "npx taze -r -w --exclude pnpm --maturity-period 3"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.6.0",


### PR DESCRIPTION
## Changes

**1. Open the Version Packages PR reliably.** The `version` job now runs the changeset CLI directly (`version: pnpm exec changeset version`) instead of the `package.json` `version` script. `pnpm version` is a reserved built-in (it just prints the version table and never ran `changeset version`), so no Version Packages PR — e.g. for `fix-group-name-callback-ts-zod` — was produced. `pnpm exec` ensures the local `changeset` binary resolves on PATH.

**2. Re-trigger on workflow edits.** Added `.github/workflows/release.yml` to `on.push.paths` so editing the release workflow re-runs it (closes the trigger gap). Merging this PR triggers the workflow and opens the pending Version Packages PR.

**3. Dropped unused npm scripts.** Removed `version`, `version:canary`, and `release:canary` from `package.json`; the workflow calls the changeset CLI directly. (`release`, `release:stage`, `release:stage:ci` kept.)

> ⚠️ **`kubb-labs/config` follow-up:** if the reusable release workflow references `pnpm version:canary` / `pnpm release:canary`, update it to call the changeset CLI directly — those scripts were removed here. Canary publishing for this repo lives in the reusable workflow.

> If a triggered run goes green but no PR appears, enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**.
