### PR TITLE
chore: downgrade kubb core packages to n-1 (5.0.0-beta.35)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,18 +12,18 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.36
-  '@kubb/agent': 5.0.0-beta.36
-  '@kubb/core': 5.0.0-beta.36
-  '@kubb/middleware-barrel': 5.0.0-beta.36
-  '@kubb/parser-ts': 5.0.0-beta.36
-  '@kubb/renderer-jsx': 5.0.0-beta.36
+  '@kubb/adapter-oas': 5.0.0-beta.35
+  '@kubb/agent': 5.0.0-beta.35
+  '@kubb/core': 5.0.0-beta.35
+  '@kubb/middleware-barrel': 5.0.0-beta.35
+  '@kubb/parser-ts': 5.0.0-beta.35
+  '@kubb/renderer-jsx': 5.0.0-beta.35
   '@size-limit/file': ^12.1.0
   '@types/node': ^22.19.19
   '@types/react': ^19.2.16
   '@vitest/coverage-v8': ^4.1.7
   '@vitest/ui': ^4.1.7
-  kubb: 5.0.0-beta.36
+  kubb: 5.0.0-beta.35
   oxfmt: ^0.47.0
   oxlint: ^1.67.0
   prettier: ^3.8.3
@@ -31,7 +31,7 @@ catalog:
   'size-limit': ^12.1.0
   tsdown: ^0.22.1
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.36
+  unplugin-kubb: 5.0.0-beta.35
   vitest: ^4.1.7
 
 minimumReleaseAge: 4320 # 72 hours, matches .npmrc min-package-age


### PR DESCRIPTION
## Summary

Updates all kubb core packages from `5.0.0-beta.36` to `5.0.0-beta.35` to prepare for a synchronized release across all packages. This allows a new changeset to bump all packages to the latest version together.

## Changes

- **pnpm-workspace.yaml**: Downgraded all Kubb core packages to 5.0.0-beta.35:
  - `@kubb/adapter-oas`
  - `@kubb/agent`
  - `@kubb/core`
  - `@kubb/middleware-barrel`
  - `@kubb/parser-ts`
  - `@kubb/renderer-jsx`
  - `kubb`
  - `unplugin-kubb`

- **pnpm-lock.yaml**: Updated with new dependencies (1027 lines changed: 573 insertions, 454 deletions)

## Next Steps

1. **Review**: Verify the version downgrade looks correct
2. **Create Changeset**: Use `pnpm changeset` to add a changeset that will bump all packages to the next version
3. **Release**: The changeset will ensure all packages are released together at the same version

The lock file will be automatically regenerated when you run `pnpm i` locally or when the changeset release runs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLieSg6gAbqMN1NnBzQb87)_