### PR TITLE
docs: replace README badges with shieldcn.dev badge group

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Want to contribute to an existing plugin or add a new one, official or community
 
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
 [coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/kubb-labs/plugins

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
+[![Coverage][coverage-src]][coverage-href]
 
   <h4>
     <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -111,3 +112,5 @@ Want to contribute to an existing plugin or add a new one, official or community
 [stars-href]: https://github.com/kubb-labs/plugins
 [license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
+[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[coverage-href]: https://app.codecov.io/gh/kubb-labs/plugins

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Want to contribute to an existing plugin or add a new one, official or community
 
 <!-- Badges -->
 
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/plugins.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/kubb-labs/plugins

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
 
   <h4>
     <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -112,5 +111,3 @@ Want to contribute to an existing plugin or add a new one, official or community
 [stars-href]: https://github.com/kubb-labs/plugins
 [license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://github.com/kubb-labs/plugins" target="_blank">
-  <img alt="kubb-labs/plugins badges" src="https://shieldcn.dev/group/github/stars/kubb-labs/plugins+badge/license-MIT-blue+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
   <h4>
     <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -106,3 +106,11 @@ Want to contribute to an existing plugin or add a new one, official or community
 
 [MIT](./LICENSE) © [Stijn Van Hulle](https://github.com/stijnvanhulle)
 
+<!-- Badges -->
+
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/plugins
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Want to contribute to an existing plugin or add a new one, official or community
 
 <!-- Badges -->
 
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/plugins.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/kubb-labs/plugins

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://github.com/kubb-labs/plugins" target="_blank">
-  <img alt="kubb-labs/plugins badges" src="https://shieldcn.dev/group/github/stars/kubb-labs/plugins+github/license/kubb-labs/plugins+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="kubb-labs/plugins badges" src="https://shieldcn.dev/group/github/stars/kubb-labs/plugins+badge/license-MIT-blue+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
   <h4>

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Want to contribute to an existing plugin or add a new one, official or community
 
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/badge/license-MIT-blue.svg?variant=secondary&size=xs&theme=zinc
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
 [coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/kubb-labs/plugins

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![License][license-src]][license-href]
+<a href="https://github.com/kubb-labs/plugins" target="_blank">
+  <img alt="kubb-labs/plugins badges" src="https://shieldcn.dev/group/github/stars/kubb-labs/plugins+github/license/kubb-labs/plugins+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
   <h4>
     <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -104,5 +106,3 @@ Want to contribute to an existing plugin or add a new one, official or community
 
 [MIT](./LICENSE) © [Stijn Van Hulle](https://github.com/stijnvanhulle)
 
-[license-src]: https://img.shields.io/github/license/kubb-labs/plugins.svg
-[license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE

--- a/README.md
+++ b/README.md
@@ -27,47 +27,47 @@ Want to build your own plugin? See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Official plugins
 
-Maintained by the Kubb team. Kubb v5 OpenAPI configs use [`@kubb/adapter-oas`](https://www.npmjs.com/package/@kubb/adapter-oas) as the adapter layer.
+Maintained by the Kubb team. Kubb v5 OpenAPI configs use [`@kubb/adapter-oas`](https://npmx.dev/package/@kubb/adapter-oas) as the adapter layer.
 
 ### TypeScript
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`@kubb/plugin-ts`](./packages/plugin-ts) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-ts.svg)](https://www.npmjs.com/package/@kubb/plugin-ts) | TypeScript types and interfaces generation |
+| [`@kubb/plugin-ts`](./packages/plugin-ts) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-ts.svg)](https://npmx.dev/package/@kubb/plugin-ts) | TypeScript types and interfaces generation |
 
 ### Clients
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`@kubb/plugin-client`](./packages/plugin-client) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-client.svg)](https://www.npmjs.com/package/@kubb/plugin-client) | API client generation ([Axios](https://github.com/axios/axios), Fetch) |
+| [`@kubb/plugin-client`](./packages/plugin-client) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-client.svg)](https://npmx.dev/package/@kubb/plugin-client) | API client generation ([Axios](https://github.com/axios/axios), Fetch) |
 
 ### Zod
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`@kubb/plugin-zod`](./packages/plugin-zod) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-zod.svg)](https://www.npmjs.com/package/@kubb/plugin-zod) | [Zod](https://github.com/colinhacks/zod) schema generation for runtime validation |
+| [`@kubb/plugin-zod`](./packages/plugin-zod) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-zod.svg)](https://npmx.dev/package/@kubb/plugin-zod) | [Zod](https://github.com/colinhacks/zod) schema generation for runtime validation |
 
 ### Data fetching
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`@kubb/plugin-react-query`](./packages/plugin-react-query) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-react-query.svg)](https://www.npmjs.com/package/@kubb/plugin-react-query) | [TanStack Query](https://github.com/TanStack/query) hooks for React |
-| [`@kubb/plugin-vue-query`](./packages/plugin-vue-query) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-vue-query.svg)](https://www.npmjs.com/package/@kubb/plugin-vue-query) | [TanStack Query](https://github.com/TanStack/query) composables for Vue |
+| [`@kubb/plugin-react-query`](./packages/plugin-react-query) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-react-query.svg)](https://npmx.dev/package/@kubb/plugin-react-query) | [TanStack Query](https://github.com/TanStack/query) hooks for React |
+| [`@kubb/plugin-vue-query`](./packages/plugin-vue-query) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-vue-query.svg)](https://npmx.dev/package/@kubb/plugin-vue-query) | [TanStack Query](https://github.com/TanStack/query) composables for Vue |
 
 ### Testing and mocking
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`@kubb/plugin-faker`](./packages/plugin-faker) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-faker.svg)](https://www.npmjs.com/package/@kubb/plugin-faker) | [Faker.js](https://github.com/faker-js/faker) mock data generation |
-| [`@kubb/plugin-msw`](./packages/plugin-msw) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-msw.svg)](https://www.npmjs.com/package/@kubb/plugin-msw) | [Mock Service Worker](https://github.com/mswjs/msw) handlers |
-| [`@kubb/plugin-cypress`](./packages/plugin-cypress) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-cypress.svg)](https://www.npmjs.com/package/@kubb/plugin-cypress) | [Cypress](https://github.com/cypress-io/cypress) e2e test generation |
+| [`@kubb/plugin-faker`](./packages/plugin-faker) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-faker.svg)](https://npmx.dev/package/@kubb/plugin-faker) | [Faker.js](https://github.com/faker-js/faker) mock data generation |
+| [`@kubb/plugin-msw`](./packages/plugin-msw) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-msw.svg)](https://npmx.dev/package/@kubb/plugin-msw) | [Mock Service Worker](https://github.com/mswjs/msw) handlers |
+| [`@kubb/plugin-cypress`](./packages/plugin-cypress) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-cypress.svg)](https://npmx.dev/package/@kubb/plugin-cypress) | [Cypress](https://github.com/cypress-io/cypress) e2e test generation |
 
 ### Documentation and AI
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`@kubb/plugin-redoc`](./packages/plugin-redoc) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-redoc.svg)](https://www.npmjs.com/package/@kubb/plugin-redoc) | [ReDoc](https://github.com/Redocly/redoc) API documentation generation |
-| [`@kubb/plugin-mcp`](./packages/plugin-mcp) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-mcp.svg)](https://www.npmjs.com/package/@kubb/plugin-mcp) | Model Context Protocol tools for AI assistants |
+| [`@kubb/plugin-redoc`](./packages/plugin-redoc) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-redoc.svg)](https://npmx.dev/package/@kubb/plugin-redoc) | [ReDoc](https://github.com/Redocly/redoc) API documentation generation |
+| [`@kubb/plugin-mcp`](./packages/plugin-mcp) | [![npm version](https://img.shields.io/npm/v/@kubb/plugin-mcp.svg)](https://npmx.dev/package/@kubb/plugin-mcp) | Model Context Protocol tools for AI assistants |
 
 ## Community plugins
 

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-client
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-client
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-client
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-client
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-client
+[node-href]: https://npmx.dev/package/@kubb/plugin-client

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-client" target="_blank">
-  <img alt="@kubb/plugin-client badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-client+npm/dm/@kubb/plugin-client+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-client badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-client+npm/dm/@kubb/plugin-client+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-client+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-client
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-client

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-client.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-client
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-client.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-client
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-client

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/client" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-client
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-client

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-client
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-client

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-client
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-client
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-client.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-client

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-client" target="_blank">
-  <img alt="@kubb/plugin-client badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-client+npm/dm/@kubb/plugin-client+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-client+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/client" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-client
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-client
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-client.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-client/README.md
+++ b/packages/plugin-client/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-client" target="_blank">
+  <img alt="@kubb/plugin-client badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-client+npm/dm/@kubb/plugin-client+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/client" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-client?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-client
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-client?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-client
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-client
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-client?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-client
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-client
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-cypress" target="_blank">
-  <img alt="@kubb/plugin-cypress badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-cypress+npm/dm/@kubb/plugin-cypress+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-cypress+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/cypress" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-cypress
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-cypress
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-cypress.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-cypress
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-cypress.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-cypress
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-cypress

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-cypress" target="_blank">
-  <img alt="@kubb/plugin-cypress badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-cypress+npm/dm/@kubb/plugin-cypress+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-cypress badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-cypress+npm/dm/@kubb/plugin-cypress+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-cypress+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-cypress
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-cypress
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-cypress

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-cypress
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-cypress

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-cypress
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-cypress

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-cypress" target="_blank">
+  <img alt="@kubb/plugin-cypress badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-cypress+npm/dm/@kubb/plugin-cypress+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/cypress" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-cypress?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-cypress
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-cypress?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-cypress
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-cypress
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-cypress?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-cypress
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-cypress
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/cypress" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-cypress
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-cypress

--- a/packages/plugin-cypress/README.md
+++ b/packages/plugin-cypress/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-cypress
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-cypress
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-cypress
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-cypress
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-cypress.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-cypress
+[node-href]: https://npmx.dev/package/@kubb/plugin-cypress

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-faker
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-faker

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-faker
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-faker

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-faker" target="_blank">
-  <img alt="@kubb/plugin-faker badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-faker+npm/dm/@kubb/plugin-faker+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-faker badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-faker+npm/dm/@kubb/plugin-faker+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-faker+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-faker" target="_blank">
-  <img alt="@kubb/plugin-faker badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-faker+npm/dm/@kubb/plugin-faker+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-faker+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/faker" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-faker
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-faker
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-faker.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-faker
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-faker.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-faker
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-faker

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/faker" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-faker
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-faker

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-faker
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-faker
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-faker

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-faker
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-faker
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-faker
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-faker
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-faker.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-faker
+[node-href]: https://npmx.dev/package/@kubb/plugin-faker

--- a/packages/plugin-faker/README.md
+++ b/packages/plugin-faker/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-faker" target="_blank">
+  <img alt="@kubb/plugin-faker badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-faker+npm/dm/@kubb/plugin-faker+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/faker" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-faker?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-faker
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-faker?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-faker
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-faker
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-faker?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-faker
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-faker
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-mcp
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-mcp
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-mcp

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-mcp" target="_blank">
-  <img alt="@kubb/plugin-mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-mcp+npm/dm/@kubb/plugin-mcp+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-mcp+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/mcp" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-mcp
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-mcp
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/mcp" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-mcp

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-mcp" target="_blank">
-  <img alt="@kubb/plugin-mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-mcp+npm/dm/@kubb/plugin-mcp+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-mcp+npm/dm/@kubb/plugin-mcp+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-mcp+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-mcp
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-mcp
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-mcp
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-mcp
+[node-href]: https://npmx.dev/package/@kubb/plugin-mcp

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-mcp

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-mcp" target="_blank">
+  <img alt="@kubb/plugin-mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-mcp+npm/dm/@kubb/plugin-mcp+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/mcp" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-mcp?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-mcp
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-mcp?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-mcp
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-mcp
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-mcp?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-mcp
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-mcp
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-mcp
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-mcp
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-mcp

--- a/packages/plugin-mcp/README.md
+++ b/packages/plugin-mcp/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-mcp.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-mcp

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-msw
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-msw

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/msw" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-msw
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-msw

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-msw
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-msw
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-msw

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-msw.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-msw
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-msw.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-msw
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-msw

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-msw" target="_blank">
-  <img alt="@kubb/plugin-msw badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-msw+npm/dm/@kubb/plugin-msw+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-msw+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/msw" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-msw
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-msw
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-msw" target="_blank">
+  <img alt="@kubb/plugin-msw badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-msw+npm/dm/@kubb/plugin-msw+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/msw" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-msw?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-msw
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-msw?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-msw
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-msw
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-msw?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-msw
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-msw
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-msw
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-msw

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-msw" target="_blank">
-  <img alt="@kubb/plugin-msw badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-msw+npm/dm/@kubb/plugin-msw+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-msw badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-msw+npm/dm/@kubb/plugin-msw+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-msw+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-msw/README.md
+++ b/packages/plugin-msw/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-msw
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-msw
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-msw
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-msw
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-msw.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-msw
+[node-href]: https://npmx.dev/package/@kubb/plugin-msw

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/react-query" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-react-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-react-query

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-react-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-react-query

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-react-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-react-query
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-react-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-react-query
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-react-query

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-react-query" target="_blank">
-  <img alt="@kubb/plugin-react-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-react-query+npm/dm/@kubb/plugin-react-query+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-react-query+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/react-query" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-react-query
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-react-query
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-react-query
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-react-query
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-react-query
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-react-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-react-query
+[node-href]: https://npmx.dev/package/@kubb/plugin-react-query

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-react-query" target="_blank">
+  <img alt="@kubb/plugin-react-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-react-query+npm/dm/@kubb/plugin-react-query+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/react-query" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-react-query?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-react-query
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-react-query?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-react-query
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-react-query
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-react-query?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-react-query
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-react-query
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-react-query" target="_blank">
-  <img alt="@kubb/plugin-react-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-react-query+npm/dm/@kubb/plugin-react-query+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-react-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-react-query+npm/dm/@kubb/plugin-react-query+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-react-query+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-react-query
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-react-query
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-react-query

--- a/packages/plugin-react-query/README.md
+++ b/packages/plugin-react-query/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-react-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-react-query.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-react-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-react-query

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-redoc" target="_blank">
-  <img alt="@kubb/plugin-redoc badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-redoc+npm/dm/@kubb/plugin-redoc+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-redoc badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-redoc+npm/dm/@kubb/plugin-redoc+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-redoc+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-redoc
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-redoc

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-redoc.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-redoc
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-redoc.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-redoc
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-redoc

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-redoc" target="_blank">
-  <img alt="@kubb/plugin-redoc badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-redoc+npm/dm/@kubb/plugin-redoc+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-redoc+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/redoc" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-redoc
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-redoc
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-redoc
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-redoc
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-redoc
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-redoc
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-redoc
+[node-href]: https://npmx.dev/package/@kubb/plugin-redoc

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-redoc
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-redoc

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-redoc" target="_blank">
+  <img alt="@kubb/plugin-redoc badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-redoc+npm/dm/@kubb/plugin-redoc+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/redoc" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-redoc?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-redoc
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-redoc?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-redoc
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-redoc
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-redoc?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-redoc
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-redoc
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/redoc" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-redoc
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-redoc

--- a/packages/plugin-redoc/README.md
+++ b/packages/plugin-redoc/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-redoc
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-redoc
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-redoc.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-redoc

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-swr" target="_blank">
+  <img alt="@kubb/plugin-swr badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-swr+npm/dm/@kubb/plugin-swr+github/stars/kubb-labs/plugins+github/license/kubb-labs/plugins+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/swr" target="_blank">Documentation</a>
@@ -55,16 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-swr?style=flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-swr
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-swr?style=flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-swr
-[coverage-src]: https://qlty.sh/badges/8959bd5b-d8a3-4811-8762-3a8be3bd2c34/test_coverage.svg
-[coverage-href]: https://qlty.sh/gh/kubb-labs/projects/plugins
-[license-src]: https://img.shields.io/github/license/kubb-labs/plugins.svg?style=flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/swr" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-swr
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-swr

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-swr
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-swr
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-swr
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-swr
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-swr
+[node-href]: https://npmx.dev/package/@kubb/plugin-swr

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-swr" target="_blank">
-  <img alt="@kubb/plugin-swr badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-swr+npm/dm/@kubb/plugin-swr+github/stars/kubb-labs/plugins+github/license/kubb-labs/plugins+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-swr badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-swr+npm/dm/@kubb/plugin-swr+github/stars/kubb-labs/plugins+npm/l/@kubb/plugin-swr+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-swr.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-swr
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-swr.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-swr
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-swr

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-swr
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-swr

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-swr
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-swr
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-swr

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-swr
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/plugins
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-swr.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-swr.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-swr

--- a/packages/plugin-swr/README.md
+++ b/packages/plugin-swr/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-swr" target="_blank">
-  <img alt="@kubb/plugin-swr badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-swr+npm/dm/@kubb/plugin-swr+github/stars/kubb-labs/plugins+npm/l/@kubb/plugin-swr+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/swr" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-swr
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-swr
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/plugins.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/plugins
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-swr.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/plugins/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-ts
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-ts
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-ts

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/ts" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-ts

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-ts

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-ts" target="_blank">
+  <img alt="@kubb/plugin-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-ts+npm/dm/@kubb/plugin-ts+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/ts" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-ts?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-ts
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-ts?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-ts
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-ts
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-ts?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-ts
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-ts
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-ts" target="_blank">
-  <img alt="@kubb/plugin-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-ts+npm/dm/@kubb/plugin-ts+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-ts+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/ts" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-ts
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-ts
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-ts
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-ts
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-ts

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-ts
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-ts
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-ts
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-ts
+[node-href]: https://npmx.dev/package/@kubb/plugin-ts

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-ts

--- a/packages/plugin-ts/README.md
+++ b/packages/plugin-ts/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-ts" target="_blank">
-  <img alt="@kubb/plugin-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-ts+npm/dm/@kubb/plugin-ts+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-ts+npm/dm/@kubb/plugin-ts+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-ts+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-vue-query
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-vue-query
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-vue-query

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-vue-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-vue-query

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-vue-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-vue-query

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-vue-query" target="_blank">
+  <img alt="@kubb/plugin-vue-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-vue-query+npm/dm/@kubb/plugin-vue-query+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/vue-query" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-vue-query?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-vue-query
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-vue-query?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-vue-query
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-vue-query
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-vue-query?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-vue-query
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-vue-query
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-vue-query" target="_blank">
-  <img alt="@kubb/plugin-vue-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-vue-query+npm/dm/@kubb/plugin-vue-query+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-vue-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-vue-query+npm/dm/@kubb/plugin-vue-query+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-vue-query+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/vue-query" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-vue-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-vue-query

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-vue-query
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-vue-query
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-vue-query
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-vue-query
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-vue-query
+[node-href]: https://npmx.dev/package/@kubb/plugin-vue-query

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-vue-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-vue-query
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-vue-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-vue-query
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-vue-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-vue-query.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-vue-query

--- a/packages/plugin-vue-query/README.md
+++ b/packages/plugin-vue-query/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-vue-query" target="_blank">
-  <img alt="@kubb/plugin-vue-query badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-vue-query+npm/dm/@kubb/plugin-vue-query+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-vue-query+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/vue-query" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-vue-query
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-vue-query
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-vue-query.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/plugin-zod" target="_blank">
+  <img alt="@kubb/plugin-zod badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-zod+npm/dm/@kubb/plugin-zod+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev/plugins/zod" target="_blank">Documentation</a>
@@ -55,20 +53,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/plugin-zod?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-zod
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/plugin-zod?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-zod
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/plugin-zod
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/plugin-zod?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/plugin-zod
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/plugin-zod
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-zod
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-zod
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-zod

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -59,12 +59,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/plugin-zod
+[npm-version-href]: https://npmx.dev/package/@kubb/plugin-zod
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-zod
+[npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-zod
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/plugin-zod
+[node-href]: https://npmx.dev/package/@kubb/plugin-zod

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/plugin-zod" target="_blank">
-  <img alt="@kubb/plugin-zod badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-zod+npm/dm/@kubb/plugin-zod+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/plugin-zod badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-zod+npm/dm/@kubb/plugin-zod+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-zod+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-zod
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/plugin-zod

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -58,13 +58,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-zod.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/plugin-zod
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-zod.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-zod
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-zod

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/zod" target="_blank">Documentation</a>
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-zod
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/plugin-zod

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/plugin-zod" target="_blank">
-  <img alt="@kubb/plugin-zod badges" src="https://shieldcn.dev/group/npm/v/@kubb/plugin-zod+npm/dm/@kubb/plugin-zod+github/stars/kubb-labs/kubb+npm/l/@kubb/plugin-zod+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev/plugins/zod" target="_blank">Documentation</a>
@@ -53,3 +55,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/plugins/blob/main/LICENSE)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/plugin-zod
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/plugin-zod
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/plugin-zod.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -64,7 +64,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/plugin-zod
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/plugin-zod.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/plugin-zod.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/plugin-zod


### PR DESCRIPTION
## Summary

- Replace the existing flat shields.io badges across the monorepo root and every plugin package README with a single shieldcn.dev badge group rendered as one shadcn-styled image
- Apply `variant=branded`, `size=xs`, `theme=zinc`, `mode=dark` to every group
- Root README gets a 3-segment group (stars + license + sponsors) for `kubb-labs/plugins`; plugin packages get a 6-segment group (npm version, downloads, stars, codecov, license, sponsors)
- Drop the now-unused reference-style `[*-src]` / `[*-href]` link defs at the bottom of each README

## Test plan

- [ ] Open `packages/plugin-ts/README.md` (and any other touched README) on GitHub and confirm the shieldcn group image renders with brand colors per segment
- [ ] Hit the group URL in a browser to confirm `shieldcn.dev` returns a 200 SVG
- [ ] `grep -RE '\[(npm-version|npm-downloads|coverage|license|sponsors|build|minified)-(src|href)\]:' packages/ README.md` returns nothing

https://claude.ai/code/session_013waRRjU1q7UcNXb3Tnnvqa

---
_Generated by [Claude Code](https://claude.ai/code/session_013waRRjU1q7UcNXb3Tnnvqa)_