### PR TITLE
refactor: adopt native Node 22 features and drop remeda

### DIFF
--- a/.changeset/modernize-node-22-natives.md
+++ b/.changeset/modernize-node-22-natives.md
@@ -1,0 +1,10 @@
+---
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-ts": patch
+"@kubb/plugin-redoc": patch
+"@kubb/plugin-zod": patch
+---
+
+Adopt native Node 22 features and drop the `remeda` dependency. The query and mutation generators now resolve their HTTP methods through a `Set` instead of `remeda`'s `difference`, `plugin-ts` sorts imports and exports with `Array.prototype.toSorted` and a local numeric guard, and `plugin-redoc` resolves its template path through `import.meta.dirname`. The shared TypeScript config moves to an ES2024 target with the ES2025 collection and iterator libraries.

--- a/configs/base.json
+++ b/configs/base.json
@@ -5,7 +5,8 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "ES2022",
+    "target": "ES2024",
+    "lib": ["es2024", "ES2025.Collection", "ES2025.Iterator", "ESNext.Array", "DOM", "DOM.Iterable"],
     "verbatimModuleSyntax": true,
     "allowJs": true,
     "resolveJsonModule": true,

--- a/internals/utils/src/imports.ts
+++ b/internals/utils/src/imports.ts
@@ -22,11 +22,13 @@ function getImportNames(entry: ImportEntry): Array<string> {
 }
 
 export function filterUsedImports(imports: Array<ImportEntry>, text: string, skipImportNames: Array<string> = []): Array<ImportEntry> {
+  const skip = new Set(skipImportNames)
+
   return imports.filter((entry) => {
     const names = getImportNames(entry)
 
     return names.some((name) => {
-      if (skipImportNames.includes(name)) {
+      if (skip.has(name)) {
         return false
       }
 

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -84,8 +84,7 @@
     "@kubb/plugin-client": "workspace:*",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
-    "@kubb/renderer-jsx": "catalog:",
-    "remeda": "catalog:"
+    "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
     "@internals/shared": "workspace:*",

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -2,7 +2,6 @@ import { getOperationParameters, operationFileEntry } from '@internals/shared'
 import { ast, defineGenerator } from '@kubb/core'
 import { File, jsxRendererSync, Type } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
-import { difference } from 'remeda'
 import type { PluginReactQuery } from '../types'
 import { resolveOperationOverrides } from '../utils.ts'
 
@@ -48,10 +47,11 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
         nodeQuery === false
           ? !!query && query.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
           : !!nodeQuery && nodeQuery.methods.some((m) => node.method.toLowerCase() === m.toLowerCase())
+      const nodeQueryMethods = new Set(nodeQuery ? nodeQuery.methods : [])
       const isMutationOp =
         nodeMutation !== false &&
         !isQueryOp &&
-        difference(nodeMutation ? nodeMutation.methods : [], nodeQuery ? nodeQuery.methods : []).some((m) => node.method.toLowerCase() === m.toLowerCase())
+        (nodeMutation ? nodeMutation.methods : []).some((m) => !nodeQueryMethods.has(m) && node.method.toLowerCase() === m.toLowerCase())
       const isSuspenseOp = !!suspense
       const isInfiniteOp = !!nodeInfiniteOptions
 

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginReactQuery } from '../types'
 
@@ -29,10 +28,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { Mutation, MutationKey, MutationOptions } from '../components'
 import type { PluginReactQuery } from '../types'
 
@@ -28,10 +27,11 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginReactQuery } from '../types'
 
@@ -29,10 +28,11 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
 
     // query: false means "this IS a query op, but skip the useQuery hook"
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { QueryKey, SuspenseInfiniteQuery, SuspenseInfiniteQueryOptions } from '../components'
 import type { PluginReactQuery } from '../types'
 
@@ -42,10 +41,11 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { QueryKey, QueryOptions, SuspenseQuery } from '../components'
 import type { PluginReactQuery } from '../types'
 
@@ -30,10 +29,11 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
 
     // query: false means "this IS a query op" (suspense hooks still generate)
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
     const isSuspense = !!suspense
 
     if (!isQuery || isMutation || !isSuspense) return null

--- a/packages/plugin-redoc/src/redoc.tsx
+++ b/packages/plugin-redoc/src/redoc.tsx
@@ -1,11 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import type { AdapterOas } from '@kubb/adapter-oas'
 import pkg from 'handlebars'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
 
 type BuildDocsOptions = {
   title?: string
@@ -19,7 +15,7 @@ type BuildDocsOptions = {
  * the generated file works without further build steps.
  */
 export async function getPageHTML(api: AdapterOas['document'], { title, disableGoogleFont, templateOptions }: BuildDocsOptions = {}) {
-  const templateFileName = path.join(__dirname, '../static/redoc.hbs')
+  const templateFileName = path.join(import.meta.dirname, '../static/redoc.hbs')
   const template = pkg.compile(fs.readFileSync(templateFileName).toString())
   return template({
     title: title || api.info.title || 'ReDoc documentation',

--- a/packages/plugin-swr/package.json
+++ b/packages/plugin-swr/package.json
@@ -82,8 +82,7 @@
     "@kubb/plugin-client": "workspace:*",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
-    "@kubb/renderer-jsx": "catalog:",
-    "remeda": "catalog:"
+    "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
     "@internals/shared": "workspace:*",

--- a/packages/plugin-swr/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-swr/src/generators/mutationGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRenderer } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { Mutation, MutationKey } from '../components'
 import type { PluginSwr } from '../types'
 
@@ -23,10 +22,11 @@ export const mutationGenerator = defineGenerator<PluginSwr>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-swr/src/generators/queryGenerator.tsx
+++ b/packages/plugin-swr/src/generators/queryGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRenderer } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginSwr } from '../types'
 
@@ -23,10 +22,11 @@ export const queryGenerator = defineGenerator<PluginSwr>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-ts/package.json
+++ b/packages/plugin-ts/package.json
@@ -61,7 +61,6 @@
     "@kubb/core": "catalog:",
     "@kubb/parser-ts": "catalog:",
     "@kubb/renderer-jsx": "catalog:",
-    "remeda": "catalog:",
     "typescript": "catalog:"
   },
   "devDependencies": {

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -1,10 +1,23 @@
 import { camelCase, pascalCase, screamingSnakeCase, snakeCase } from '@internals/utils'
 import { ast } from '@kubb/core'
-import { isNumber, sortBy } from 'remeda'
 import ts from 'typescript'
 import { OPTIONAL_ADDS_UNDEFINED } from './constants.ts'
 
 const { SyntaxKind, factory } = ts
+
+/**
+ * Compares two strings by UTF-16 code unit, keeping sorted output identical across platforms
+ * regardless of locale.
+ */
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1
+  if (a > b) return 1
+  return 0
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === 'number' && !Number.isNaN(value)
+}
 
 // https://ts-ast-viewer.com/
 
@@ -397,7 +410,7 @@ export function createImportDeclaration({
   }
 
   // Sort the imports alphabetically for consistent output across platforms
-  const sortedName = sortBy(name, [(item) => (typeof item === 'object' ? item.propertyName : item), 'asc'])
+  const sortedName = name.toSorted((a, b) => compareStrings(typeof a === 'object' ? a.propertyName : a, typeof b === 'object' ? b.propertyName : b))
 
   return factory.createImportDeclaration(
     undefined,
@@ -456,7 +469,7 @@ export function createExportDeclaration({
   }
 
   // Sort the exports alphabetically for consistent output across platforms
-  const sortedName = sortBy(name, [(propertyName) => (typeof propertyName === 'string' ? propertyName : propertyName.text), 'asc'])
+  const sortedName = name.toSorted((a, b) => compareStrings(typeof a === 'string' ? a : a.text, typeof b === 'string' ? b : b.text))
 
   return factory.createExportDeclaration(
     undefined,

--- a/packages/plugin-ts/src/printers/functionPrinter.ts
+++ b/packages/plugin-ts/src/printers/functionPrinter.ts
@@ -64,11 +64,11 @@ function rank(param: ast.FunctionParameterNode | ast.ParameterGroupNode): number
 }
 
 function sortParams(params: ReadonlyArray<ast.FunctionParameterNode | ast.ParameterGroupNode>): Array<ast.FunctionParameterNode | ast.ParameterGroupNode> {
-  return [...params].sort((a, b) => rank(a) - rank(b))
+  return params.toSorted((a, b) => rank(a) - rank(b))
 }
 
 function sortChildParams(params: Array<ast.FunctionParameterNode>): Array<ast.FunctionParameterNode> {
-  return [...params].sort((a, b) => rank(a) - rank(b))
+  return params.toSorted((a, b) => rank(a) - rank(b))
 }
 
 /**

--- a/packages/plugin-vue-query/package.json
+++ b/packages/plugin-vue-query/package.json
@@ -86,8 +86,7 @@
     "@kubb/plugin-client": "workspace:*",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
-    "@kubb/renderer-jsx": "catalog:",
-    "remeda": "catalog:"
+    "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
     "@internals/shared": "workspace:*",

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginVueQuery } from '../types'
 
@@ -29,10 +28,11 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
     const infiniteOptions = infinite && typeof infinite === 'object' ? infinite : null
 
     if (!isQuery || isMutation || !infiniteOptions) return null

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { Mutation, MutationKey } from '../components'
 import type { PluginVueQuery } from '../types'
 
@@ -28,10 +27,11 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
 
     if (!isMutation) return null
 

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -6,7 +6,6 @@ import { Client, pluginClientName } from '@kubb/plugin-client'
 import { pluginTsName } from '@kubb/plugin-ts'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRendererSync } from '@kubb/renderer-jsx'
-import { difference } from 'remeda'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginVueQuery } from '../types'
 
@@ -28,10 +27,11 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     const tsResolver = driver.getResolver(pluginTsName)
 
     const isQuery = query === false || (!!query && query.methods.some((method) => node.method.toLowerCase() === method.toLowerCase()))
+    const queryMethods = new Set(query ? query.methods : [])
     const isMutation =
       mutation !== false &&
       !isQuery &&
-      difference(mutation ? mutation.methods : [], query ? query.methods : []).some((method) => node.method.toLowerCase() === method.toLowerCase())
+      (mutation ? mutation.methods : []).some((method) => !queryMethods.has(method) && node.method.toLowerCase() === method.toLowerCase())
 
     if (!isQuery || isMutation) return null
 

--- a/packages/plugin-zod/package.json
+++ b/packages/plugin-zod/package.json
@@ -61,8 +61,7 @@
   },
   "dependencies": {
     "@kubb/core": "catalog:",
-    "@kubb/renderer-jsx": "catalog:",
-    "remeda": "catalog:"
+    "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
     "@internals/shared": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ catalogs:
     prettier:
       specifier: ^3.8.3
       version: 3.8.3
-    remeda:
-      specifier: ^2.37.0
-      version: 2.37.0
     size-limit:
       specifier: ^12.1.0
       version: 12.1.0
@@ -865,9 +862,6 @@ importers:
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
         version: 5.0.0-beta.40
-      remeda:
-        specifier: 'catalog:'
-        version: 2.37.0
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -912,9 +906,6 @@ importers:
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
         version: 5.0.0-beta.40
-      remeda:
-        specifier: 'catalog:'
-        version: 2.37.0
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -937,9 +928,6 @@ importers:
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
         version: 5.0.0-beta.40
-      remeda:
-        specifier: 'catalog:'
-        version: 2.37.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -968,9 +956,6 @@ importers:
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
         version: 5.0.0-beta.40
-      remeda:
-        specifier: 'catalog:'
-        version: 2.37.0
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -990,9 +975,6 @@ importers:
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
         version: 5.0.0-beta.40
-      remeda:
-        specifier: 'catalog:'
-        version: 2.37.0
     devDependencies:
       '@internals/shared':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,6 @@ catalog:
   oxfmt: ^0.47.0
   oxlint: ^1.67.0
   prettier: ^3.8.3
-  remeda: ^2.37.0
   'size-limit': ^12.1.0
   tsdown: ^0.22.1
   typescript: ^6.0.3


### PR DESCRIPTION
## Summary

Modernizes the plugins to native Node 22 / ES2024 APIs and removes the `remeda` runtime dependency.

- **Drop `remeda`**: the query/mutation generators in `plugin-react-query`, `plugin-vue-query`, and `plugin-swr` resolved their HTTP methods with `remeda`'s `difference`. They now build a `Set` of the query methods once and test membership with `.has()` — O(1), behavior-identical. `plugin-ts`'s `factory.ts` swaps `sortBy` for `Array.prototype.toSorted` (with a code-unit comparator to keep output stable across platforms) and `isNumber` for a small local guard. `remeda` is removed from all plugin `package.json`s and the workspace catalog.
- **`import.meta.dirname`**: `plugin-redoc` resolves its template path without `fileURLToPath` boilerplate.
- **`toSorted`**: `plugin-ts`'s `functionPrinter` sorts parameters immutably.
- **`Set` membership**: `@internals/utils` `filterUsedImports` hoists a `Set` for `skipImportNames`.
- **tsconfig**: `target` → `ES2024` with explicit `lib` (`es2024` + `ES2025.Collection`/`ES2025.Iterator`/`ESNext.Array` + `DOM`). `ES2025.*` is chosen over `ESNext.*` so the types only expose APIs shipped in Node 22.

> Note: `remeda` still appears in the lockfile as a **transitive** dependency of the published `@kubb/agent` package — that's outside this repo.

## Verification

- `pnpm typecheck` — all 14 packages pass.
- `pnpm test` for the query plugins, `plugin-ts`, `plugin-redoc`, and `@internals/utils` — green (snapshots unchanged, confirming the `difference` swap is behavior-preserving). One `plugin-ts` enum snapshot caught that `remeda.isNumber` excludes `NaN`; the local guard now matches.
- `pnpm build` for the affected packages, `pnpm lint`, and `pnpm format` clean.

A patch changeset is included for the affected plugins.


---
_Generated by [Claude Code](https://claude.ai/code/session_0198D2QT3EzcrUtMhdH3zHr3)_