### PR TITLE
fix(plugins): clean whitespace in raw generated react-query, vue-query, and MCP output

### DIFF
--- a/.changeset/clean-raw-generated-whitespace.md
+++ b/.changeset/clean-raw-generated-whitespace.md
@@ -1,0 +1,10 @@
+---
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-mcp": patch
+---
+
+Clean up whitespace in the raw generated output (the source emitted before any external formatter runs):
+
+- **react-query / vue-query**: empty conditional fragments (`enabled`, `customOptions`) no longer leave stray blank lines. This removes the double blank line in mutation/query hooks and the blank line that appeared right after `queryOptions<…, typeof queryKey>({`.
+- **mcp**: the handler `return { content: […], structuredContent: {…} }` block is now indented at the function-body baseline instead of being over-indented.

--- a/configs/mocks.ts
+++ b/configs/mocks.ts
@@ -32,3 +32,12 @@ const parsers = new Map<`.${string}`, any>([['.ts', parserTs]])
 export function matchFiles(files: Array<ast.FileNode> | undefined, pre?: string) {
   return matchFilesBase(files, { parsers, format, pre })
 }
+
+/**
+ * Renders the driver's `.ts` files to their raw, unformatted source. Snapshots run through
+ * prettier (see {@link format}), which silently repairs whitespace, so tests that need to guard
+ * the generator's own output must inspect this raw text instead.
+ */
+export function rawSources(files: Array<ast.FileNode> | undefined): Array<string> {
+  return (files ?? []).filter((file) => file.baseName.endsWith('.ts')).map((file) => parserTs.parse(file))
+}

--- a/configs/mocks.ts
+++ b/configs/mocks.ts
@@ -4,6 +4,7 @@ import { parserTs } from '@kubb/parser-ts'
 import type { Options } from 'prettier'
 import { format as prettierFormat } from 'prettier'
 import pluginTypescript from 'prettier/plugins/typescript'
+import { expect } from 'vitest'
 
 const formatOptions: Options = {
   tabWidth: 2,
@@ -29,15 +30,28 @@ export const mockedPluginDriver = createMockedPluginDriver()
 
 const parsers = new Map<`.${string}`, any>([['.ts', parserTs]])
 
-export function matchFiles(files: Array<ast.FileNode> | undefined, pre?: string) {
-  return matchFilesBase(files, { parsers, format, pre })
-}
-
 /**
  * Renders the driver's `.ts` files to their raw, unformatted source. Snapshots run through
- * prettier (see {@link format}), which silently repairs whitespace, so tests that need to guard
- * the generator's own output must inspect this raw text instead.
+ * prettier (see {@link format}), which silently repairs whitespace, so guarding the generator's
+ * own output means inspecting this raw text instead.
  */
 export function rawSources(files: Array<ast.FileNode> | undefined): Array<string> {
   return (files ?? []).filter((file) => file.baseName.endsWith('.ts')).map((file) => parserTs.parse(file))
+}
+
+/**
+ * Guards the raw (pre-prettier) output every generator emits. Prettier repairs whitespace before
+ * snapshotting, so without this check a generator could regress to double blank lines or a blank
+ * line straight after an opening bracket and no snapshot would notice.
+ */
+function assertCleanRawOutput(files: Array<ast.FileNode> | undefined): void {
+  for (const source of rawSources(files)) {
+    expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
+    expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
+  }
+}
+
+export function matchFiles(files: Array<ast.FileNode> | undefined, pre?: string) {
+  assertCleanRawOutput(files)
+  return matchFilesBase(files, { parsers, format, pre })
 }

--- a/packages/plugin-mcp/src/components/McpHandler.tsx
+++ b/packages/plugin-mcp/src/components/McpHandler.tsx
@@ -94,26 +94,16 @@ export function McpHandler({ name, node, resolver, baseURL, dataReturnType, para
   if (requestName) fetchConfig.push(`data: ${isFormData ? 'formData as FormData' : 'requestData'}`)
   if (headers.length) fetchConfig.push(`headers: { ${headers.join(', ')} }`)
 
-  const callToolResult =
-    dataReturnType === 'data'
-      ? `return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify(res.data)
-              }
-            ],
-            structuredContent: { data: res.data }
-           }`
-      : `return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify(res)
-              }
-            ],
-            structuredContent: { data: res.data }
-           }`
+  const payload = dataReturnType === 'data' ? 'res.data' : 'res'
+  const callToolResult = `return {
+  content: [
+    {
+      type: 'text',
+      text: JSON.stringify(${payload})
+    }
+  ],
+  structuredContent: { data: res.data }
+}`
 
   return (
     <File.Source name={name} isExportable isIndexable>

--- a/packages/plugin-mcp/src/generators/mcpGenerator.test.tsx
+++ b/packages/plugin-mcp/src/generators/mcpGenerator.test.tsx
@@ -135,8 +135,6 @@ describe('mcpGenerator — Operation', () => {
     })
 
     for (const source of rawSources(driver.fileManager.files)) {
-      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
-      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
       if (source.includes('structuredContent')) {
         expect(source, 'handler return is indented at the function-body baseline').toContain('\n  return {\n    content: [')
       }

--- a/packages/plugin-mcp/src/generators/mcpGenerator.test.tsx
+++ b/packages/plugin-mcp/src/generators/mcpGenerator.test.tsx
@@ -5,8 +5,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, test } from 'vitest'
-import { matchFiles } from '#mocks'
+import { describe, expect, test } from 'vitest'
+import { matchFiles, rawSources } from '#mocks'
 import { resolverMcp } from '../resolvers/resolverMcp.ts'
 import type { PluginMcp } from '../types.ts'
 import { mcpGenerator } from './mcpGenerator.tsx'
@@ -133,6 +133,14 @@ describe('mcpGenerator — Operation', () => {
       options,
       resolver: resolverMcp,
     })
+
+    for (const source of rawSources(driver.fileManager.files)) {
+      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
+      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
+      if (source.includes('structuredContent')) {
+        expect(source, 'handler return is indented at the function-body baseline').toContain('\n  return {\n    content: [')
+      }
+    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-react-query/src/components/InfiniteQuery.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQuery.tsx
@@ -148,11 +148,10 @@ export function InfiniteQuery({
         {`
        const { query: queryConfig = {}, client: config = {} } = options ?? {}
        const { client: queryClient, ...resolvedOptions } = queryConfig
-       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})
-       ${customOptions ? `const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
+       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})${customOptions ? `\n       const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
 
        const query = useInfiniteQuery({
-        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n...customOptions,' : ''}
+        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n        ...customOptions,' : ''}
         ...resolvedOptions,
         queryKey,
        } as unknown as InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, queryClient) as ${returnType}

--- a/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
@@ -133,8 +133,7 @@ export function InfiniteQueryOptions({
         <Function name={name} export params={paramsSignature}>
           {`
 const queryKey = ${queryKeyName}(${queryKeyParamsCall})
-return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({
-  ${enabledText}
+return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({${enabledText ? `\n  ${enabledText}` : ''}
   queryKey,
   queryFn: async ({ signal, pageParam }) => {
     ${infiniteOverrideParams}
@@ -153,8 +152,7 @@ return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${que
       <Function name={name} export params={paramsSignature}>
         {`
 const queryKey = ${queryKeyName}(${queryKeyParamsCall})
-return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({
-  ${enabledText}
+return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({${enabledText ? `\n  ${enabledText}` : ''}
   queryKey,
   queryFn: async ({ signal }) => {
     return ${clientName}(${clientCallStr})

--- a/packages/plugin-react-query/src/components/Mutation.tsx
+++ b/packages/plugin-react-query/src/components/Mutation.tsx
@@ -108,11 +108,10 @@ export function Mutation({ name, mutationOptionsName, paramsCasing, dataReturnTy
         const { client: queryClient, ...mutationOptions } = mutation;
         const mutationKey = mutationOptions.mutationKey ?? ${mutationKeyName}()
 
-        const baseOptions = ${mutationOptionsName}(${mutationOptionsParamsCall}) as UseMutationOptions<${generics}>
-        ${customOptions ? `const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' }) as UseMutationOptions<${generics}>` : ''}
+        const baseOptions = ${mutationOptionsName}(${mutationOptionsParamsCall}) as UseMutationOptions<${generics}>${customOptions ? `\n        const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' }) as UseMutationOptions<${generics}>` : ''}
 
         return useMutation<${generics}>({
-          ...baseOptions,${customOptions ? '\n...customOptions,' : ''}
+          ...baseOptions,${customOptions ? '\n          ...customOptions,' : ''}
           mutationKey,
           ...mutationOptions,
         }, queryClient) as ${returnType}

--- a/packages/plugin-react-query/src/components/Query.tsx
+++ b/packages/plugin-react-query/src/components/Query.tsx
@@ -106,11 +106,10 @@ export function Query({
         {`
        const { query: queryConfig = {}, client: config = {} } = options ?? {}
        const { client: queryClient, ...resolvedOptions } = queryConfig
-       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})
-       ${customOptions ? `const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
+       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})${customOptions ? `\n       const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
 
        const query = useQuery({
-        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n...customOptions,' : ''}
+        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n        ...customOptions,' : ''}
         ...resolvedOptions,
         queryKey,
        } as unknown as QueryObserverOptions, queryClient) as ${returnType}

--- a/packages/plugin-react-query/src/components/QueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/QueryOptions.tsx
@@ -72,8 +72,7 @@ export function QueryOptions({
       <Function name={name} export params={paramsSignature}>
         {`
       const queryKey = ${queryKeyName}(${queryKeyParamsCall})
-      return queryOptions<${TData}, ${TError}, ${TData}, typeof queryKey>({
-       ${enabledText}
+      return queryOptions<${TData}, ${TError}, ${TData}, typeof queryKey>({${enabledText ? `\n       ${enabledText}` : ''}
        queryKey,
        queryFn: async ({ signal }) => {
           return ${clientName}(${clientCallStr})

--- a/packages/plugin-react-query/src/components/SuspenseInfiniteQuery.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseInfiniteQuery.tsx
@@ -143,11 +143,10 @@ export function SuspenseInfiniteQuery({
         {`
        const { query: queryConfig = {}, client: config = {} } = options ?? {}
        const { client: queryClient, ...resolvedOptions } = queryConfig
-       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})
-       ${customOptions ? `const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
+       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})${customOptions ? `\n       const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
 
        const query = useSuspenseInfiniteQuery({
-        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n...customOptions,' : ''}
+        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n        ...customOptions,' : ''}
         ...resolvedOptions,
         queryKey,
        } as unknown as UseSuspenseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, queryClient) as ${returnType}

--- a/packages/plugin-react-query/src/components/SuspenseQuery.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseQuery.tsx
@@ -101,11 +101,10 @@ export function SuspenseQuery({
         {`
        const { query: queryConfig = {}, client: config = {} } = options ?? {}
        const { client: queryClient, ...resolvedOptions } = queryConfig
-       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})
-       ${customOptions ? `const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
+       const queryKey = resolvedOptions?.queryKey ?? ${queryKeyName}(${queryKeyParamsCall})${customOptions ? `\n       const customOptions = ${customOptions.name}({ hookName: '${name}', operationId: '${node.operationId}' })` : ''}
 
        const query = useSuspenseQuery({
-        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n...customOptions,' : ''}
+        ...${queryOptionsName}(${queryOptionsParamsCall}),${customOptions ? '\n        ...customOptions,' : ''}
         ...resolvedOptions,
         queryKey,
        } as unknown as UseSuspenseQueryOptions, queryClient) as ${returnType}

--- a/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
@@ -3,8 +3,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, test } from 'vitest'
-import { matchFiles } from '#mocks'
+import { describe, expect, test } from 'vitest'
+import { matchFiles, rawSources } from '#mocks'
 import { mutationKeyTransformer, queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverReactQuery } from '../resolvers/resolverReactQuery.ts'
 import type { PluginReactQuery } from '../types.ts'
@@ -157,6 +157,11 @@ describe('mutationGenerator operation', () => {
       options,
       resolver: resolverReactQuery,
     })
+
+    for (const source of rawSources(driver.fileManager.files)) {
+      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
+      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
+    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
@@ -3,8 +3,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, expect, test } from 'vitest'
-import { matchFiles, rawSources } from '#mocks'
+import { describe, test } from 'vitest'
+import { matchFiles } from '#mocks'
 import { mutationKeyTransformer, queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverReactQuery } from '../resolvers/resolverReactQuery.ts'
 import type { PluginReactQuery } from '../types.ts'
@@ -157,11 +157,6 @@ describe('mutationGenerator operation', () => {
       options,
       resolver: resolverReactQuery,
     })
-
-    for (const source of rawSources(driver.fileManager.files)) {
-      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
-      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
-    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
@@ -5,8 +5,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, expect, test } from 'vitest'
-import { matchFiles, rawSources } from '#mocks'
+import { describe, test } from 'vitest'
+import { matchFiles } from '#mocks'
 import { mutationKeyTransformer, queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverReactQuery } from '../resolvers/resolverReactQuery.ts'
 import type { PluginReactQuery } from '../types.ts'
@@ -148,11 +148,6 @@ describe('queryGenerator operation', () => {
       options,
       resolver: resolverReactQuery,
     })
-
-    for (const source of rawSources(driver.fileManager.files)) {
-      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
-      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
-    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
@@ -5,8 +5,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, test } from 'vitest'
-import { matchFiles } from '#mocks'
+import { describe, expect, test } from 'vitest'
+import { matchFiles, rawSources } from '#mocks'
 import { mutationKeyTransformer, queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverReactQuery } from '../resolvers/resolverReactQuery.ts'
 import type { PluginReactQuery } from '../types.ts'
@@ -148,6 +148,11 @@ describe('queryGenerator operation', () => {
       options,
       resolver: resolverReactQuery,
     })
+
+    for (const source of rawSources(driver.fileManager.files)) {
+      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
+      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
+    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
@@ -134,8 +134,7 @@ export function InfiniteQueryOptions({
         <Function name={name} export params={paramsSignature}>
           {`
 const queryKey = ${queryKeyName}(${queryKeyParamsCall})
-return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, QueryKey, ${pageParamType}>({
-  ${enabledText}
+return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, QueryKey, ${pageParamType}>({${enabledText ? `\n  ${enabledText}` : ''}
   queryKey,
   queryFn: async ({ signal, pageParam }) => {
     ${infiniteOverrideParams}
@@ -154,8 +153,7 @@ return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${que
       <Function name={name} export params={paramsSignature}>
         {`
 const queryKey = ${queryKeyName}(${queryKeyParamsCall})
-return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, QueryKey, ${pageParamType}>({
-  ${enabledText}
+return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, QueryKey, ${pageParamType}>({${enabledText ? `\n  ${enabledText}` : ''}
   queryKey,
   queryFn: async ({ signal }) => {
     return ${clientName}(${addToValueCalls(clientCallStr, enabledNames)})

--- a/packages/plugin-vue-query/src/components/QueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/QueryOptions.tsx
@@ -71,8 +71,7 @@ export function QueryOptions({
       <Function name={name} export params={paramsSignature}>
         {`
       const queryKey = ${queryKeyName}(${queryKeyParamsCall})
-      return queryOptions<${TData}, ${TError}, ${TData}>({
-       ${enabledText}
+      return queryOptions<${TData}, ${TError}, ${TData}>({${enabledText ? `\n       ${enabledText}` : ''}
        queryKey,
        queryFn: async ({ signal }) => {
           return ${clientName}(${addToValueCalls(clientCallStr, enabledNames)})

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
@@ -3,8 +3,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, expect, test } from 'vitest'
-import { matchFiles, rawSources } from '#mocks'
+import { describe, test } from 'vitest'
+import { matchFiles } from '#mocks'
 import { mutationKeyTransformer } from '@internals/tanstack-query'
 import { queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverVueQuery } from '../resolvers/resolverVueQuery.ts'
@@ -117,11 +117,6 @@ describe('infiniteQueryGenerator operation', () => {
       options,
       resolver: resolverVueQuery,
     })
-
-    for (const source of rawSources(driver.fileManager.files)) {
-      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
-      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
-    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
@@ -3,8 +3,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, test } from 'vitest'
-import { matchFiles } from '#mocks'
+import { describe, expect, test } from 'vitest'
+import { matchFiles, rawSources } from '#mocks'
 import { mutationKeyTransformer } from '@internals/tanstack-query'
 import { queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverVueQuery } from '../resolvers/resolverVueQuery.ts'
@@ -117,6 +117,11 @@ describe('infiniteQueryGenerator operation', () => {
       options,
       resolver: resolverVueQuery,
     })
+
+    for (const source of rawSources(driver.fileManager.files)) {
+      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
+      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
+    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
@@ -5,8 +5,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, expect, test } from 'vitest'
-import { matchFiles, rawSources } from '#mocks'
+import { describe, test } from 'vitest'
+import { matchFiles } from '#mocks'
 import { mutationKeyTransformer } from '@internals/tanstack-query'
 import { queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverVueQuery } from '../resolvers/resolverVueQuery.ts'
@@ -146,11 +146,6 @@ describe('queryGenerator operation', () => {
       options,
       resolver: resolverVueQuery,
     })
-
-    for (const source of rawSources(driver.fileManager.files)) {
-      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
-      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
-    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
@@ -5,8 +5,8 @@ import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
-import { describe, test } from 'vitest'
-import { matchFiles } from '#mocks'
+import { describe, expect, test } from 'vitest'
+import { matchFiles, rawSources } from '#mocks'
 import { mutationKeyTransformer } from '@internals/tanstack-query'
 import { queryKeyTransformer } from '@internals/tanstack-query'
 import { resolverVueQuery } from '../resolvers/resolverVueQuery.ts'
@@ -146,6 +146,11 @@ describe('queryGenerator operation', () => {
       options,
       resolver: resolverVueQuery,
     })
+
+    for (const source of rawSources(driver.fileManager.files)) {
+      expect(source, 'raw output has no double blank lines').not.toMatch(/\n[ \t]*\n[ \t]*\n/)
+      expect(source, 'raw output has no blank line right after an opening bracket').not.toMatch(/[([{][ \t]*\n[ \t]*\n/)
+    }
 
     await matchFiles(driver.fileManager.files, props.name)
   })

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/createUser.ts
@@ -15,12 +15,12 @@ export async function createUserHandler({ data }: { data?: CreateUserData } = {}
   const res = await client<CreateUserResponse, ResponseErrorConfig<Error>, CreateUserData>({ method: "POST", url: `/user`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/createUsersWithListInput.ts
@@ -15,12 +15,12 @@ export async function createUsersWithListInputHandler({ data }: { data?: CreateU
   const res = await client<CreateUsersWithListInputResponse, ResponseErrorConfig<Error>, CreateUsersWithListInputData>({ method: "POST", url: `/user/createWithList`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/deleteOrder.ts
@@ -13,12 +13,12 @@ export async function deleteOrderHandler({ orderId }: { orderId: DeleteOrderPath
   const res = await client<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, unknown>({ method: "DELETE", url: `/store/order/${orderId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/deleteUser.ts
@@ -13,12 +13,12 @@ export async function deleteUserHandler({ username }: { username: DeleteUserPath
   const res = await client<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, unknown>({ method: "DELETE", url: `/user/${username}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/findPetsByStatus.ts
@@ -13,12 +13,12 @@ export async function findPetsByStatusHandler({ params }: { params?: { status?: 
   const res = await client<FindPetsByStatusResponse, ResponseErrorConfig<FindPetsByStatusStatus400>, unknown>({ method: "GET", url: `/pet/findByStatus`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/findPetsByTags.ts
@@ -13,12 +13,12 @@ export async function findPetsByTagsHandler({ params }: { params?: { tags?: Find
   const res = await client<FindPetsByTagsResponse, ResponseErrorConfig<FindPetsByTagsStatus400>, unknown>({ method: "GET", url: `/pet/findByTags`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getInventory.ts
@@ -13,12 +13,12 @@ export async function getInventoryHandler(request: RequestHandlerExtra<ServerReq
   const res = await client<GetInventoryResponse, ResponseErrorConfig<Error>, unknown>({ method: "GET", url: `/store/inventory` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getOrderById.ts
@@ -13,12 +13,12 @@ export async function getOrderByIdHandler({ orderId }: { orderId: GetOrderByIdPa
   const res = await client<GetOrderByIdResponse, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, unknown>({ method: "GET", url: `/store/order/${orderId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getPetById.ts
@@ -13,12 +13,12 @@ export async function getPetByIdHandler({ petId }: { petId: GetPetByIdPathPetId 
   const res = await client<GetPetByIdResponse, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, unknown>({ method: "GET", url: `/pet/${petId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/getUserByName.ts
@@ -12,12 +12,12 @@ export async function getUserByNameHandler({ username }: { username: GetUserByNa
   const res = await client<GetUserByNameResponse, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, unknown>({ method: "GET", url: `/user/${username}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/loginUser.ts
@@ -12,12 +12,12 @@ export async function loginUserHandler({ params }: { params?: { username?: Login
   const res = await client<LoginUserResponse, ResponseErrorConfig<LoginUserStatus400>, unknown>({ method: "GET", url: `/user/login`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/logoutUser.ts
@@ -12,12 +12,12 @@ export async function logoutUserHandler(request: RequestHandlerExtra<ServerReque
   const res = await client<LogoutUserResponse, ResponseErrorConfig<Error>, unknown>({ method: "GET", url: `/user/logout` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/placeOrder.ts
@@ -15,12 +15,12 @@ export async function placeOrderHandler({ data }: { data?: PlaceOrderData } = {}
   const res = await client<PlaceOrderResponse, ResponseErrorConfig<PlaceOrderStatus405>, PlaceOrderData>({ method: "POST", url: `/store/order`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/updatePet.ts
@@ -15,12 +15,12 @@ export async function updatePetHandler({ data }: { data: UpdatePetData }, reques
   const res = await client<UpdatePetResponse, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, UpdatePetData>({ method: "PUT", url: `/pet`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/updatePetWithForm.ts
@@ -12,12 +12,12 @@ export async function updatePetWithFormHandler({ petId, params }: { petId: Updat
   const res = await client<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, unknown>({ method: "POST", url: `/pet/${petId}`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/updateUser.ts
@@ -15,12 +15,12 @@ export async function updateUserHandler({ username, data }: { username: UpdateUs
   const res = await client<UpdateUserResponse, ResponseErrorConfig<Error>, UpdateUserData>({ method: "PUT", url: `/user/${username}`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/uploadFile.ts
@@ -14,12 +14,12 @@ export async function uploadFileHandler({ petId, data, params }: { petId: Upload
   const res = await client<UploadFileResponse, ResponseErrorConfig<Error>, UploadFileData>({ method: "POST", url: `/pet/${petId}/uploadImage`, params, data: requestData, headers: { 'Content-Type': 'application/octet-stream' } }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/addPet.ts
@@ -15,12 +15,12 @@ export async function addPetHandler({ data }: { data: AddPetData }, request: Req
   const res = await client<AddPetResponse, ResponseErrorConfig<AddPetStatus405>, AddPetData>({ method: "POST", url: `/pet`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/deletePet.ts
@@ -13,12 +13,12 @@ export async function deletePetHandler({ petId, headers }: { petId: DeletePetPat
   const res = await client<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, unknown>({ method: "DELETE", url: `/pet/${petId}`, headers: { ...headers } }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/findPetsByStatus.ts
@@ -13,12 +13,12 @@ export async function findPetsByStatusHandler({ params }: { params?: { status?: 
   const res = await client<FindPetsByStatusResponse, ResponseErrorConfig<FindPetsByStatusStatus400>, unknown>({ method: "GET", url: `/pet/findByStatus`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/findPetsByTags.ts
@@ -13,12 +13,12 @@ export async function findPetsByTagsHandler({ params }: { params?: { tags?: Find
   const res = await client<FindPetsByTagsResponse, ResponseErrorConfig<FindPetsByTagsStatus400>, unknown>({ method: "GET", url: `/pet/findByTags`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/getPetById.ts
@@ -13,12 +13,12 @@ export async function getPetByIdHandler({ petId }: { petId: GetPetByIdPathPetId 
   const res = await client<GetPetByIdResponse, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, unknown>({ method: "GET", url: `/pet/${petId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/updatePet.ts
@@ -15,12 +15,12 @@ export async function updatePetHandler({ data }: { data: UpdatePetData }, reques
   const res = await client<UpdatePetResponse, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, UpdatePetData>({ method: "PUT", url: `/pet`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/updatePetWithForm.ts
@@ -12,12 +12,12 @@ export async function updatePetWithFormHandler({ petId, params }: { petId: Updat
   const res = await client<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, unknown>({ method: "POST", url: `/pet/${petId}`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/petRequests/uploadFile.ts
@@ -14,12 +14,12 @@ export async function uploadFileHandler({ petId, data, params }: { petId: Upload
   const res = await client<UploadFileResponse, ResponseErrorConfig<Error>, UploadFileData>({ method: "POST", url: `/pet/${petId}/uploadImage`, params, data: requestData, headers: { 'Content-Type': 'application/octet-stream' } }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/deleteOrder.ts
@@ -13,12 +13,12 @@ export async function deleteOrderHandler({ orderId }: { orderId: DeleteOrderPath
   const res = await client<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, unknown>({ method: "DELETE", url: `/store/order/${orderId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/getInventory.ts
@@ -13,12 +13,12 @@ export async function getInventoryHandler(request: RequestHandlerExtra<ServerReq
   const res = await client<GetInventoryResponse, ResponseErrorConfig<Error>, unknown>({ method: "GET", url: `/store/inventory` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/getOrderById.ts
@@ -13,12 +13,12 @@ export async function getOrderByIdHandler({ orderId }: { orderId: GetOrderByIdPa
   const res = await client<GetOrderByIdResponse, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, unknown>({ method: "GET", url: `/store/order/${orderId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/storeRequests/placeOrder.ts
@@ -15,12 +15,12 @@ export async function placeOrderHandler({ data }: { data?: PlaceOrderData } = {}
   const res = await client<PlaceOrderResponse, ResponseErrorConfig<PlaceOrderStatus405>, PlaceOrderData>({ method: "POST", url: `/store/order`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/createUser.ts
@@ -15,12 +15,12 @@ export async function createUserHandler({ data }: { data?: CreateUserData } = {}
   const res = await client<CreateUserResponse, ResponseErrorConfig<Error>, CreateUserData>({ method: "POST", url: `/user`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/createUsersWithListInput.ts
@@ -15,12 +15,12 @@ export async function createUsersWithListInputHandler({ data }: { data?: CreateU
   const res = await client<CreateUsersWithListInputResponse, ResponseErrorConfig<Error>, CreateUsersWithListInputData>({ method: "POST", url: `/user/createWithList`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/deleteUser.ts
@@ -13,12 +13,12 @@ export async function deleteUserHandler({ username }: { username: DeleteUserPath
   const res = await client<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, unknown>({ method: "DELETE", url: `/user/${username}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/getUserByName.ts
@@ -12,12 +12,12 @@ export async function getUserByNameHandler({ username }: { username: GetUserByNa
   const res = await client<GetUserByNameResponse, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, unknown>({ method: "GET", url: `/user/${username}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/loginUser.ts
@@ -12,12 +12,12 @@ export async function loginUserHandler({ params }: { params?: { username?: Login
   const res = await client<LoginUserResponse, ResponseErrorConfig<LoginUserStatus400>, unknown>({ method: "GET", url: `/user/login`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/logoutUser.ts
@@ -12,12 +12,12 @@ export async function logoutUserHandler(request: RequestHandlerExtra<ServerReque
   const res = await client<LogoutUserResponse, ResponseErrorConfig<Error>, unknown>({ method: "GET", url: `/user/logout` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/userRequests/updateUser.ts
@@ -15,12 +15,12 @@ export async function updateUserHandler({ username, data }: { username: UpdateUs
   const res = await client<UpdateUserResponse, ResponseErrorConfig<Error>, UpdateUserData>({ method: "PUT", url: `/user/${username}`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/addPet.ts
@@ -15,12 +15,12 @@ export async function addPetHandler({ data }: { data: AddPetData }, request: Req
   const res = await client<AddPetResponse, ResponseErrorConfig<AddPetStatus405>, AddPetData>({ method: "POST", url: `/pet`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/deletePet.ts
@@ -13,12 +13,12 @@ export async function deletePetHandler({ petId, headers }: { petId: DeletePetPat
   const res = await client<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, unknown>({ method: "DELETE", url: `/pet/${petId}`, headers: { ...headers } }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/findPetsByStatus.ts
@@ -13,12 +13,12 @@ export async function findPetsByStatusHandler({ params }: { params?: { status?: 
   const res = await client<FindPetsByStatusResponse, ResponseErrorConfig<FindPetsByStatusStatus400>, unknown>({ method: "GET", url: `/pet/findByStatus`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/findPetsByTags.ts
@@ -13,12 +13,12 @@ export async function findPetsByTagsHandler({ params }: { params?: { tags?: Find
   const res = await client<FindPetsByTagsResponse, ResponseErrorConfig<FindPetsByTagsStatus400>, unknown>({ method: "GET", url: `/pet/findByTags`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/getPetById.ts
@@ -13,12 +13,12 @@ export async function getPetByIdHandler({ petId }: { petId: GetPetByIdPathPetId 
   const res = await client<GetPetByIdResponse, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, unknown>({ method: "GET", url: `/pet/${petId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/updatePet.ts
@@ -15,12 +15,12 @@ export async function updatePetHandler({ data }: { data: UpdatePetData }, reques
   const res = await client<UpdatePetResponse, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, UpdatePetData>({ method: "PUT", url: `/pet`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/updatePetWithForm.ts
@@ -12,12 +12,12 @@ export async function updatePetWithFormHandler({ petId, params }: { petId: Updat
   const res = await client<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, unknown>({ method: "POST", url: `/pet/${petId}`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/uploadFile.ts
@@ -14,12 +14,12 @@ export async function uploadFileHandler({ petId, data, params }: { petId: Upload
   const res = await client<UploadFileResponse, ResponseErrorConfig<Error>, UploadFileData>({ method: "POST", url: `/pet/${petId}/uploadImage`, params, data: requestData, headers: { 'Content-Type': 'application/octet-stream' } }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/mcp/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/mcp/updatePet.ts
@@ -17,12 +17,12 @@ export async function updatePetHandler({ petId, data, params }: { petId: UpdateP
   const res = await client<UpdatePetResponse, ResponseErrorConfig<Error>, UpdatePetData>({ method: "POST", url: `/pets/${pet_id}`, params: mappedParams, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/addPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/addPet.ts
@@ -15,12 +15,12 @@ export async function addPetHandler({ data }: { data: AddPetData }, request: Req
   const res = await client<AddPetResponse, ResponseErrorConfig<AddPetStatus405>, AddPetData>({ method: "POST", url: `/pet`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/createUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/createUser.ts
@@ -15,12 +15,12 @@ export async function createUserHandler({ data }: { data?: CreateUserData } = {}
   const res = await client<CreateUserResponse, ResponseErrorConfig<Error>, CreateUserData>({ method: "POST", url: `/user`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/createUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/createUsersWithListInput.ts
@@ -15,12 +15,12 @@ export async function createUsersWithListInputHandler({ data }: { data?: CreateU
   const res = await client<CreateUsersWithListInputResponse, ResponseErrorConfig<Error>, CreateUsersWithListInputData>({ method: "POST", url: `/user/createWithList`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/deleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/deleteOrder.ts
@@ -13,12 +13,12 @@ export async function deleteOrderHandler({ orderId }: { orderId: DeleteOrderPath
   const res = await client<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, unknown>({ method: "DELETE", url: `/store/order/${orderId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/deletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/deletePet.ts
@@ -13,12 +13,12 @@ export async function deletePetHandler({ petId, headers }: { petId: DeletePetPat
   const res = await client<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, unknown>({ method: "DELETE", url: `/pet/${petId}`, headers: { ...headers } }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/deleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/deleteUser.ts
@@ -13,12 +13,12 @@ export async function deleteUserHandler({ username }: { username: DeleteUserPath
   const res = await client<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, unknown>({ method: "DELETE", url: `/user/${username}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/findPetsByStatus.ts
@@ -13,12 +13,12 @@ export async function findPetsByStatusHandler({ params }: { params?: { status?: 
   const res = await client<FindPetsByStatusResponse, ResponseErrorConfig<FindPetsByStatusStatus400>, unknown>({ method: "GET", url: `/pet/findByStatus`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/findPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/findPetsByTags.ts
@@ -13,12 +13,12 @@ export async function findPetsByTagsHandler({ params }: { params?: { tags?: Find
   const res = await client<FindPetsByTagsResponse, ResponseErrorConfig<FindPetsByTagsStatus400>, unknown>({ method: "GET", url: `/pet/findByTags`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getInventory.ts
@@ -13,12 +13,12 @@ export async function getInventoryHandler(request: RequestHandlerExtra<ServerReq
   const res = await client<GetInventoryResponse, ResponseErrorConfig<Error>, unknown>({ method: "GET", url: `/store/inventory` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getOrderById.ts
@@ -13,12 +13,12 @@ export async function getOrderByIdHandler({ orderId }: { orderId: GetOrderByIdPa
   const res = await client<GetOrderByIdResponse, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, unknown>({ method: "GET", url: `/store/order/${orderId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getPetById.ts
@@ -13,12 +13,12 @@ export async function getPetByIdHandler({ petId }: { petId: GetPetByIdPathPetId 
   const res = await client<GetPetByIdResponse, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, unknown>({ method: "GET", url: `/pet/${petId}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/getUserByName.ts
@@ -12,12 +12,12 @@ export async function getUserByNameHandler({ username }: { username: GetUserByNa
   const res = await client<GetUserByNameResponse, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, unknown>({ method: "GET", url: `/user/${username}` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/loginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/loginUser.ts
@@ -12,12 +12,12 @@ export async function loginUserHandler({ params }: { params?: { username?: Login
   const res = await client<LoginUserResponse, ResponseErrorConfig<LoginUserStatus400>, unknown>({ method: "GET", url: `/user/login`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/logoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/logoutUser.ts
@@ -12,12 +12,12 @@ export async function logoutUserHandler(request: RequestHandlerExtra<ServerReque
   const res = await client<LogoutUserResponse, ResponseErrorConfig<Error>, unknown>({ method: "GET", url: `/user/logout` }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/placeOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/placeOrder.ts
@@ -15,12 +15,12 @@ export async function placeOrderHandler({ data }: { data?: PlaceOrderData } = {}
   const res = await client<PlaceOrderResponse, ResponseErrorConfig<PlaceOrderStatus405>, PlaceOrderData>({ method: "POST", url: `/store/order`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/updatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/updatePet.ts
@@ -15,12 +15,12 @@ export async function updatePetHandler({ data }: { data: UpdatePetData }, reques
   const res = await client<UpdatePetResponse, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, UpdatePetData>({ method: "PUT", url: `/pet`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/updatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/updatePetWithForm.ts
@@ -12,12 +12,12 @@ export async function updatePetWithFormHandler({ petId, params }: { petId: Updat
   const res = await client<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, unknown>({ method: "POST", url: `/pet/${petId}`, params }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/updateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/updateUser.ts
@@ -15,12 +15,12 @@ export async function updateUserHandler({ username, data }: { username: UpdateUs
   const res = await client<UpdateUserResponse, ResponseErrorConfig<Error>, UpdateUserData>({ method: "PUT", url: `/user/${username}`, data: requestData }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/uploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/uploadFile.ts
@@ -14,12 +14,12 @@ export async function uploadFileHandler({ petId, data, params }: { petId: Upload
   const res = await client<UploadFileResponse, ResponseErrorConfig<Error>, UploadFileData>({ method: "POST", url: `/pet/${petId}/uploadImage`, params, data: requestData, headers: { 'Content-Type': 'application/octet-stream' } }, request)
 
   return {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify(res.data)
-                }
-              ],
-              structuredContent: { data: res.data }
-             }
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(res.data)
+      }
+    ],
+    structuredContent: { data: res.data }
+  }
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/petController/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/storeController/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/hooks/userController/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<Error>, {petId: UpdatePetPathPetId, data: UpdatePetData, params?: { includeDeleted?: UpdatePetQueryIncludeDeleted; requestSource?: UpdatePetQueryRequestSource }}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<Error>, {petId: UpdatePetPathPetId, data: UpdatePetData, params?: { includeDeleted?: UpdatePetQueryIncludeDeleted; requestSource?: UpdatePetQueryRequestSource }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus({ params }: { params?: { status?: FindPet
 export function findPetsByStatusQueryOptions({ params }: { params?: { status?: FindPetsByStatusQueryStatus } } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus({ params }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions({ params }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense({ params }: { params?: { status?:
 export function findPetsByStatusSuspenseQueryOptions({ params }: { params?: { status?: FindPetsByStatusQueryStatus } } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense({ params }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions({ params }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags({ params }: { params?: { tags?: FindPetsByT
 export function findPetsByTagsQueryOptions({ params }: { params?: { tags?: FindPetsByTagsQueryTags } } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags({ params }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions({ params }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense({ params }: { params?: { tags?: Fin
 export function findPetsByTagsSuspenseQueryOptions({ params }: { params?: { tags?: FindPetsByTagsQueryTags } } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense({ params }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions({ params }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey({ orderId })
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions({ orderId }, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense({ orderId }: { orderId: GetOrderByIdP
 export function getOrderByIdSuspenseQueryOptions({ orderId }: { orderId: GetOrderByIdPathOrderId }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey({ orderId })
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense({ orderId }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey({ orderId })
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions({ orderId }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey({ petId })
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions({ petId }, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense({ petId }: { petId: GetPetByIdPathPetId
 export function getPetByIdSuspenseQueryOptions({ petId }: { petId: GetPetByIdPathPetId }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey({ petId })
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense({ petId }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey({ petId })
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions({ petId }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey({ username })
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions({ username }, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense({ username }: { username: GetUserByN
 export function getUserByNameSuspenseQueryOptions({ username }: { username: GetUserByNamePathUsername }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey({ username })
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense({ username }, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey({ username })
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions({ username }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser({ params }: { params?: { username?: LoginUserQue
 export function loginUserQueryOptions({ params }: { params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword } } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser({ params }, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions({ params }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense({ params }: { params?: { username?: Logi
 export function loginUserSuspenseQueryOptions({ params }: { params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword } } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense({ params }, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions({ params }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useAddPet.ts
@@ -52,7 +52,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useCreateUser.ts
@@ -52,7 +52,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useCreateUsersWithListInput.ts
@@ -52,7 +52,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useDeleteOrder.ts
@@ -50,7 +50,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useDeletePet.ts
@@ -50,7 +50,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useDeleteUser.ts
@@ -50,7 +50,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByStatus.ts
@@ -30,7 +30,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByStatusSuspense.ts
@@ -30,7 +30,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByTags.ts
@@ -30,7 +30,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useFindPetsByTagsSuspense.ts
@@ -30,7 +30,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetInventorySuspense.ts
@@ -30,7 +30,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetOrderById.ts
@@ -51,7 +51,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetOrderByIdSuspense.ts
@@ -30,7 +30,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetPetById.ts
@@ -51,7 +51,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetPetByIdSuspense.ts
@@ -30,7 +30,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -50,7 +49,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetUserByName.ts
@@ -49,7 +49,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useGetUserByNameSuspense.ts
@@ -29,7 +29,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -48,7 +47,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLoginUser.ts
@@ -29,7 +29,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -48,7 +47,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLoginUserSuspense.ts
@@ -29,7 +29,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -48,7 +47,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -48,7 +47,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useLogoutUserSuspense.ts
@@ -29,7 +29,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -48,7 +47,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/usePlaceOrder.ts
@@ -52,7 +52,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUpdatePet.ts
@@ -52,7 +52,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUpdatePetWithForm.ts
@@ -48,7 +48,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUpdateUser.ts
@@ -52,7 +52,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/hooks/useUploadFile.ts
@@ -50,7 +50,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey({ orderId })
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions({ orderId }, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense({ orderId }: { orderId: GetOrderByIdP
 export function getOrderByIdSuspenseQueryOptions({ orderId }: { orderId: GetOrderByIdPathOrderId }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey({ orderId })
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense({ orderId }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey({ orderId })
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions({ orderId }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey({ petId })
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions({ petId }, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense({ petId }: { petId: GetPetByIdPathPetId
 export function getPetByIdSuspenseQueryOptions({ petId }: { petId: GetPetByIdPathPetId }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey({ petId })
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense({ petId }, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey({ petId })
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions({ petId }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey({ username })
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions({ username }, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense({ username }: { username: GetUserByN
 export function getUserByNameSuspenseQueryOptions({ username }: { username: GetUserByNamePathUsername }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey({ username })
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense({ username }, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey({ username })
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions({ username }, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useAddPet.ts
@@ -51,7 +51,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useCreateUser.ts
@@ -51,7 +51,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useCreateUsersWithListInput.ts
@@ -51,7 +51,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useDeleteOrder.ts
@@ -49,7 +49,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useDeletePet.ts
@@ -49,7 +49,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useDeleteUser.ts
@@ -49,7 +49,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByStatus.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByStatusSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByStatusSuspense(params?: { status?: FindPetsBySta
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatusSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByTags.ts
@@ -29,7 +29,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useFindPetsByTagsSuspense.ts
@@ -29,7 +29,6 @@ export async function findPetsByTagsSuspense(params?: { tags?: FindPetsByTagsQue
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTagsSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetInventory.ts
@@ -29,7 +29,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetInventorySuspense.ts
@@ -29,7 +29,6 @@ export async function getInventorySuspense(config: Partial<RequestConfig> & { cl
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventorySuspense({ ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetOrderById.ts
@@ -50,7 +50,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetOrderByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getOrderByIdSuspense(orderId: GetOrderByIdPathOrderId, con
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderByIdSuspense(orderId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetPetById.ts
@@ -50,7 +50,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetPetByIdSuspense.ts
@@ -29,7 +29,6 @@ export async function getPetByIdSuspense(petId: GetPetByIdPathPetId, config: Par
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetByIdSuspense(petId, { ...config, signal: config.signal ?? signal })
@@ -49,7 +48,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetUserByName.ts
@@ -48,7 +48,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useGetUserByNameSuspense.ts
@@ -28,7 +28,6 @@ export async function getUserByNameSuspense(username: GetUserByNamePathUsername,
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByNameSuspense(username, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLoginUser.ts
@@ -28,7 +28,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLoginUserSuspense.ts
@@ -28,7 +28,6 @@ export async function loginUserSuspense(params?: { username?: LoginUserQueryUser
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUserSuspense(params, { ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLogoutUser.ts
@@ -28,7 +28,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useLogoutUserSuspense.ts
@@ -28,7 +28,6 @@ export async function logoutUserSuspense(config: Partial<RequestConfig> & { clie
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUserSuspense({ ...config, signal: config.signal ?? signal })
@@ -47,7 +46,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/usePlaceOrder.ts
@@ -51,7 +51,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUpdatePet.ts
@@ -51,7 +51,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUpdatePetWithForm.ts
@@ -47,7 +47,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUpdateUser.ts
@@ -51,7 +51,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/hooks/useUploadFile.ts
@@ -49,7 +49,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useAddPet.ts
@@ -36,7 +36,6 @@ export function useAddPet<TContext>(options: {
 
   const baseOptions = addPetMutationOptions(config) as UseMutationOptions<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>
 
-
   return useMutation<AddPetStatus200, ResponseErrorConfig<AddPetStatus405>, {data: AddPetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useCreateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useCreateUser.ts
@@ -36,7 +36,6 @@ export function useCreateUser<TContext>(options: {
 
   const baseOptions = createUserMutationOptions(config) as UseMutationOptions<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>
 
-
   return useMutation<CreateUserResponse, ResponseErrorConfig<Error>, {data?: CreateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useCreateUsersWithListInput.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useCreateUsersWithListInput.ts
@@ -36,7 +36,6 @@ export function useCreateUsersWithListInput<TContext>(options: {
 
   const baseOptions = createUsersWithListInputMutationOptions(config) as UseMutationOptions<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>
 
-
   return useMutation<CreateUsersWithListInputStatus200, ResponseErrorConfig<Error>, {data?: CreateUsersWithListInputData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useDeleteOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useDeleteOrder.ts
@@ -36,7 +36,6 @@ export function useDeleteOrder<TContext>(options: {
 
   const baseOptions = deleteOrderMutationOptions(config) as UseMutationOptions<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>
 
-
   return useMutation<DeleteOrderResponse, ResponseErrorConfig<DeleteOrderStatus400 | DeleteOrderStatus404>, {orderId: DeleteOrderPathOrderId}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useDeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useDeletePet.ts
@@ -36,7 +36,6 @@ export function useDeletePet<TContext>(options: {
 
   const baseOptions = deletePetMutationOptions(config) as UseMutationOptions<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>
 
-
   return useMutation<DeletePetResponse, ResponseErrorConfig<DeletePetStatus400>, {petId: DeletePetPathPetId, headers?: { api_key?: DeletePetHeaderApiKey }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useDeleteUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useDeleteUser.ts
@@ -36,7 +36,6 @@ export function useDeleteUser<TContext>(options: {
 
   const baseOptions = deleteUserMutationOptions(config) as UseMutationOptions<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>
 
-
   return useMutation<DeleteUserResponse, ResponseErrorConfig<DeleteUserStatus400 | DeleteUserStatus404>, {username: DeleteUserPathUsername}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByStatus.ts
@@ -16,7 +16,6 @@ type FindPetsByStatusQueryKey = ReturnType<typeof findPetsByStatusQueryKey>
 export function findPetsByStatusQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useFindPetsByStatus<TData = FindPetsByStatusStatus200, TQueryDat
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByStatusQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByStatusSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByStatusSuspense.ts
@@ -16,7 +16,6 @@ type FindPetsByStatusSuspenseQueryKey = ReturnType<typeof findPetsByStatusSuspen
 export function findPetsByStatusSuspenseQueryOptions(params?: { status?: FindPetsByStatusQueryStatus }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusSuspenseQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(params, { ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useFindPetsByStatusSuspense<TData = FindPetsByStatusStatus200, T
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByStatusSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByStatusSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByTags.ts
@@ -16,7 +16,6 @@ type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 export function findPetsByTagsQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useFindPetsByTags<TData = FindPetsByTagsStatus200, TQueryData = 
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsQueryKey(params)
-
 
   const query = useQuery({
    ...findPetsByTagsQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByTagsSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useFindPetsByTagsSuspense.ts
@@ -16,7 +16,6 @@ type FindPetsByTagsSuspenseQueryKey = ReturnType<typeof findPetsByTagsSuspenseQu
 export function findPetsByTagsSuspenseQueryOptions(params?: { tags?: FindPetsByTagsQueryTags }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsSuspenseQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(params, { ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useFindPetsByTagsSuspense<TData = FindPetsByTagsStatus200, TQuer
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? findPetsByTagsSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...findPetsByTagsSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetInventory.ts
@@ -16,7 +16,6 @@ type GetInventoryQueryKey = ReturnType<typeof getInventoryQueryKey>
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useGetInventory<TData = GetInventoryStatus200, TQueryData = GetI
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventoryQueryKey()
-
 
   const query = useQuery({
    ...getInventoryQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetInventorySuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetInventorySuspense.ts
@@ -16,7 +16,6 @@ type GetInventorySuspenseQueryKey = ReturnType<typeof getInventorySuspenseQueryK
 export function getInventorySuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventorySuspenseQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useGetInventorySuspense<TData = GetInventoryStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getInventorySuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...getInventorySuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetOrderById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetOrderById.ts
@@ -37,7 +37,6 @@ export function useGetOrderById<TData = GetOrderByIdStatus200, TQueryData = GetO
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
-
   const query = useQuery({
    ...getOrderByIdQueryOptions(orderId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetOrderByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetOrderByIdSuspense.ts
@@ -16,7 +16,6 @@ type GetOrderByIdSuspenseQueryKey = ReturnType<typeof getOrderByIdSuspenseQueryK
 export function getOrderByIdSuspenseQueryOptions(orderId: GetOrderByIdPathOrderId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getOrderByIdSuspenseQueryKey(orderId)
   return queryOptions<GetOrderByIdStatus200, ResponseErrorConfig<GetOrderByIdStatus400 | GetOrderByIdStatus404>, GetOrderByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getOrderById(orderId, { ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useGetOrderByIdSuspense<TData = GetOrderByIdStatus200, TQueryKey
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getOrderByIdSuspenseQueryKey(orderId)
-
 
   const query = useSuspenseQuery({
    ...getOrderByIdSuspenseQueryOptions(orderId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetPetById.ts
@@ -37,7 +37,6 @@ export function useGetPetById<TData = GetPetByIdStatus200, TQueryData = GetPetBy
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
-
   const query = useQuery({
    ...getPetByIdQueryOptions(petId, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetPetByIdSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetPetByIdSuspense.ts
@@ -16,7 +16,6 @@ type GetPetByIdSuspenseQueryKey = ReturnType<typeof getPetByIdSuspenseQueryKey>
 export function getPetByIdSuspenseQueryOptions(petId: GetPetByIdPathPetId, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getPetByIdSuspenseQueryKey(petId)
   return queryOptions<GetPetByIdStatus200, ResponseErrorConfig<GetPetByIdStatus400 | GetPetByIdStatus404>, GetPetByIdStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getPetById(petId, { ...config, signal: config.signal ?? signal })
@@ -36,7 +35,6 @@ export function useGetPetByIdSuspense<TData = GetPetByIdStatus200, TQueryKey ext
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getPetByIdSuspenseQueryKey(petId)
-
 
   const query = useSuspenseQuery({
    ...getPetByIdSuspenseQueryOptions(petId, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetUserByName.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetUserByName.ts
@@ -36,7 +36,6 @@ export function useGetUserByName<TData = GetUserByNameStatus200, TQueryData = Ge
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameQueryKey(username)
 
-
   const query = useQuery({
    ...getUserByNameQueryOptions(username, config),
    ...resolvedOptions,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetUserByNameSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useGetUserByNameSuspense.ts
@@ -16,7 +16,6 @@ type GetUserByNameSuspenseQueryKey = ReturnType<typeof getUserByNameSuspenseQuer
 export function getUserByNameSuspenseQueryOptions(username: GetUserByNamePathUsername, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getUserByNameSuspenseQueryKey(username)
   return queryOptions<GetUserByNameStatus200, ResponseErrorConfig<GetUserByNameStatus400 | GetUserByNameStatus404>, GetUserByNameStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getUserByName(username, { ...config, signal: config.signal ?? signal })
@@ -35,7 +34,6 @@ export function useGetUserByNameSuspense<TData = GetUserByNameStatus200, TQueryK
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? getUserByNameSuspenseQueryKey(username)
-
 
   const query = useSuspenseQuery({
    ...getUserByNameSuspenseQueryOptions(username, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLoginUser.ts
@@ -16,7 +16,6 @@ type LoginUserQueryKey = ReturnType<typeof loginUserQueryKey>
 export function loginUserQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -35,7 +34,6 @@ export function useLoginUser<TData = LoginUserStatus200, TQueryData = LoginUserS
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserQueryKey(params)
-
 
   const query = useQuery({
    ...loginUserQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLoginUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLoginUserSuspense.ts
@@ -16,7 +16,6 @@ type LoginUserSuspenseQueryKey = ReturnType<typeof loginUserSuspenseQueryKey>
 export function loginUserSuspenseQueryOptions(params?: { username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserSuspenseQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(params, { ...config, signal: config.signal ?? signal })
@@ -35,7 +34,6 @@ export function useLoginUserSuspense<TData = LoginUserStatus200, TQueryKey exten
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? loginUserSuspenseQueryKey(params)
-
 
   const query = useSuspenseQuery({
    ...loginUserSuspenseQueryOptions(params, config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLogoutUser.ts
@@ -16,7 +16,6 @@ type LogoutUserQueryKey = ReturnType<typeof logoutUserQueryKey>
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -35,7 +34,6 @@ export function useLogoutUser<TData = LogoutUserResponse, TQueryData = LogoutUse
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserQueryKey()
-
 
   const query = useQuery({
    ...logoutUserQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLogoutUserSuspense.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useLogoutUserSuspense.ts
@@ -16,7 +16,6 @@ type LogoutUserSuspenseQueryKey = ReturnType<typeof logoutUserSuspenseQueryKey>
 export function logoutUserSuspenseQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserSuspenseQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse, typeof queryKey>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })
@@ -35,7 +34,6 @@ export function useLogoutUserSuspense<TData = LogoutUserResponse, TQueryKey exte
   const { query: queryConfig = {}, client: config = {} } = options ?? {}
   const { client: queryClient, ...resolvedOptions } = queryConfig
   const queryKey = resolvedOptions?.queryKey ?? logoutUserSuspenseQueryKey()
-
 
   const query = useSuspenseQuery({
    ...logoutUserSuspenseQueryOptions(config),

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/usePlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/usePlaceOrder.ts
@@ -36,7 +36,6 @@ export function usePlaceOrder<TContext>(options: {
 
   const baseOptions = placeOrderMutationOptions(config) as UseMutationOptions<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>
 
-
   return useMutation<PlaceOrderStatus200, ResponseErrorConfig<PlaceOrderStatus405>, {data?: PlaceOrderData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUpdatePet.ts
@@ -36,7 +36,6 @@ export function useUpdatePet<TContext>(options: {
 
   const baseOptions = updatePetMutationOptions(config) as UseMutationOptions<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>
 
-
   return useMutation<UpdatePetStatus200, ResponseErrorConfig<UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405>, {data: UpdatePetData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUpdatePetWithForm.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUpdatePetWithForm.ts
@@ -35,7 +35,6 @@ export function useUpdatePetWithForm<TContext>(options: {
 
   const baseOptions = updatePetWithFormMutationOptions(config) as UseMutationOptions<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>
 
-
   return useMutation<UpdatePetWithFormResponse, ResponseErrorConfig<UpdatePetWithFormStatus405>, {petId: UpdatePetWithFormPathPetId, params?: { name?: UpdatePetWithFormQueryName; status?: UpdatePetWithFormQueryStatus }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUpdateUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUpdateUser.ts
@@ -36,7 +36,6 @@ export function useUpdateUser<TContext>(options: {
 
   const baseOptions = updateUserMutationOptions(config) as UseMutationOptions<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>
 
-
   return useMutation<UpdateUserResponse, ResponseErrorConfig<Error>, {username: UpdateUserPathUsername, data?: UpdateUserData}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/hooks/useUploadFile.ts
@@ -35,7 +35,6 @@ export function useUploadFile<TContext>(options: {
 
   const baseOptions = uploadFileMutationOptions(config) as UseMutationOptions<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>
 
-
   return useMutation<UploadFileStatus200, ResponseErrorConfig<Error>, {petId: UploadFilePathPetId, data?: UploadFileData, params?: { additionalMetadata?: UploadFileQueryAdditionalMetadata }}, TContext>({
     ...baseOptions,
     mutationKey,

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useLoginUser.ts
@@ -30,7 +30,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/hooks/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/petController/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/petController/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/petController/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/petController/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/storeController/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/storeController/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/userController/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/userController/useLoginUser.ts
@@ -30,7 +30,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/userController/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/hooks/userController/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/hooks/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/hooks/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useLoginUser.ts
@@ -30,7 +30,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/hooks/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useLoginUser.ts
@@ -30,7 +30,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/hooks/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus({ params }: { params?: { status?: FindPet
 export function findPetsByStatusQueryOptions({ params }: { params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }> } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus({ params: toValue(params) }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags({ params }: { params?: { tags?: FindPetsByT
 export function findPetsByTagsQueryOptions({ params }: { params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }> } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags({ params: toValue(params) }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useLoginUser.ts
@@ -30,7 +30,6 @@ export async function loginUser({ params }: { params?: { username?: LoginUserQue
 export function loginUserQueryOptions({ params }: { params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }> } = {}, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser({ params: toValue(params) }, { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/hooks/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useFindPetsByStatus.ts
@@ -32,7 +32,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useFindPetsByTags.ts
@@ -32,7 +32,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useGetInventory.ts
@@ -31,7 +31,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useLoginUser.ts
@@ -31,7 +31,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/hooks/useLogoutUser.ts
@@ -30,7 +30,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useLoginUser.ts
@@ -30,7 +30,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/hooks/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useFindPetsByStatus.ts
@@ -31,7 +31,6 @@ export async function findPetsByStatus(params?: { status?: FindPetsByStatusQuery
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useFindPetsByTags.ts
@@ -31,7 +31,6 @@ export async function findPetsByTags(params?: { tags?: FindPetsByTagsQueryTags }
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useGetInventory.ts
@@ -30,7 +30,6 @@ export async function getInventory(config: Partial<RequestConfig> & { client?: C
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useLoginUser.ts
@@ -30,7 +30,6 @@ export async function loginUser(params?: { username?: LoginUserQueryUsername; pa
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/hooks/useLogoutUser.ts
@@ -29,7 +29,6 @@ export async function logoutUser(config: Partial<RequestConfig> & { client?: Cli
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useFindPetsByStatus.ts
@@ -18,7 +18,6 @@ export type FindPetsByStatusQueryKey = ReturnType<typeof findPetsByStatusQueryKe
 export function findPetsByStatusQueryOptions(params?: MaybeRefOrGetter<{ status?: FindPetsByStatusQueryStatus }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByStatusQueryKey(params)
   return queryOptions<FindPetsByStatusStatus200, ResponseErrorConfig<FindPetsByStatusStatus400>, FindPetsByStatusStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByStatus(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useFindPetsByTags.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useFindPetsByTags.ts
@@ -18,7 +18,6 @@ export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 export function findPetsByTagsQueryOptions(params?: MaybeRefOrGetter<{ tags?: FindPetsByTagsQueryTags }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsStatus200, ResponseErrorConfig<FindPetsByTagsStatus400>, FindPetsByTagsStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return findPetsByTags(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useGetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useGetInventory.ts
@@ -17,7 +17,6 @@ export type GetInventoryQueryKey = ReturnType<typeof getInventoryQueryKey>
 export function getInventoryQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = getInventoryQueryKey()
   return queryOptions<GetInventoryStatus200, ResponseErrorConfig<Error>, GetInventoryStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return getInventory({ ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useLoginUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useLoginUser.ts
@@ -18,7 +18,6 @@ export type LoginUserQueryKey = ReturnType<typeof loginUserQueryKey>
 export function loginUserQueryOptions(params?: MaybeRefOrGetter<{ username?: LoginUserQueryUsername; password?: LoginUserQueryPassword }>, config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = loginUserQueryKey(params)
   return queryOptions<LoginUserStatus200, ResponseErrorConfig<LoginUserStatus400>, LoginUserStatus200>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return loginUser(toValue(params), { ...config, signal: config.signal ?? signal })

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useLogoutUser.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/hooks/useLogoutUser.ts
@@ -17,7 +17,6 @@ export type LogoutUserQueryKey = ReturnType<typeof logoutUserQueryKey>
 export function logoutUserQueryOptions(config: Partial<RequestConfig> & { client?: Client } = {}) {
   const queryKey = logoutUserQueryKey()
   return queryOptions<LogoutUserResponse, ResponseErrorConfig<Error>, LogoutUserResponse>({
-
    queryKey,
    queryFn: async ({ signal }) => {
       return logoutUser({ ...config, signal: config.signal ?? signal })


### PR DESCRIPTION
## Problem

The generated TypeScript still has whitespace defects in the **raw** generator output — what users get before any external formatter runs:

1. **Double blank lines** in mutation/query hooks (e.g. `useUpdatePetWithForm`), between the `baseOptions` block and `return useMutation(...)`.
2. **A stray blank line** right after `return queryOptions<…, typeof queryKey>({` and before `queryKey,` (e.g. `logoutUserQueryOptions`).
3. **Mis-indented MCP handler return** — the `return { content: […], structuredContent: {…} }` object was over-indented.

### Root cause

Function bodies are template literals; at print time `@kubb/parser-ts` runs `dedent()` then re-indents. Empty conditional fragments on their own line (`${enabledText}`, `${customOptions ? … : ''}`) collapse to whitespace-only lines, which become stray/double blanks. The MCP `return {` sat at column 0 while its continuations were indented 12 spaces, so `dedent` (keying off the min indent of 0) left the nested object over-indented.

These were invisible in tests because the snapshot suite runs output through **prettier** (`configs/mocks.ts`), which silently repairs whitespace.

## Fix

- **react-query / vue-query**: fold empty `enabled`/`customOptions` fragments into the adjacent line so they never occupy their own line, and give inserted continuation lines the correct indentation (this also fixes a latent column-0 insert for the `customOptions`-set path).
- **mcp**: re-indent the handler `return { … }` block to the function-body baseline.

## Tests

The prettier-normalized snapshots can't catch raw defects, so `matchFiles` now also asserts the **raw** (pre-prettier) source has no double blank lines and no blank line right after an opening bracket — guarding every generator test centrally, with no per-test boilerplate. The MCP test keeps one targeted indentation assertion (over-indentation trips neither universal guard).

All 709 tests across 35 files pass; lint, typecheck, and oxfmt are clean.

https://claude.ai/code/session_01GRiiKixv1tuAoten6VcBRZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRiiKixv1tuAoten6VcBRZ)_