### PR TITLE
fix(plugins): replace stale v4 barrelType defaults with v5 barrel object

### DIFF
--- a/.changeset/fix-stale-barrel-type-defaults.md
+++ b/.changeset/fix-stale-barrel-type-defaults.md
@@ -1,0 +1,16 @@
+---
+"@kubb/plugin-client": patch
+"@kubb/plugin-cypress": patch
+"@kubb/plugin-faker": patch
+"@kubb/plugin-mcp": patch
+"@kubb/plugin-msw": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-ts": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-zod": patch
+---
+
+Replace the stale v4 `barrelType: 'named'` key in every plugin's `output` destructuring default with the v5 `barrel: { type: 'named' }` object. Generated output is unchanged: `@kubb/middleware-barrel` never read the dead key and already fell back to `{ type: 'named' }`. The code now matches the documented default in each plugin's option docs.
+
+Docs metadata fixes in the same pass: `@kubb/plugin-zod` documents that `importPath` defaults to `'zod/mini'` when `mini` is enabled, and `@kubb/plugin-swr` documents the `parser` default as the boolean `false` instead of the string `'false'`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,6 @@ The `plugins/` directory contains YAML configuration files for each plugin, with
 > - **Generated output:** `packages/<name>/extension.yaml` is produced by `scripts/build-extension-yaml.ts`, which resolves every `extends:` into a self-contained file. **Never edit `packages/*/extension.yaml` by hand.** Your changes are overwritten on the next build.
 > - **Regenerate** after editing any source: `pnpm build:extension-yaml`. Commit both the source and the regenerated `packages/*/extension.yaml`.
 > - **Shared fragments are global:** changing a file under `plugins/_shared/` updates every plugin that `extends` it. Override per-plugin by adding fields next to the `extends:` (they are deep-merged on top of the shared fragment).
-> - **Exception:** `plugin-swr` has no source file in `plugins/` and is not part of the build script, so its `packages/plugin-swr/extension.yaml` is hand-maintained. Edit it directly until a `plugins/plugin-swr.yaml` source is added.
 > - **Keep docs in sync with code:** an option only belongs in the YAML if it exists in that plugin's `src/types.ts` `Options` type and is honored in `src/plugin.ts`. Match documented `default:` values to the destructuring defaults in `plugin.ts`.
 
 ### Examples and tests

--- a/packages/plugin-client/src/plugin.ts
+++ b/packages/plugin-client/src/plugin.ts
@@ -48,7 +48,7 @@ export const pluginClientName = 'plugin-client' satisfies PluginClient['name']
  */
 export const pluginClient = definePlugin<PluginClient>((options) => {
   const {
-    output = { path: 'clients', barrelType: 'named' },
+    output = { path: 'clients', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-cypress/src/plugin.ts
+++ b/packages/plugin-cypress/src/plugin.ts
@@ -36,7 +36,7 @@ export const pluginCypressName = 'plugin-cypress' satisfies PluginCypress['name'
  */
 export const pluginCypress = definePlugin<PluginCypress>((options) => {
   const {
-    output = { path: 'cypress', barrelType: 'named' },
+    output = { path: 'cypress', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-faker/src/plugin.ts
+++ b/packages/plugin-faker/src/plugin.ts
@@ -37,7 +37,7 @@ export const pluginFakerName = 'plugin-faker' satisfies PluginFaker['name']
  */
 export const pluginFaker = definePlugin<PluginFaker>((options) => {
   const {
-    output = { path: 'mocks', barrelType: 'named' },
+    output = { path: 'mocks', barrel: { type: 'named' } },
     seed,
     locale = 'en',
     group,

--- a/packages/plugin-mcp/src/plugin.ts
+++ b/packages/plugin-mcp/src/plugin.ts
@@ -49,7 +49,7 @@ export const pluginMcpName = 'plugin-mcp' satisfies PluginMcp['name']
  */
 export const pluginMcp = definePlugin<PluginMcp>((options) => {
   const {
-    output = { path: 'mcp', barrelType: 'named' },
+    output = { path: 'mcp', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-msw/src/plugin.ts
+++ b/packages/plugin-msw/src/plugin.ts
@@ -40,7 +40,7 @@ export const pluginMswName = 'plugin-msw' satisfies PluginMsw['name']
  */
 export const pluginMsw = definePlugin<PluginMsw>((options) => {
   const {
-    output = { path: 'handlers', barrelType: 'named' },
+    output = { path: 'handlers', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-react-query/src/plugin.ts
+++ b/packages/plugin-react-query/src/plugin.ts
@@ -53,7 +53,7 @@ export const pluginReactQueryName = 'plugin-react-query' satisfies PluginReactQu
  */
 export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
   const {
-    output = { path: 'hooks', barrelType: 'named' },
+    output = { path: 'hooks', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-swr/extension.yaml
+++ b/packages/plugin-swr/extension.yaml
@@ -66,7 +66,7 @@ options:
   - name: parser
     type: "false | 'zod'"
     required: false
-    default: 'false'
+    default: false
     description: |
       Runtime validator applied to the response body before it is returned.
 

--- a/packages/plugin-swr/src/plugin.ts
+++ b/packages/plugin-swr/src/plugin.ts
@@ -16,7 +16,7 @@ export const pluginSwrName = 'plugin-swr' satisfies PluginSwr['name']
 
 export const pluginSwr = definePlugin<PluginSwr>((options) => {
   const {
-    output = { path: 'hooks', barrelType: 'named' },
+    output = { path: 'hooks', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-ts/src/plugin.ts
+++ b/packages/plugin-ts/src/plugin.ts
@@ -36,7 +36,7 @@ export const pluginTsName = 'plugin-ts' satisfies PluginTs['name']
  */
 export const pluginTs = definePlugin<PluginTs>((options) => {
   const {
-    output = { path: 'types', barrelType: 'named' },
+    output = { path: 'types', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-vue-query/src/plugin.ts
+++ b/packages/plugin-vue-query/src/plugin.ts
@@ -45,7 +45,7 @@ export const pluginVueQueryName = 'plugin-vue-query' satisfies PluginVueQuery['n
  */
 export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
   const {
-    output = { path: 'hooks', barrelType: 'named' },
+    output = { path: 'hooks', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-zod/extension.yaml
+++ b/packages/plugin-zod/extension.yaml
@@ -417,11 +417,11 @@ options:
   - name: importPath
     type: string
     required: false
-    default: "'zod'"
+    default: "mini ? 'zod/mini' : 'zod'"
     description: |
       Module specifier used in the `import { z } from '...'` statement at the top of generated files.
 
-      Use `'zod/mini'` to import from the tree-shakeable Mini bundle, or a custom path when re-exporting Zod from your own module.
+      Defaults to `'zod'`, or `'zod/mini'` when the `mini` option is enabled. Set it explicitly to import from a custom path, for example when re-exporting Zod from your own module.
     examples:
       - name: Use Zod's mini bundle
         files:

--- a/packages/plugin-zod/src/plugin.ts
+++ b/packages/plugin-zod/src/plugin.ts
@@ -37,7 +37,7 @@ export const pluginZodName = 'plugin-zod' satisfies PluginZod['name']
  */
 export const pluginZod = definePlugin<PluginZod>((options) => {
   const {
-    output = { path: 'zod', barrelType: 'named' },
+    output = { path: 'zod', barrel: { type: 'named' } },
     group,
     exclude = [],
     include,

--- a/packages/plugin-zod/src/types.ts
+++ b/packages/plugin-zod/src/types.ts
@@ -115,7 +115,7 @@ export type Options = {
    * Module specifier used in the `import { z } from '...'` statement.
    * Use `'zod/mini'` for the tree-shakeable bundle.
    *
-   * @default 'zod'
+   * @default mini ? 'zod/mini' : 'zod'
    */
   importPath?: 'zod' | 'zod/mini' | (string & {})
   /**

--- a/plugins/plugin-swr.yaml
+++ b/plugins/plugin-swr.yaml
@@ -64,7 +64,7 @@ options:
     default: "'inline'"
     description: Defines how pathParams are passed to generated functions.
   - name: parser
-    type: false | 'zod'
+    type: "false | 'zod'"
     required: false
     default: false
     description: |

--- a/plugins/plugin-zod.yaml
+++ b/plugins/plugin-zod.yaml
@@ -68,11 +68,11 @@ options:
   - name: importPath
     type: string
     required: false
-    default: "'zod'"
+    default: "mini ? 'zod/mini' : 'zod'"
     description: |
       Module specifier used in the `import { z } from '...'` statement at the top of generated files.
 
-      Use `'zod/mini'` to import from the tree-shakeable Mini bundle, or a custom path when re-exporting Zod from your own module.
+      Defaults to `'zod'`, or `'zod/mini'` when the `mini` option is enabled. Set it explicitly to import from a custom path, for example when re-exporting Zod from your own module.
     examples:
       - name: Use Zod's mini bundle
         files:

--- a/scripts/build-extension-yaml.ts
+++ b/scripts/build-extension-yaml.ts
@@ -94,6 +94,7 @@ const sourceFiles = [
   'plugin-msw',
   'plugin-react-query',
   'plugin-redoc',
+  'plugin-swr',
   'plugin-ts',
   'plugin-vue-query',
   'plugin-zod',


### PR DESCRIPTION
## What changed

Every plugin's `output` destructuring default in `plugin.ts` still carried the dead v4 `barrelType: 'named'` key. Core v5 only knows `output.barrel` (registry augmentation from `@kubb/middleware-barrel`), and the middleware falls back to `{ type: 'named' }` either way, so generated output is unchanged. The destructuring defaults now read `barrel: { type: 'named' }`, matching the documented default in each plugin's `types.ts` JSDoc and option YAML.

Two docs defaults synced in the same pass:

- `plugins/plugin-zod.yaml` and the `importPath` JSDoc now document the conditional default `mini ? 'zod/mini' : 'zod'` that `plugin.ts` actually uses.
- `packages/plugin-swr/extension.yaml` documents the `parser` default as the boolean `false` instead of the string `'false'`.

`packages/*/extension.yaml` files were regenerated with `pnpm build:extension-yaml`.

## plugin-swr now has a source in `plugins/`

plugin-swr was the only plugin without a `plugins/<name>.yaml` source, so its `extension.yaml` had to be hand-maintained. This PR seeds `plugins/plugin-swr.yaml` from the current file, registers plugin-swr in `scripts/build-extension-yaml.ts`, and drops the exception from AGENTS.md. The regenerated `extension.yaml` is content-identical apart from one normalized quote style, and regeneration is idempotent across all 11 plugins.

## Verification

- `pnpm format` and `pnpm lint` clean
- `pnpm typecheck`: 14/14 packages pass
- `pnpm test`: 899/899 tests pass
- `pnpm build:extension-yaml` regenerates all 11 extension.yaml files with zero drift against the committed output
- Patch changeset included for all 10 plugin packages

Part of a docs-sync effort across kubb, plugins, and platform: kubb-labs/kubb#3504 and kubb-labs/platform#134 (both merged).

https://claude.ai/code/session_013F9Ew8dgT5FMzsgGPrma71