### PR TITLE
fix(plugin-zod): emit cross-file codec input refs as named imports

### DIFF
--- a/.changeset/plugin-zod-codec-ref-named-import.md
+++ b/.changeset/plugin-zod-codec-ref-named-import.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-zod": patch
+---
+
+Fix cross-file input schema refs being emitted as default imports. When a codec schema (e.g. a `date` field with `dateType: 'date'` or `coercion.dates`) is referenced from another file, the generated input import now renders as a named import (`import { recordLocationInputSchema } from './recordLocationSchema'`) instead of a default import, resolving the `TS2613` "Module has no default export" error reported in kubb-labs/kubb#3508.

--- a/packages/plugin-zod/src/generators/zodGenerator.test.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.test.tsx
@@ -5,7 +5,7 @@ import type { Config, Group } from '@kubb/core'
 import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation, renderGeneratorSchema } from '@kubb/core/mocks'
 import { describe, expect, test } from 'vitest'
-import { matchFiles, rawSources } from '#mocks'
+import { matchFiles } from '#mocks'
 import { resolverZod } from '../resolvers/resolverZod.ts'
 import type { PluginZod } from '../types.ts'
 import { zodGenerator } from './zodGenerator.tsx'
@@ -340,52 +340,6 @@ describe('zodGenerator — Schema', () => {
     })
 
     await matchFiles(driver.fileManager.files, 'catCycle')
-  })
-
-  test('codec ref — cross-file input ref renders a named import, not a default import (issue #3508)', async () => {
-    const recordLocationSchema = ast.createSchema({
-      type: 'object',
-      primitive: 'object',
-      name: 'RecordLocation',
-      properties: [
-        ast.createProperty({ name: 'id', required: true, schema: ast.createSchema({ type: 'string' }) }),
-        ast.createProperty({ name: 'reportDate', required: true, schema: ast.createSchema({ type: 'date', representation: 'date', format: 'date' }) }),
-      ],
-    })
-
-    const searchResponseSchema = ast.createSchema({
-      type: 'object',
-      primitive: 'object',
-      name: 'SearchResponse',
-      properties: [
-        ast.createProperty({
-          name: 'records',
-          required: true,
-          schema: ast.createSchema({
-            type: 'array',
-            items: [ast.createSchema({ type: 'ref', name: 'RecordLocation', ref: '#/components/schemas/RecordLocation', schema: recordLocationSchema })],
-          }),
-        }),
-      ],
-    })
-
-    const options: PluginZod['resolvedOptions'] = { ...defaultOptions, coercion: { dates: true } }
-    const plugin = createMockedPlugin<PluginZod>({ name: 'plugin-zod', options, resolver: resolverZod })
-    const driver = createMockedPluginDriver({ name: 'searchResponse' })
-
-    await renderGeneratorSchema(zodGenerator, searchResponseSchema, {
-      config: testConfig,
-      adapter: createMockedAdapter({ resolvedOptions: { dateType: 'date' } }),
-      driver,
-      plugin,
-      options,
-      resolver: resolverZod,
-    })
-
-    const source = rawSources(driver.fileManager.files).join('\n')
-
-    expect(source).toContain('import { recordLocationInputSchema }')
-    expect(source).not.toMatch(/import\s+recordLocationInputSchema\s+from/)
   })
 })
 

--- a/packages/plugin-zod/src/generators/zodGenerator.test.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.test.tsx
@@ -5,7 +5,7 @@ import type { Config, Group } from '@kubb/core'
 import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation, renderGeneratorSchema } from '@kubb/core/mocks'
 import { describe, expect, test } from 'vitest'
-import { matchFiles } from '#mocks'
+import { matchFiles, rawSources } from '#mocks'
 import { resolverZod } from '../resolvers/resolverZod.ts'
 import type { PluginZod } from '../types.ts'
 import { zodGenerator } from './zodGenerator.tsx'
@@ -340,6 +340,52 @@ describe('zodGenerator — Schema', () => {
     })
 
     await matchFiles(driver.fileManager.files, 'catCycle')
+  })
+
+  test('codec ref — cross-file input ref renders a named import, not a default import (issue #3508)', async () => {
+    const recordLocationSchema = ast.createSchema({
+      type: 'object',
+      primitive: 'object',
+      name: 'RecordLocation',
+      properties: [
+        ast.createProperty({ name: 'id', required: true, schema: ast.createSchema({ type: 'string' }) }),
+        ast.createProperty({ name: 'reportDate', required: true, schema: ast.createSchema({ type: 'date', representation: 'date', format: 'date' }) }),
+      ],
+    })
+
+    const searchResponseSchema = ast.createSchema({
+      type: 'object',
+      primitive: 'object',
+      name: 'SearchResponse',
+      properties: [
+        ast.createProperty({
+          name: 'records',
+          required: true,
+          schema: ast.createSchema({
+            type: 'array',
+            items: [ast.createSchema({ type: 'ref', name: 'RecordLocation', ref: '#/components/schemas/RecordLocation', schema: recordLocationSchema })],
+          }),
+        }),
+      ],
+    })
+
+    const options: PluginZod['resolvedOptions'] = { ...defaultOptions, coercion: { dates: true } }
+    const plugin = createMockedPlugin<PluginZod>({ name: 'plugin-zod', options, resolver: resolverZod })
+    const driver = createMockedPluginDriver({ name: 'searchResponse' })
+
+    await renderGeneratorSchema(zodGenerator, searchResponseSchema, {
+      config: testConfig,
+      adapter: createMockedAdapter({ resolvedOptions: { dateType: 'date' } }),
+      driver,
+      plugin,
+      options,
+      resolver: resolverZod,
+    })
+
+    const source = rawSources(driver.fileManager.files).join('\n')
+
+    expect(source).toContain('import { recordLocationInputSchema }')
+    expect(source).not.toMatch(/import\s+recordLocationInputSchema\s+from/)
   })
 })
 

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -86,7 +86,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
     }))
     const inputImportEntries = hasCodec
       ? [...codecRefNames].map((schemaName) => ({
-          name: resolver.resolveInputSchemaName(schemaName),
+          name: [resolver.resolveInputSchemaName(schemaName)],
           path: resolver.resolveFile({ name: schemaName, extname: '.ts' }, { root, output, group: group ?? undefined }).path,
         }))
       : []


### PR DESCRIPTION
## Summary

Fixes kubb-labs/kubb#3508 — input schemas were incorrectly treated as a default export.

When a codec schema (e.g. a `date` field with `dateType: 'date'` or `coercion.dates`) is `$ref`'d from another file, the generated import for its input variant rendered as a **default** import:

```ts
import recordLocationInputSchema, { recordLocationSchema } from './recordLocationSchema'
//     ^ TS2613: Module has no default export
```

instead of the expected named import:

```ts
import { recordLocationInputSchema, recordLocationSchema } from './recordLocationSchema'
```

## Root cause

In `zodGenerator`, output refs go through `adapter.getImports`, which wraps the name in an array (`[result.name]`) via `ast.createImport`. The `inputImportEntries` branch built its objects directly with a **bare string** name. `@kubb/parser-ts` renders a non-array `name` as a default import, while an array renders as named imports. Schema files only have named exports, so the default import broke with `TS2613`.

## Fix

Wrap the resolved input schema name in an array so it renders as a named import, matching how output refs are already handled:

```diff
- name: resolver.resolveInputSchemaName(schemaName),
+ name: [resolver.resolveInputSchemaName(schemaName)],
```

## Testing

- Added a regression test in `zodGenerator.test.tsx` reproducing the `SearchResponse → RecordLocation` codec ref scenario. It fails on `main` (renders a default import) and passes with the fix.
- Full `@kubb/plugin-zod` suite passes (286 tests), plus `lint` and `typecheck` are clean.

A `patch` changeset is included.

https://claude.ai/code/session_01KN2gA4w6DAPwi4hYGaEoUP

---
_Generated by [Claude Code](https://claude.ai/code/session_01KN2gA4w6DAPwi4hYGaEoUP)_