### PR TITLE
fix(tests): restore issue2696 import snapshots and resolve #mocks in vitest configs

### DIFF
--- a/packages/plugin-client/vitest.config.ts
+++ b/packages/plugin-client/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     include: ['./src/**/*.test.{ts,tsx}', './templates/**/*.test.{ts,tsx}'],
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/packages/plugin-faker/vitest.config.ts
+++ b/packages/plugin-faker/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/packages/plugin-react-query/vitest.config.ts
+++ b/packages/plugin-react-query/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/packages/plugin-swr/vitest.config.ts
+++ b/packages/plugin-swr/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/packages/plugin-vue-query/vitest.config.ts
+++ b/packages/plugin-vue-query/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/packages/plugin-zod/vitest.config.ts
+++ b/packages/plugin-zod/vitest.config.ts
@@ -4,4 +4,7 @@ export default defineConfig({
   test: {
     dir: './src',
   },
+  resolve: {
+    tsconfigPaths: true,
+  },
 })

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/AppState.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/AppState.ts
@@ -3,6 +3,9 @@
 * Do not edit manually.
 */
 
+import type { Employer } from './Employer.ts'
+import type { User } from './User.ts'
+
 /**
  * @type object
 */
@@ -10,35 +13,9 @@ export type AppState = {
     /**
      * @type object | undefined
     */
-    currentUser?: {
-        /**
-         * @type string
-        */
-        id: string;
-        /**
-         * @type string
-        */
-        email: string;
-        /**
-         * @type string | undefined
-        */
-        name?: string;
-    };
+    currentUser?: User;
     /**
      * @type array | undefined
     */
-    employers?: {
-        /**
-         * @type string
-        */
-        id: string;
-        /**
-         * @type string
-        */
-        name: string;
-        /**
-         * @type string | undefined
-        */
-        industry?: string;
-    }[];
+    employers?: Employer[];
 };

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/GetEmployers.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/GetEmployers.ts
@@ -3,12 +3,12 @@
 * Do not edit manually.
 */
 
-import type { Items } from './Items.ts'
+import type { Employer } from './Employer.ts'
 
 /**
  * @type array
 */
-export type GetEmployersStatus200 = Items[];
+export type GetEmployersStatus200 = Employer[];
 
 /**
  * @type object

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/GetMe.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/GetMe.ts
@@ -3,12 +3,12 @@
 * Do not edit manually.
 */
 
-import type { CurrentUser } from './CurrentUser.ts'
+import type { User } from './User.ts'
 
 /**
  * @type object
 */
-export type GetMeStatus200 = CurrentUser;
+export type GetMeStatus200 = User;
 
 /**
  * @type object


### PR DESCRIPTION
## 🎯 Changes

Targets `chore/plugin-middleware` so the fixes land in #399.

The `tests/3.0.x/__snapshots__/main/issue2696` snapshots (`AppState.ts`, `GetMe.ts`, `GetEmployers.ts`) go back to importing their referenced types. The inline-type snapshots that landed with the beta.52 bump captured a kubb bundling regression: `@kubb/adapter-oas` stopped hoisting external file refs into named `components.schemas` entries, so generators inlined the shapes. The upstream fix lives in kubb-labs/kubb#3549, which bundles external `$ref`s with `api-ref-bundler`. Linking that build into this workspace, the 3.0.x suites, the root test suite, and the e2e `generate` and `typecheck` all pass with the restored snapshots.

The vitest configs for plugin-client, plugin-faker, plugin-react-query, plugin-swr, plugin-vue-query, and plugin-zod now set `resolve.tsconfigPaths`. Without it, their generator tests can't resolve the `#mocks` alias when run per package with `turbo run test`. This matches plugin-ts, plugin-msw, plugin-mcp, and plugin-cypress, which already had it.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

> [!IMPORTANT]
> The restored `issue2696` snapshots stay red on CI until the catalog in `pnpm-workspace.yaml` moves off `5.0.0-beta.52` (which still has the regression) onto a kubb beta that includes kubb-labs/kubb#3549.

https://claude.ai/code/session_01CdiAoNs8SMHuaKjC8JbUrz