### PR TITLE
refactor(example): use Url from @kubb/core in react-query config

### DIFF
--- a/examples/react-query/kubb.config.ts
+++ b/examples/react-query/kubb.config.ts
@@ -1,8 +1,8 @@
 import { adapterOas } from '@kubb/adapter-oas'
+import { Url } from '@kubb/core'
 import { pluginReactQuery } from '@kubb/plugin-react-query'
 import { pluginTs } from '@kubb/plugin-ts'
 import { defineConfig } from 'kubb'
-import { Url } from '@internals/utils'
 
 function capitalize(name: string): string {
   return `${name.charAt(0).toUpperCase()}${name.slice(1)}`

--- a/examples/react-query/package.json
+++ b/examples/react-query/package.json
@@ -21,8 +21,8 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@internals/utils": "workspace:*",
     "@kubb/adapter-oas": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-client": "workspace:*",
     "@kubb/plugin-react-query": "workspace:*",
     "@kubb/plugin-ts": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,12 +436,12 @@ importers:
 
   examples/react-query:
     dependencies:
-      '@internals/utils':
-        specifier: workspace:*
-        version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
         version: 5.0.0-beta.58(@kubb/renderer-jsx@5.0.0-beta.58)(openapi-types@12.1.3)
+      '@kubb/core':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.58(@kubb/renderer-jsx@5.0.0-beta.58)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client


### PR DESCRIPTION
## Summary

Updates `examples/react-query/kubb.config.ts` to import `Url` from the public `@kubb/core` package instead of the internal `@internals/utils` workspace package.

`@kubb/core` re-exports `Url` (which replaces the old `UrlPath`), so examples should consume it through the public package the same way real consumers do, rather than reaching into an internal workspace package.

## Changes

- `examples/react-query/kubb.config.ts`: import `Url` from `@kubb/core`
- `examples/react-query/package.json`: swap the `@internals/utils` dependency for `@kubb/core` (`catalog:`)
- `pnpm-lock.yaml`: regenerated for the dependency change

## Verification

- `tsc` typechecks the config without errors; the only remaining typecheck errors are pre-existing and unrelated (missing generated `.kubb/client.ts`, which requires `kubb generate`).

https://claude.ai/code/session_017SgCQ9Fc5Ut7JoeAV1NSHB

---
_Generated by [Claude Code](https://claude.ai/code/session_017SgCQ9Fc5Ut7JoeAV1NSHB)_