### PR TITLE
refactor(printers): consume shared schema-traversal helpers from @kubb/ast/utils (#411, 5b)

### DIFF
--- a/.changeset/printer-shared-traversal.md
+++ b/.changeset/printer-shared-traversal.md
@@ -1,0 +1,9 @@
+---
+"@kubb/plugin-faker": patch
+"@kubb/plugin-ts": patch
+"@kubb/plugin-zod": patch
+---
+
+Consume the shared schema-traversal helpers (`mapSchemaProperties`, `mapSchemaMembers`,
+`mapSchemaItems`, `lazyGetter`) from `@kubb/ast/utils` in the zod, zod-mini, faker, and TypeScript
+printers, replacing the per-printer property, member, and item walks. Generated output is unchanged.

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -1,4 +1,4 @@
-import { buildObject, extractRefName, objectKey, stringify, toRegExpString } from '@kubb/ast/utils'
+import { buildObject, extractRefName, mapSchemaItems, mapSchemaMembers, objectKey, stringify, toRegExpString } from '@kubb/ast/utils'
 import { ast } from '@kubb/core'
 import { containsCircularRef } from '@kubb/ast/utils'
 import type { PluginFaker, ResolverFaker } from '../types.ts'
@@ -312,46 +312,46 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         const { discriminatorPropertyName } = node
         const baseTypeName = this.options.typeName
 
-        const items: Array<string> = (node.members ?? [])
-          .map((member) => {
-            // For a discriminated union, narrow each variant to its own branch so nested
-            // `NonNullable<T>[K]` indexes resolve against that branch instead of the whole union.
-            const value = discriminatorPropertyName ? getDiscriminatorValue(member, discriminatorPropertyName) : undefined
+        const items: Array<string> = mapSchemaMembers(node, (member) => {
+          // For a discriminated union, narrow each variant to its own branch so nested
+          // `NonNullable<T>[K]` indexes resolve against that branch instead of the whole union.
+          const value = discriminatorPropertyName ? getDiscriminatorValue(member, discriminatorPropertyName) : undefined
 
-            if (baseTypeName && value !== undefined) {
-              const typeName = `Extract<NonNullable<${baseTypeName}>, { ${JSON.stringify(discriminatorPropertyName)}: ${parseEnumValue(value)} }>`
+          if (baseTypeName && value !== undefined) {
+            const typeName = `Extract<NonNullable<${baseTypeName}>, { ${JSON.stringify(discriminatorPropertyName)}: ${parseEnumValue(value)} }>`
 
-              return printNested(member, { typeName, nestedInObject: true })
-            }
+            return printNested(member, { typeName, nestedInObject: true })
+          }
 
-            // Without a discriminator, keep the union type but guard each indexed access (see
-            // `indexedTypeName`) so a key carried by only some branches resolves to `unknown`
-            // rather than erroring with TS2339.
-            return printNested(member, { typeName: baseTypeName, nestedInObject: true, nestedInUnion: true })
-          })
+          // Without a discriminator, keep the union type but guard each indexed access (see
+          // `indexedTypeName`) so a key carried by only some branches resolves to `unknown`
+          // rather than erroring with TS2339.
+          return printNested(member, { typeName: baseTypeName, nestedInObject: true, nestedInUnion: true })
+        })
+          .map(({ output }) => output)
           .filter((item): item is string => Boolean(item))
 
         return fakerKeywordMapper.union(items)
       },
       intersection(node): string {
-        const items: Array<string> = (node.members ?? [])
-          .map((member) =>
-            printNested(member, {
-              nestedInObject: true,
-            }),
-          )
+        const items: Array<string> = mapSchemaMembers(node, (member) =>
+          printNested(member, {
+            nestedInObject: true,
+          }),
+        )
+          .map(({ output }) => output)
           .filter((item): item is string => Boolean(item))
 
         return fakerKeywordMapper.and(items)
       },
       array(node): string {
-        const items: Array<string> = (node.items ?? [])
-          .map((member) =>
-            printNested(member, {
-              typeName: this.options.typeName ? `NonNullable<${this.options.typeName}>[number]` : undefined,
-              nestedInObject: true,
-            }),
-          )
+        const items: Array<string> = mapSchemaItems(node, (member) =>
+          printNested(member, {
+            typeName: this.options.typeName ? `NonNullable<${this.options.typeName}>[number]` : undefined,
+            nestedInObject: true,
+          }),
+        )
+          .map(({ output }) => output)
           .filter((item): item is string => Boolean(item))
 
         return fakerKeywordMapper.array(items, node.min, node.max)

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -1,4 +1,4 @@
-import { extractRefName } from '@kubb/ast/utils'
+import { extractRefName, mapSchemaItems, mapSchemaProperties } from '@kubb/ast/utils'
 import { ast } from '@kubb/core'
 import { isStringType, syncSchemaRef } from '@kubb/ast/utils'
 import { parserTs } from '@kubb/parser-ts'
@@ -229,7 +229,9 @@ export const printerTs = ast.definePrinter<PrinterTs>((options) => {
         return factory.createIntersectionDeclaration({ withParentheses: true, nodes: factory.buildMemberNodes(node.members, this.transform) }) ?? null
       },
       array(node) {
-        const itemNodes = (node.items ?? []).map((item) => this.transform(item)).filter(isNonNullable)
+        const itemNodes = mapSchemaItems(node, (item) => this.transform(item))
+          .map(({ output }) => output)
+          .filter(isNonNullable)
 
         return factory.createArrayDeclaration({ nodes: itemNodes, arrayType: this.options.arrayType }) ?? null
       },
@@ -241,19 +243,19 @@ export const printerTs = ast.definePrinter<PrinterTs>((options) => {
 
         const addsQuestionToken = OPTIONAL_ADDS_QUESTION_TOKEN.has(options.optionalType)
 
-        const propertyNodes: Array<ts.TypeElement> = node.properties.map((prop) => {
-          const baseType = transform(prop.schema) ?? factory.keywordTypeNodes.unknown
-          const type = factory.buildPropertyType(prop.schema, baseType, options.optionalType)
-          const propMeta = syncSchemaRef(prop.schema)
+        const propertyNodes: Array<ts.TypeElement> = mapSchemaProperties(node, (schema) => transform(schema)).map(({ name, property, output }) => {
+          const baseType = output ?? factory.keywordTypeNodes.unknown
+          const type = factory.buildPropertyType(property.schema, baseType, options.optionalType)
+          const propMeta = syncSchemaRef(property.schema)
 
           const propertyNode = factory.createPropertySignature({
-            questionToken: prop.schema.optional || prop.schema.nullish ? addsQuestionToken : false,
-            name: prop.name,
+            questionToken: property.schema.optional || property.schema.nullish ? addsQuestionToken : false,
+            name,
             type,
             readOnly: propMeta?.readOnly,
           })
 
-          return factory.appendJSDocToNode({ node: propertyNode, comments: buildPropertyJSDocComments(prop.schema) })
+          return factory.appendJSDocToNode({ node: propertyNode, comments: buildPropertyJSDocComments(property.schema) })
         })
 
         const allElements = [...propertyNodes, ...factory.buildIndexSignatures(node, propertyNodes.length, transform)]

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -1,4 +1,4 @@
-import { buildList, buildObject, extractRefName, objectKey, stringify } from '@kubb/ast/utils'
+import { buildList, buildObject, extractRefName, lazyGetter, mapSchemaItems, mapSchemaMembers, mapSchemaProperties, objectKey, stringify } from '@kubb/ast/utils'
 
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
@@ -222,24 +222,22 @@ export const printerZod = ast.definePrinter<PrinterZodFactory>((options) => {
         return resolvedName
       },
       object(node) {
-        const entries = node.properties.map((prop) => {
-          const { name: propName, schema } = prop
+        const isCyclic = (schema: ast.SchemaNode): boolean =>
+          this.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: this.options.cyclicSchemas })
 
-          const meta = syncSchemaRef(schema)
-
-          const isNullable = meta.nullable
-          const isOptional = schema.optional
-          const isNullish = schema.nullish
-
-          const hasSelfRef = this.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: this.options.cyclicSchemas })
-          // Inside a getter the getter itself defers evaluation, so suppress
-          // z.lazy() wrapping on nested refs by temporarily clearing cyclicSchemas.
-          // Save before clearing: this.options === options (same reference via definePrinter),
-          // so reading options.cyclicSchemas after mutation would return undefined.
+        const entries = mapSchemaProperties(node, (schema) => {
+          // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
+          // nested refs by temporarily clearing cyclicSchemas. Save before clearing: this.options
+          // === options (same reference via definePrinter), so reading it after mutation returns undefined.
+          const hasSelfRef = isCyclic(schema)
           const savedCyclicSchemas = this.options.cyclicSchemas
           if (hasSelfRef) this.options.cyclicSchemas = undefined
           const baseOutput = this.transform(schema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
           if (hasSelfRef) this.options.cyclicSchemas = savedCyclicSchemas
+          return baseOutput
+        }).map(({ name: propName, property, output: baseOutput }) => {
+          const { schema } = property
+          const meta = syncSchemaRef(schema)
 
           const wrappedOutput = this.options.wrapOutput ? this.options.wrapOutput({ output: baseOutput, schema }) || baseOutput : baseOutput
 
@@ -250,17 +248,14 @@ export const printerZod = ast.definePrinter<PrinterZodFactory>((options) => {
 
           const value = applyModifiers({
             value: wrappedOutput,
-            nullable: isNullable,
-            optional: isOptional,
-            nullish: isNullish,
+            nullable: meta.nullable,
+            optional: schema.optional,
+            nullish: schema.nullish,
             defaultValue: meta.default,
             description: descriptionToApply,
           })
 
-          if (hasSelfRef) {
-            return `get ${objectKey(propName)}() { return ${value} }`
-          }
-          return `${objectKey(propName)}: ${value}`
+          return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
         })
 
         const objectBase = `z.object(${buildObject(entries)})`
@@ -279,25 +274,25 @@ export const printerZod = ast.definePrinter<PrinterZodFactory>((options) => {
         return result
       },
       array(node) {
-        const items = (node.items ?? []).map((item) => this.transform(item)).filter(Boolean)
+        const items = mapSchemaItems(node, (item) => this.transform(item))
+          .map(({ output }) => output)
+          .filter(Boolean)
         const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
         const base = `z.array(${inner})${lengthConstraints(node)}`
 
         return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
       },
       tuple(node) {
-        const items = (node.items ?? []).map((item) => this.transform(item)).filter(Boolean)
+        const items = mapSchemaItems(node, (item) => this.transform(item))
+          .map(({ output }) => output)
+          .filter(Boolean)
 
         return `z.tuple(${buildList(items)})`
       },
       union(node) {
         const nodeMembers = node.members ?? []
-        const members = nodeMembers
-          .map((memberNode) => {
-            const member = this.transform(memberNode)
-
-            return member && node.strategy === 'one' ? strictOneOfMember(member, memberNode) : member
-          })
+        const members = mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
+          .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema) : output))
           .filter(Boolean)
         if (members.length === 0) return ''
         if (members.length === 1) return members[0]!

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -1,4 +1,14 @@
-import { buildList, buildObject, extractRefName, lazyGetter, mapSchemaItems, mapSchemaMembers, mapSchemaProperties, objectKey, stringify } from '@kubb/ast/utils'
+import {
+  buildList,
+  buildObject,
+  extractRefName,
+  lazyGetter,
+  mapSchemaItems,
+  mapSchemaMembers,
+  mapSchemaProperties,
+  objectKey,
+  stringify,
+} from '@kubb/ast/utils'
 
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -1,4 +1,14 @@
-import { buildList, buildObject, extractRefName, lazyGetter, mapSchemaItems, mapSchemaMembers, mapSchemaProperties, objectKey, stringify } from '@kubb/ast/utils'
+import {
+  buildList,
+  buildObject,
+  extractRefName,
+  lazyGetter,
+  mapSchemaItems,
+  mapSchemaMembers,
+  mapSchemaProperties,
+  objectKey,
+  stringify,
+} from '@kubb/ast/utils'
 
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -1,4 +1,4 @@
-import { buildList, buildObject, extractRefName, objectKey, stringify } from '@kubb/ast/utils'
+import { buildList, buildObject, extractRefName, lazyGetter, mapSchemaItems, mapSchemaMembers, mapSchemaProperties, objectKey, stringify } from '@kubb/ast/utils'
 
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
@@ -172,63 +172,58 @@ export const printerZodMini = ast.definePrinter<PrinterZodMiniFactory>((options)
         return resolvedName
       },
       object(node) {
-        const entries = node.properties.map((prop) => {
-          const { name: propName, schema } = prop
+        const isCyclic = (schema: ast.SchemaNode): boolean =>
+          this.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: this.options.cyclicSchemas })
 
-          const meta = syncSchemaRef(schema)
-
-          const isNullable = meta.nullable
-          const isOptional = schema.optional
-          const isNullish = schema.nullish
-
-          const hasSelfRef = this.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: this.options.cyclicSchemas })
-          // Inside a getter the getter itself defers evaluation, so suppress
-          // z.lazy() wrapping on nested refs by temporarily clearing cyclicSchemas.
-          // Save before clearing: this.options === options (same reference via definePrinter),
-          // so reading options.cyclicSchemas after mutation would return undefined.
+        const entries = mapSchemaProperties(node, (schema) => {
+          // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
+          // nested refs by temporarily clearing cyclicSchemas. Save before clearing: this.options
+          // === options (same reference via definePrinter), so reading it after mutation returns undefined.
+          const hasSelfRef = isCyclic(schema)
           const savedCyclicSchemas = this.options.cyclicSchemas
           if (hasSelfRef) this.options.cyclicSchemas = undefined
           const baseOutput = this.transform(schema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
           if (hasSelfRef) this.options.cyclicSchemas = savedCyclicSchemas
+          return baseOutput
+        }).map(({ name: propName, property, output: baseOutput }) => {
+          const { schema } = property
+          const meta = syncSchemaRef(schema)
 
           const wrappedOutput = this.options.wrapOutput ? this.options.wrapOutput({ output: baseOutput, schema }) || baseOutput : baseOutput
 
           const value = applyMiniModifiers({
             value: wrappedOutput,
-            nullable: isNullable,
-            optional: isOptional,
-            nullish: isNullish,
+            nullable: meta.nullable,
+            optional: schema.optional,
+            nullish: schema.nullish,
             defaultValue: meta.default,
           })
 
-          if (hasSelfRef) {
-            return `get ${objectKey(propName)}() { return ${value} }`
-          }
-          return `${objectKey(propName)}: ${value}`
+          return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
         })
 
         return `z.object(${buildObject(entries)})`
       },
       array(node) {
-        const items = (node.items ?? []).map((item) => this.transform(item)).filter(Boolean)
+        const items = mapSchemaItems(node, (item) => this.transform(item))
+          .map(({ output }) => output)
+          .filter(Boolean)
         const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
         const base = `z.array(${inner})${lengthChecksMini(node)}`
 
         return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
       },
       tuple(node) {
-        const items = (node.items ?? []).map((item) => this.transform(item)).filter(Boolean)
+        const items = mapSchemaItems(node, (item) => this.transform(item))
+          .map(({ output }) => output)
+          .filter(Boolean)
 
         return `z.tuple(${buildList(items)})`
       },
       union(node) {
         const nodeMembers = node.members ?? []
-        const members = nodeMembers
-          .map((memberNode) => {
-            const member = this.transform(memberNode)
-
-            return member && node.strategy === 'one' ? strictOneOfMember(member, memberNode) : member
-          })
+        const members = mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
+          .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema) : output))
           .filter(Boolean)
         if (members.length === 0) return ''
         if (members.length === 1) return members[0]!


### PR DESCRIPTION
Part of kubb-labs/kubb#411 (Epic 5: cross-plugin printer consolidation). This is **5b**, the consumer side of the traversal helpers added in 5a (kubb-labs/kubb#3596, merged). No behavior change: generated output is byte-identical.

## What changed
The zod, zod-mini, faker, and TypeScript printers now walk schemas through the shared helpers from `@kubb/ast/utils` instead of each repeating the same `node.properties` / `node.members` / `node.items` loops:

- `mapSchemaProperties` — object handlers in `printerZod`, `printerZodMini`, `printerTs`.
- `mapSchemaMembers` — union handlers in `printerZod`, `printerZodMini`, `printerFaker`, plus faker's intersection.
- `mapSchemaItems` — array handlers in all four, plus the zod/zod-mini tuple handlers.
- `lazyGetter` — the circular-ref getter string in the zod and zod-mini object handlers.

## What stays as-is (and why)
- **faker `object`** keeps its own loop: it short-circuits per-key on the `mapper` option (so it must not transform eagerly) and emits a memoizing getter (`Object.defineProperty`), not the plain `lazyGetter` form.
- **faker `tuple`** keeps its indexed walk (the item type is `NonNullable<T>[${index}]`, which needs the position).
- **ts `union` / `intersection` / `tuple`** keep `factory.buildMemberNodes` / `factory.buildTupleNode`.

## Verification
Verified against the published `@kubb/ast@5.0.0-beta.60` (which ships the 5a helpers), after merging `main`:

- `pnpm typecheck` — 14/14 packages. The helpers are generic over the output type, so the same traversal serves `string` (zod, faker) and `ts.TypeNode` (ts).
- `pnpm test` — 57 files, 909 tests. The snapshot and e2e suites assert exact generated output, so a green run is the byte-identical gate end to end.
- `pnpm lint` and `oxfmt --check` clean.

## Release coordination
Merged `main` to pick up the beta.60 catalog (which exposes the helpers on `@kubb/ast/utils`) and #413's `createOperationParams` consumer change. No longer release-gated, no conflicts.

https://claude.ai/code/session_01CFh2gpjvENtE1F8f2RhW7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFh2gpjvENtE1F8f2RhW7X)_