### PR TITLE
feat(internals/client): shared generator foundation for the slim client plugins

### DIFF
--- a/internals/client/package.json
+++ b/internals/client/package.json
@@ -1,0 +1,82 @@
+{
+  "name": "@internals/client",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared generator builders and runtime sources for Kubb's slim HTTP client plugins (plugin-fetch, plugin-axios, plugin-ky). Not intended for direct use.",
+  "keywords": [
+    "axios",
+    "client",
+    "fetch",
+    "http-client",
+    "internal",
+    "kubb",
+    "ky",
+    "typescript",
+    "workspace"
+  ],
+  "license": "MIT",
+  "author": "stijnvanhulle",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kubb-labs/plugins.git",
+    "directory": "internals/client"
+  },
+  "files": [
+    "src",
+    "templates",
+    "dist",
+    "!/**/**.test.**",
+    "!/**/__tests__/**",
+    "!/**/__snapshots__/**"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "templates/runtime.source": [
+        "./dist/templates/runtime.source.d.ts"
+      ]
+    }
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./templates/runtime.source": {
+      "import": "./dist/templates/runtime.source.js",
+      "require": "./dist/templates/runtime.source.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "clean": "node -e \"require('node:fs').rmSync('./dist', {recursive:true,force:true})\"",
+    "lint": "oxlint .",
+    "lint:fix": "oxlint --fix .",
+    "start": "tsdown --watch",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@internals/shared": "workspace:*",
+    "@internals/utils": "workspace:*",
+    "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
+    "@kubb/plugin-ts": "workspace:*",
+    "@kubb/plugin-zod": "workspace:*",
+    "@kubb/renderer-jsx": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:"
+  },
+  "peerDependencies": {
+    "@kubb/renderer-jsx": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/internals/client/src/builders/generics.test.ts
+++ b/internals/client/src/builders/generics.test.ts
@@ -1,0 +1,19 @@
+import { ast } from '@kubb/core'
+import { resolverTs } from '@kubb/plugin-ts'
+import { describe, expect, test } from 'vitest'
+import { buildRequestResultGenerics } from './generics.ts'
+
+const node = ast.factory.createOperation({
+  operationId: 'getPetById',
+  method: 'GET',
+  path: '/pet/{petId}',
+  tags: ['pet'],
+  parameters: [ast.factory.createParameter({ name: 'petId', in: 'path', schema: ast.factory.createSchema({ type: 'string' }), required: true })],
+  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
+})
+
+describe('buildRequestResultGenerics', () => {
+  test('names the responses record and threads ThrowOnError', () => {
+    expect(buildRequestResultGenerics({ node, tsResolver: resolverTs })).toBe('GetPetByIdResponses, ThrowOnError')
+  })
+})

--- a/internals/client/src/builders/generics.ts
+++ b/internals/client/src/builders/generics.ts
@@ -1,0 +1,14 @@
+import type { ast } from '@kubb/core'
+import type { ResolverTs } from '@kubb/plugin-ts'
+
+/**
+ * Builds the `RequestResult` generic arguments for one operation: the plugin-ts per-status responses
+ * record plus the per-call `ThrowOnError` flag. `SuccessOf` / `ErrorOf` split the record inside the
+ * runtime, so this only names the record and threads `ThrowOnError`.
+ *
+ * @example
+ * `buildRequestResultGenerics({ node, tsResolver }) // 'AddPetResponses, ThrowOnError'`
+ */
+export function buildRequestResultGenerics({ node, tsResolver }: { node: ast.OperationNode; tsResolver: ResolverTs }): string {
+  return `${tsResolver.resolveResponsesName(node)}, ThrowOnError`
+}

--- a/internals/client/src/builders/parser.test.ts
+++ b/internals/client/src/builders/parser.test.ts
@@ -1,0 +1,39 @@
+import { ast } from '@kubb/core'
+import { resolverZod } from '@kubb/plugin-zod'
+import { describe, expect, test } from 'vitest'
+import { buildZodResponseParse, isParserEnabled, resolveQueryParamsParser, resolveRequestParser, resolveResponseParser } from './parser.ts'
+
+const node = ast.factory.createOperation({
+  operationId: 'addPet',
+  method: 'POST',
+  path: '/pet',
+  tags: ['pet'],
+  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
+})
+
+describe('parser resolvers', () => {
+  test('isParserEnabled tracks every form', () => {
+    expect(isParserEnabled(false)).toBe(false)
+    expect(isParserEnabled('zod')).toBe(true)
+    expect(isParserEnabled({ request: 'zod' })).toBe(true)
+    expect(isParserEnabled({})).toBe(false)
+  })
+
+  test("the 'zod' shorthand maps to response parsing only", () => {
+    expect(resolveResponseParser('zod')).toBe('zod')
+    expect(resolveRequestParser('zod')).toBeNull()
+    expect(resolveQueryParamsParser('zod')).toBeNull()
+  })
+
+  test('the object form opts in per direction', () => {
+    expect(resolveRequestParser({ request: 'zod' })).toBe('zod')
+    expect(resolveQueryParamsParser({ request: 'zod' })).toBe('zod')
+    expect(resolveResponseParser({ response: 'zod' })).toBe('zod')
+  })
+})
+
+describe('buildZodResponseParse', () => {
+  test('resolves the success-only response schema', () => {
+    expect(buildZodResponseParse(node, resolverZod)).toStrictEqual({ expression: 'addPetResponseSchema', importNames: ['addPetResponseSchema'] })
+  })
+})

--- a/internals/client/src/builders/parser.ts
+++ b/internals/client/src/builders/parser.ts
@@ -1,0 +1,64 @@
+import type { ast } from '@kubb/core'
+import type { ResolverZod } from '@kubb/plugin-zod'
+import type { ParserOptions } from '../types.ts'
+
+/**
+ * Returns `true` when any direction of the parser uses zod (used for dependency checks).
+ */
+export function isParserEnabled(parser: ParserOptions | undefined): boolean {
+  if (!parser) return false
+  if (parser === 'zod') return true
+  return Boolean(parser.request || parser.response)
+}
+
+/**
+ * Returns `'zod'` when request body parsing is enabled, `null` otherwise. The string shorthand
+ * `'zod'` validates the response only, so it does not enable request parsing.
+ */
+export function resolveRequestParser(parser: ParserOptions | undefined): 'zod' | null {
+  if (!parser || parser === 'zod') return null
+  return parser.request ?? null
+}
+
+/**
+ * Returns `'zod'` when query-parameters parsing is enabled, `null` otherwise. Only the object form
+ * `{ request: 'zod' }` enables it.
+ */
+export function resolveQueryParamsParser(parser: ParserOptions | undefined): 'zod' | null {
+  if (!parser || parser === 'zod') return null
+  return parser.request ?? null
+}
+
+/**
+ * Returns `'zod'` when response parsing is enabled, `null` otherwise. The string shorthand `'zod'`
+ * maps to response parsing.
+ */
+export function resolveResponseParser(parser: ParserOptions | undefined): 'zod' | null {
+  if (!parser) return null
+  if (parser === 'zod') return 'zod'
+  return parser.response ?? null
+}
+
+/**
+ * The zod validation a generated client applies to a success response body.
+ */
+export type ZodResponseParse = {
+  /**
+   * Expression the generated code calls `.parse(data)` on — the success-only response schema name.
+   */
+  expression: string
+  /**
+   * Schema names the generated file imports from the zod plugin output.
+   */
+  importNames: Array<string>
+}
+
+/**
+ * Resolves the zod expression a generated client validates a success response with. Only success
+ * (2xx) bodies reach the parse under the throw-on-error contract, so the success-only
+ * `<operation>ResponseSchema` is used; error bodies are never zod-parsed.
+ */
+export function buildZodResponseParse(node: ast.OperationNode, zodResolver: ResolverZod): ZodResponseParse | null {
+  const name = zodResolver.resolveResponseName?.(node)
+  return name ? { expression: name, importNames: [name] } : null
+}

--- a/internals/client/src/builders/returnStatement.test.ts
+++ b/internals/client/src/builders/returnStatement.test.ts
@@ -1,0 +1,21 @@
+import { ast } from '@kubb/core'
+import { resolverTs } from '@kubb/plugin-ts'
+import { describe, expect, test } from 'vitest'
+import { buildReturnStatement } from './returnStatement.ts'
+
+const node = ast.factory.createOperation({
+  operationId: 'addPet',
+  method: 'POST',
+  path: '/pet',
+  tags: ['pet'],
+  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
+})
+
+describe('buildReturnStatement', () => {
+  test('forwards the call config and casts to the operation RequestResult', () => {
+    const callConfig = "{ method: 'POST', url: '/pet', ...config }"
+    expect(buildReturnStatement({ node, tsResolver: resolverTs, callConfig })).toBe(
+      "return request({ method: 'POST', url: '/pet', ...config }) as Promise<RequestResult<AddPetResponses, ThrowOnError>>",
+    )
+  })
+})

--- a/internals/client/src/builders/returnStatement.ts
+++ b/internals/client/src/builders/returnStatement.ts
@@ -1,0 +1,15 @@
+import type { ast } from '@kubb/core'
+import type { ResolverTs } from '@kubb/plugin-ts'
+import { buildRequestResultGenerics } from './generics.ts'
+
+/**
+ * Builds the return statement of a generated operation function. The runtime call already resolves
+ * to `{ data, error, request, response }`; the generated code forwards that result and casts it to
+ * the operation's `RequestResult`, which carries the `throwOnError` discrimination.
+ *
+ * @example
+ * `return request({ method: 'POST', url: '/pet', ...config }) as Promise<RequestResult<AddPetResponses, ThrowOnError>>`
+ */
+export function buildReturnStatement({ node, tsResolver, callConfig }: { node: ast.OperationNode; tsResolver: ResolverTs; callConfig: string }): string {
+  return `return request(${callConfig}) as Promise<RequestResult<${buildRequestResultGenerics({ node, tsResolver })}>>`
+}

--- a/internals/client/src/builders/security.test.ts
+++ b/internals/client/src/builders/security.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest'
+import { buildSecurityMetadata } from './security.ts'
+
+describe('buildSecurityMetadata', () => {
+  test('returns null when there are no requirements', () => {
+    expect(buildSecurityMetadata({ security: undefined })).toBeNull()
+    expect(buildSecurityMetadata({ security: [] })).toBeNull()
+  })
+
+  test('serializes a scheme with no scopes', () => {
+    expect(buildSecurityMetadata({ security: [{ bearerAuth: [] }] })).toBe('[{ bearerAuth: [] }]')
+  })
+
+  test('serializes scopes as single-quoted strings', () => {
+    expect(buildSecurityMetadata({ security: [{ oauth2: ['read', 'write'] }] })).toBe("[{ oauth2: ['read', 'write'] }]")
+  })
+
+  test('quotes scheme names that are not valid identifiers', () => {
+    expect(buildSecurityMetadata({ security: [{ 'api-key': [] }] })).toBe("[{ 'api-key': [] }]")
+  })
+
+  test('serializes multiple requirements', () => {
+    expect(buildSecurityMetadata({ security: [{ bearerAuth: [] }, { apiKey: [] }] })).toBe('[{ bearerAuth: [] }, { apiKey: [] }]')
+  })
+})

--- a/internals/client/src/builders/security.ts
+++ b/internals/client/src/builders/security.ts
@@ -1,0 +1,27 @@
+/**
+ * A single OpenAPI security requirement: scheme name to the scopes it needs.
+ */
+export type SecurityRequirement = Record<string, Array<string>>
+
+const identifierPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/
+
+function serializeRequirement(requirement: SecurityRequirement): string {
+  const entries = Object.entries(requirement).map(([scheme, scopes]) => {
+    const key = identifierPattern.test(scheme) ? scheme : `'${scheme}'`
+    return `${key}: [${scopes.map((scope) => `'${scope}'`).join(', ')}]`
+  })
+  return `{ ${entries.join(', ')} }`
+}
+
+/**
+ * Serializes per-operation security requirements into the literal emitted on each generated call's
+ * `security` field. The runtime `resolveAuth` helper consumes it (full wiring lands with #395), so
+ * the requirements come in as a parameter rather than being read off the operation node here.
+ *
+ * @example
+ * `buildSecurityMetadata({ security: [{ bearerAuth: [] }] }) // "[{ bearerAuth: [] }]"`
+ */
+export function buildSecurityMetadata({ security }: { security?: Array<SecurityRequirement> }): string | null {
+  if (!security?.length) return null
+  return `[${security.map(serializeRequirement).join(', ')}]`
+}

--- a/internals/client/src/builders/signature.test.ts
+++ b/internals/client/src/builders/signature.test.ts
@@ -1,0 +1,54 @@
+import { ast } from '@kubb/core'
+import { resolverTs } from '@kubb/plugin-ts'
+import { describe, expect, test } from 'vitest'
+import { buildGroupedOptionsSignature } from './signature.ts'
+
+const addPet = ast.factory.createOperation({
+  operationId: 'addPet',
+  method: 'POST',
+  path: '/pet',
+  tags: ['pet'],
+  requestBody: { content: [{ contentType: 'application/json', schema: ast.factory.createSchema({ type: 'object', properties: [] }) }] },
+  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
+})
+
+const listPets = ast.factory.createOperation({
+  operationId: 'listPets',
+  method: 'GET',
+  path: '/pets',
+  tags: ['pet'],
+  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
+})
+
+describe('buildGroupedOptionsSignature', () => {
+  test('emits a single grouped options parameter with a ThrowOnError generic', () => {
+    const signature = buildGroupedOptionsSignature({ node: addPet, tsResolver: resolverTs })
+    expect(signature.paramsSignature).toBe('options: Options<AddPetData, ThrowOnError>')
+    expect(signature.generics).toStrictEqual(['ThrowOnError extends boolean = true'])
+  })
+
+  test('keys the return type on the plugin-ts per-status responses record', () => {
+    const signature = buildGroupedOptionsSignature({ node: addPet, tsResolver: resolverTs })
+    expect(signature.returnType).toBe('Promise<RequestResult<AddPetResponses, ThrowOnError>>')
+  })
+
+  test('derives the grouped data type from RequestConfig with the contract key names', () => {
+    const signature = buildGroupedOptionsSignature({ node: addPet, tsResolver: resolverTs })
+    expect(signature.dataTypeName).toBe('AddPetData')
+    expect(signature.dataTypeDefinition).toContain("body: AddPetRequestConfig['data']")
+    expect(signature.dataTypeDefinition).toContain("path?: AddPetRequestConfig['pathParams']")
+    expect(signature.dataTypeDefinition).toContain("query?: AddPetRequestConfig['queryParams']")
+    expect(signature.dataTypeDefinition).toContain("headers?: AddPetRequestConfig['headerParams']")
+    expect(signature.dataTypeDefinition).toContain("url: AddPetRequestConfig['url']")
+  })
+
+  test('marks the body optional when the operation has no request body', () => {
+    const signature = buildGroupedOptionsSignature({ node: listPets, tsResolver: resolverTs })
+    expect(signature.dataTypeDefinition).toContain("body?: ListPetsRequestConfig['data']")
+  })
+
+  test('imports only the request-config and responses types', () => {
+    const signature = buildGroupedOptionsSignature({ node: addPet, tsResolver: resolverTs })
+    expect(signature.importedTypeNames).toStrictEqual(['AddPetRequestConfig', 'AddPetResponses'])
+  })
+})

--- a/internals/client/src/builders/signature.ts
+++ b/internals/client/src/builders/signature.ts
@@ -1,6 +1,8 @@
-import type { ast } from '@kubb/core'
-import type { ResolverTs } from '@kubb/plugin-ts'
+import { ast } from '@kubb/core'
+import { functionPrinter, type ResolverTs, renderType } from '@kubb/plugin-ts'
 import { buildRequestResultGenerics } from './generics.ts'
+
+const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 /**
  * The pieces of a generated operation function's grouped-options signature.
@@ -11,7 +13,7 @@ export type GroupedOptionsSignature = {
    */
   dataTypeName: string
   /**
-   * Body of the per-operation grouped data type, with the contract key names
+   * Rendered body of the per-operation grouped data type, with the contract key names
    * (`body` / `path` / `query` / `headers` / `url`) derived from the plugin-ts `<Name>RequestConfig`.
    */
   dataTypeDefinition: string
@@ -38,9 +40,9 @@ export type GroupedOptionsSignature = {
  * carries a literal `url`, and a `RequestResult` return type keyed to the plugin-ts per-status
  * responses record. There are no positional arguments.
  *
- * The grouped data type reuses the plugin-ts `<Name>RequestConfig` through indexed access, so the
- * generated file only imports `<Name>RequestConfig` and `<Name>Responses` and never collides with
- * the per-direction type names.
+ * The grouped data type is an AST type literal whose members index into the plugin-ts
+ * `<Name>RequestConfig`, so the generated file only imports `<Name>RequestConfig` and `<Name>Responses`
+ * and never collides with the per-direction type names.
  */
 export function buildGroupedOptionsSignature({ node, tsResolver }: { node: ast.OperationNode; tsResolver: ResolverTs }): GroupedOptionsSignature {
   const requestConfigName = tsResolver.resolveRequestConfigName(node)
@@ -49,20 +51,30 @@ export function buildGroupedOptionsSignature({ node, tsResolver }: { node: ast.O
   const hasBody = Boolean(node.requestBody?.content?.[0]?.schema)
   const resultGenerics = buildRequestResultGenerics({ node, tsResolver })
 
-  const dataTypeDefinition = [
-    '{',
-    `  body${hasBody ? '' : '?'}: ${requestConfigName}['data']`,
-    `  path?: ${requestConfigName}['pathParams']`,
-    `  query?: ${requestConfigName}['queryParams']`,
-    `  headers?: ${requestConfigName}['headerParams']`,
-    `  url: ${requestConfigName}['url']`,
-    '}',
-  ].join('\n')
+  const indexed = (indexType: string) => ast.factory.createIndexedAccessType({ objectType: requestConfigName, indexType })
+  const dataTypeDefinition = renderType(
+    ast.factory.createTypeLiteral({
+      members: [
+        { name: 'body', type: indexed('data'), optional: !hasBody },
+        { name: 'path', type: indexed('pathParams'), optional: true },
+        { name: 'query', type: indexed('queryParams'), optional: true },
+        { name: 'headers', type: indexed('headerParams'), optional: true },
+        { name: 'url', type: indexed('url'), optional: false },
+      ],
+    }),
+  )
+
+  const paramsSignature =
+    declarationPrinter.print(
+      ast.factory.createFunctionParameters({
+        params: [ast.factory.createFunctionParameter({ name: 'options', type: `Options<${dataTypeName}, ThrowOnError>` })],
+      }),
+    ) ?? ''
 
   return {
     dataTypeName,
     dataTypeDefinition,
-    paramsSignature: `options: Options<${dataTypeName}, ThrowOnError>`,
+    paramsSignature,
     returnType: `Promise<RequestResult<${resultGenerics}>>`,
     generics: ['ThrowOnError extends boolean = true'],
     importedTypeNames: [requestConfigName, responsesName],

--- a/internals/client/src/builders/signature.ts
+++ b/internals/client/src/builders/signature.ts
@@ -1,0 +1,70 @@
+import type { ast } from '@kubb/core'
+import type { ResolverTs } from '@kubb/plugin-ts'
+import { buildRequestResultGenerics } from './generics.ts'
+
+/**
+ * The pieces of a generated operation function's grouped-options signature.
+ */
+export type GroupedOptionsSignature = {
+  /**
+   * Name of the per-operation grouped data type (`<Name>Data`).
+   */
+  dataTypeName: string
+  /**
+   * Body of the per-operation grouped data type, with the contract key names
+   * (`body` / `path` / `query` / `headers` / `url`) derived from the plugin-ts `<Name>RequestConfig`.
+   */
+  dataTypeDefinition: string
+  /**
+   * The single function parameter: `options: Options<<Name>Data, ThrowOnError>`.
+   */
+  paramsSignature: string
+  /**
+   * The function return type: `Promise<RequestResult<<Name>Responses, ThrowOnError>>`.
+   */
+  returnType: string
+  /**
+   * The function generics. One per-call `ThrowOnError` flag, defaulting to `true`.
+   */
+  generics: Array<string>
+  /**
+   * The plugin-ts type names the generated file imports (type-only).
+   */
+  importedTypeNames: Array<string>
+}
+
+/**
+ * Builds the grouped-options signature for one operation: a single `options` object whose `TData`
+ * carries a literal `url`, and a `RequestResult` return type keyed to the plugin-ts per-status
+ * responses record. There are no positional arguments.
+ *
+ * The grouped data type reuses the plugin-ts `<Name>RequestConfig` through indexed access, so the
+ * generated file only imports `<Name>RequestConfig` and `<Name>Responses` and never collides with
+ * the per-direction type names.
+ */
+export function buildGroupedOptionsSignature({ node, tsResolver }: { node: ast.OperationNode; tsResolver: ResolverTs }): GroupedOptionsSignature {
+  const requestConfigName = tsResolver.resolveRequestConfigName(node)
+  const responsesName = tsResolver.resolveResponsesName(node)
+  const dataTypeName = tsResolver.resolveDataName(node)
+  const hasBody = Boolean(node.requestBody?.content?.[0]?.schema)
+  const resultGenerics = buildRequestResultGenerics({ node, tsResolver })
+
+  const dataTypeDefinition = [
+    '{',
+    `  body${hasBody ? '' : '?'}: ${requestConfigName}['data']`,
+    `  path?: ${requestConfigName}['pathParams']`,
+    `  query?: ${requestConfigName}['queryParams']`,
+    `  headers?: ${requestConfigName}['headerParams']`,
+    `  url: ${requestConfigName}['url']`,
+    '}',
+  ].join('\n')
+
+  return {
+    dataTypeName,
+    dataTypeDefinition,
+    paramsSignature: `options: Options<${dataTypeName}, ThrowOnError>`,
+    returnType: `Promise<RequestResult<${resultGenerics}>>`,
+    generics: ['ThrowOnError extends boolean = true'],
+    importedTypeNames: [requestConfigName, responsesName],
+  }
+}

--- a/internals/client/src/builders/validator.test.ts
+++ b/internals/client/src/builders/validator.test.ts
@@ -1,0 +1,44 @@
+import { ast } from '@kubb/core'
+import { resolverZod } from '@kubb/plugin-zod'
+import { describe, expect, test } from 'vitest'
+import { buildValidatorHooks } from './validator.ts'
+
+const addPet = ast.factory.createOperation({
+  operationId: 'addPet',
+  method: 'POST',
+  path: '/pet',
+  tags: ['pet'],
+  requestBody: { content: [{ contentType: 'application/json', schema: ast.factory.createSchema({ type: 'object', properties: [] }) }] },
+  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
+})
+
+describe('buildValidatorHooks', () => {
+  test('emits no validators when the parser is off', () => {
+    expect(buildValidatorHooks({ node: addPet, parser: false, zodResolver: resolverZod })).toStrictEqual({
+      requestValidator: null,
+      responseValidator: null,
+      importedZodNames: [],
+    })
+  })
+
+  test("the 'zod' shorthand wires the response validator only", () => {
+    const hooks = buildValidatorHooks({ node: addPet, parser: 'zod', zodResolver: resolverZod })
+    expect(hooks.requestValidator).toBeNull()
+    expect(hooks.responseValidator).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
+    expect(hooks.importedZodNames).toStrictEqual(['addPetResponseSchema'])
+  })
+
+  test('the object form wires the request validator from the data schema', () => {
+    const hooks = buildValidatorHooks({ node: addPet, parser: { request: 'zod' }, zodResolver: resolverZod })
+    expect(hooks.requestValidator).toBe('(data: unknown) => addPetDataSchema.parse(data)')
+    expect(hooks.responseValidator).toBeNull()
+    expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema'])
+  })
+
+  test('wires both directions when both are enabled', () => {
+    const hooks = buildValidatorHooks({ node: addPet, parser: { request: 'zod', response: 'zod' }, zodResolver: resolverZod })
+    expect(hooks.requestValidator).toBe('(data: unknown) => addPetDataSchema.parse(data)')
+    expect(hooks.responseValidator).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
+    expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema', 'addPetResponseSchema'])
+  })
+})

--- a/internals/client/src/builders/validator.ts
+++ b/internals/client/src/builders/validator.ts
@@ -1,0 +1,52 @@
+import type { ast } from '@kubb/core'
+import type { ResolverZod } from '@kubb/plugin-zod'
+import type { ParserOptions } from '../types.ts'
+import { buildZodResponseParse, resolveRequestParser, resolveResponseParser } from './parser.ts'
+
+/**
+ * The per-call validator expressions a generated function wires into its request config. Both run
+ * through the runtime's `requestValidator` / `responseValidator` hooks rather than inline parse
+ * calls, and the response validator only ever sees success (2xx) bodies.
+ */
+export type ValidatorHooks = {
+  /**
+   * Expression for the `requestValidator` field, or `null` when request parsing is off.
+   */
+  requestValidator: string | null
+  /**
+   * Expression for the `responseValidator` field, or `null` when response parsing is off.
+   */
+  responseValidator: string | null
+  /**
+   * Zod schema names the generated file imports from the zod plugin output.
+   */
+  importedZodNames: Array<string>
+}
+
+/**
+ * Builds the validator-hook expressions for one operation. Request validation runs before the send;
+ * response validation runs on the success body only. Returns `null` expressions when the matching
+ * parser direction is disabled or the schema is absent.
+ */
+export function buildValidatorHooks({
+  node,
+  parser,
+  zodResolver,
+}: {
+  node: ast.OperationNode
+  parser: ParserOptions | undefined
+  zodResolver: ResolverZod | null | undefined
+}): ValidatorHooks {
+  const importedZodNames: Array<string> = []
+
+  const hasRequestBody = Boolean(node.requestBody?.content?.[0]?.schema)
+  const zodRequestName = zodResolver && resolveRequestParser(parser) === 'zod' && hasRequestBody ? zodResolver.resolveDataName?.(node) : null
+  const requestValidator = zodRequestName ? `(data: unknown) => ${zodRequestName}.parse(data)` : null
+  if (zodRequestName) importedZodNames.push(zodRequestName)
+
+  const responseParse = zodResolver && resolveResponseParser(parser) === 'zod' ? buildZodResponseParse(node, zodResolver) : null
+  const responseValidator = responseParse ? `(data: unknown) => ${responseParse.expression}.parse(data)` : null
+  if (responseParse) importedZodNames.push(...responseParse.importNames)
+
+  return { requestValidator, responseValidator, importedZodNames }
+}

--- a/internals/client/src/components/Operation.tsx
+++ b/internals/client/src/components/Operation.tsx
@@ -2,7 +2,7 @@ import { buildOperationComments } from '@internals/shared'
 import { ast } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
-import { File, Function } from '@kubb/renderer-jsx'
+import { File, Function, Type } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import { buildReturnStatement } from '../builders/returnStatement.ts'
 import { buildSecurityMetadata, type SecurityRequirement } from '../builders/security.ts'
@@ -40,8 +40,9 @@ type Props = {
 }
 
 /**
- * Renders one slim client operation: the grouped `<Name>Data` type and the async-free function that
- * forwards a single `options` object to the resolved client and returns the `RequestResult`.
+ * Renders one slim client operation: the grouped `<Name>Data` type and the function that forwards a
+ * single `options` object to the resolved client and returns the `RequestResult`. The type, signature,
+ * and call config are built with the AST factory; only the jsx-renderer emits the source.
  */
 export function Operation({ name, node, tsResolver, zodResolver, parser, security, isExportable = true, isIndexable = true }: Props): KubbReactNode {
   if (!ast.isHttpOperationNode(node)) return null
@@ -63,9 +64,9 @@ export function Operation({ name, node, tsResolver, zodResolver, parser, securit
 
   return (
     <>
-      <File.Source name={signature.dataTypeName} isExportable isIndexable isTypeOnly>
-        {`export type ${signature.dataTypeName} = ${signature.dataTypeDefinition}`}
-      </File.Source>
+      <Type export={isExportable} name={signature.dataTypeName}>
+        {signature.dataTypeDefinition}
+      </Type>
       <br />
       <File.Source name={name} isExportable={isExportable} isIndexable={isIndexable}>
         <Function

--- a/internals/client/src/components/Operation.tsx
+++ b/internals/client/src/components/Operation.tsx
@@ -1,0 +1,86 @@
+import { buildOperationComments } from '@internals/shared'
+import { ast } from '@kubb/core'
+import type { ResolverTs } from '@kubb/plugin-ts'
+import type { ResolverZod } from '@kubb/plugin-zod'
+import { File, Function } from '@kubb/renderer-jsx'
+import type { KubbReactNode } from '@kubb/renderer-jsx/types'
+import { buildReturnStatement } from '../builders/returnStatement.ts'
+import { buildSecurityMetadata, type SecurityRequirement } from '../builders/security.ts'
+import { buildGroupedOptionsSignature } from '../builders/signature.ts'
+import { buildValidatorHooks } from '../builders/validator.ts'
+import type { ParserOptions } from '../types.ts'
+
+type Props = {
+  /**
+   * The generated function name.
+   */
+  name: string
+  /**
+   * The operation being generated.
+   */
+  node: ast.OperationNode
+  /**
+   * Resolver for the plugin-ts type names the signature references.
+   */
+  tsResolver: ResolverTs
+  /**
+   * Resolver for the zod schema names the validators reference, when `parser` is on.
+   */
+  zodResolver?: ResolverZod | null
+  /**
+   * The active parser option, driving the validator-hook wiring.
+   */
+  parser?: ParserOptions
+  /**
+   * Per-operation security requirements, serialized onto the call config (consumed by #395).
+   */
+  security?: Array<SecurityRequirement>
+  isExportable?: boolean
+  isIndexable?: boolean
+}
+
+/**
+ * Renders one slim client operation: the grouped `<Name>Data` type and the async-free function that
+ * forwards a single `options` object to the resolved client and returns the `RequestResult`.
+ */
+export function Operation({ name, node, tsResolver, zodResolver, parser, security, isExportable = true, isIndexable = true }: Props): KubbReactNode {
+  if (!ast.isHttpOperationNode(node)) return null
+
+  const signature = buildGroupedOptionsSignature({ node, tsResolver })
+  const validators = buildValidatorHooks({ node, parser, zodResolver })
+  const securityLiteral = buildSecurityMetadata({ security })
+
+  const callConfig = `{ ${[
+    `method: '${node.method.toUpperCase()}'`,
+    `url: '${node.path}'`,
+    securityLiteral ? `security: ${securityLiteral}` : null,
+    validators.requestValidator ? `requestValidator: ${validators.requestValidator}` : null,
+    validators.responseValidator ? `responseValidator: ${validators.responseValidator}` : null,
+    '...config',
+  ]
+    .filter(Boolean)
+    .join(', ')} }`
+
+  return (
+    <>
+      <File.Source name={signature.dataTypeName} isExportable isIndexable isTypeOnly>
+        {`export type ${signature.dataTypeName} = ${signature.dataTypeDefinition}`}
+      </File.Source>
+      <br />
+      <File.Source name={name} isExportable={isExportable} isIndexable={isIndexable}>
+        <Function
+          name={name}
+          export={isExportable}
+          generics={signature.generics}
+          params={signature.paramsSignature}
+          returnType={signature.returnType}
+          JSDoc={{ comments: buildOperationComments(node, { link: 'urlPath', linkPosition: 'beforeDeprecated', splitLines: true }) }}
+        >
+          {'const { client: request = client, ...config } = options'}
+          <br />
+          {buildReturnStatement({ node, tsResolver, callConfig })}
+        </Function>
+      </File.Source>
+    </>
+  )
+}

--- a/internals/client/src/index.ts
+++ b/internals/client/src/index.ts
@@ -1,0 +1,18 @@
+export { buildRequestResultGenerics } from './builders/generics.ts'
+export {
+  buildZodResponseParse,
+  isParserEnabled,
+  resolveQueryParamsParser,
+  resolveRequestParser,
+  resolveResponseParser,
+  type ZodResponseParse,
+} from './builders/parser.ts'
+export { buildReturnStatement } from './builders/returnStatement.ts'
+export { buildSecurityMetadata, type SecurityRequirement } from './builders/security.ts'
+export { buildGroupedOptionsSignature, type GroupedOptionsSignature } from './builders/signature.ts'
+export { buildValidatorHooks, type ValidatorHooks } from './builders/validator.ts'
+export { Operation } from './components/Operation.tsx'
+export { composeClientRuntime, injectClientRuntime, type InjectClientRuntimeParams, runtimeSource, type TransportDescriptor } from './inject/injectRuntime.ts'
+export { resolveOptions } from './options.ts'
+export { resolverClient } from './resolver.ts'
+export type { Options, ParserOptions, PluginSlimClient, ResolvedOptions, ResolverClient } from './types.ts'

--- a/internals/client/src/index.ts
+++ b/internals/client/src/index.ts
@@ -13,6 +13,7 @@ export { buildGroupedOptionsSignature, type GroupedOptionsSignature } from './bu
 export { buildValidatorHooks, type ValidatorHooks } from './builders/validator.ts'
 export { Operation } from './components/Operation.tsx'
 export { composeClientRuntime, injectClientRuntime, type InjectClientRuntimeParams, runtimeSource, type TransportDescriptor } from './inject/injectRuntime.ts'
+export { defaultMacros } from './macros.ts'
 export { resolveOptions } from './options.ts'
 export { resolverClient } from './resolver.ts'
 export type { Options, ParserOptions, PluginSlimClient, ResolvedOptions, ResolverClient } from './types.ts'

--- a/internals/client/src/inject/injectRuntime.test.ts
+++ b/internals/client/src/inject/injectRuntime.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test, vi } from 'vitest'
+import { composeClientRuntime, injectClientRuntime, runtimeSource } from './injectRuntime.ts'
+
+const transport = {
+  source:
+    'const defaultTransport: Transport = (request) => globalThis.fetch(new Request(request.url))\nexport const client = createClientCore({ defaultTransport })',
+  imports: ["import type { Transport } from './types'"],
+}
+
+describe('runtimeSource', () => {
+  test('inlines the shared runtime core', () => {
+    expect(runtimeSource).toContain('export function createClientCore')
+    expect(runtimeSource).toContain('export class ResponseError')
+  })
+})
+
+describe('composeClientRuntime', () => {
+  test('orders imports, the shared runtime, then the transport prelude', () => {
+    const composed = composeClientRuntime(transport)
+    const importIndex = composed.indexOf(transport.imports[0]!)
+    const runtimeIndex = composed.indexOf('export function createClientCore')
+    const transportIndex = composed.indexOf('const defaultTransport')
+    expect(importIndex).toBeGreaterThanOrEqual(0)
+    expect(importIndex).toBeLessThan(runtimeIndex)
+    expect(runtimeIndex).toBeLessThan(transportIndex)
+  })
+
+  test('omits the imports block when there are none', () => {
+    const composed = composeClientRuntime({ source: 'export const client = null' })
+    expect(composed.startsWith('/**')).toBe(true)
+  })
+})
+
+describe('injectClientRuntime', () => {
+  test('injects the composed runtime at .kubb/client.ts', () => {
+    const injectFile = vi.fn()
+    injectClientRuntime({ injectFile, root: '/out/clients', transport })
+
+    expect(injectFile).toHaveBeenCalledTimes(1)
+    const file = injectFile.mock.calls[0]![0]
+    expect(file.baseName).toBe('client.ts')
+    expect(file.path).toBe('/out/clients/.kubb/client.ts')
+    expect(JSON.stringify(file.sources)).toContain('const defaultTransport')
+    expect(JSON.stringify(file.sources)).toContain('export function createClientCore')
+  })
+})

--- a/internals/client/src/inject/injectRuntime.ts
+++ b/internals/client/src/inject/injectRuntime.ts
@@ -1,0 +1,68 @@
+import path from 'node:path'
+import { ast } from '@kubb/core'
+import type { KubbPluginSetupContext } from '@kubb/core'
+import { source as runtimeSource } from '../templates/runtime.source.ts'
+
+/**
+ * The shared runtime source, inlined as a string at build time. Each slim plugin embeds this into
+ * its generated `.kubb/client.ts` and appends a transport prelude.
+ */
+export { runtimeSource }
+
+/**
+ * The per-plugin half of the runtime. `source` is appended after the shared runtime and must define
+ * `defaultTransport`, then export the default `client` and a `createClient` factory built from it.
+ */
+export type TransportDescriptor = {
+  /**
+   * Source spliced in after the shared runtime. Defines `defaultTransport` and exports
+   * `client` / `createClient`.
+   */
+  source: string
+  /**
+   * Import lines the transport prelude needs at the top of the generated file (e.g.
+   * `import axios from 'axios'`).
+   */
+  imports?: Array<string>
+}
+
+export type InjectClientRuntimeParams = {
+  /**
+   * The plugin setup context's `injectFile`. Passed in rather than the whole context so this stays
+   * pure and unit-testable.
+   */
+  injectFile: KubbPluginSetupContext['injectFile']
+  /**
+   * Absolute path of the plugin's output root. The runtime is written to `<root>/.kubb/client.ts`.
+   */
+  root: string
+  transport: TransportDescriptor
+}
+
+/**
+ * Assembles the final `.kubb/client.ts` body: the transport's imports, then the shared runtime, then
+ * the transport prelude.
+ */
+export function composeClientRuntime(transport: TransportDescriptor): string {
+  const imports = transport.imports?.length ? `${transport.imports.join('\n')}\n\n` : ''
+  return `${imports}${runtimeSource}\n${transport.source}\n`
+}
+
+/**
+ * Injects the composed runtime into the generated output as `.kubb/client.ts`. This is the
+ * always-on bundle path — the slim plugins have no `bundle` option, the runtime is always embedded.
+ */
+export function injectClientRuntime({ injectFile, root, transport }: InjectClientRuntimeParams): void {
+  injectFile({
+    baseName: 'client.ts',
+    path: path.resolve(root, '.kubb/client.ts'),
+    sources: [
+      ast.factory.createSource({
+        name: 'client',
+        nodes: [ast.factory.createText(composeClientRuntime(transport))],
+        isExportable: true,
+        isIndexable: true,
+      }),
+    ],
+  })
+}

--- a/internals/client/src/macros.test.ts
+++ b/internals/client/src/macros.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'vitest'
+import { defaultMacros } from './macros.ts'
+
+describe('defaultMacros', () => {
+  test('ships the simplify-union macro', () => {
+    expect(defaultMacros.map((macro) => macro.name)).toContain('simplify-union')
+  })
+})

--- a/internals/client/src/macros.ts
+++ b/internals/client/src/macros.ts
@@ -1,0 +1,9 @@
+import type { ast } from '@kubb/core'
+import { macroSimplifyUnion } from '@kubb/ast/macros'
+
+/**
+ * Macros the slim client plugins apply by default, ahead of any user macros. `macroSimplifyUnion`
+ * drops union members a broader scalar already covers, keeping the generated response and error
+ * unions tidy. A plugin wires them with `ctx.setMacros([...defaultMacros, ...userMacros])`.
+ */
+export const defaultMacros: ReadonlyArray<ast.Macro> = [macroSimplifyUnion]

--- a/internals/client/src/options.ts
+++ b/internals/client/src/options.ts
@@ -1,0 +1,31 @@
+import { createGroupConfig } from '@internals/shared'
+import { resolverClient } from './resolver.ts'
+import type { Options, ResolvedOptions } from './types.ts'
+
+/**
+ * Applies the slim client defaults to user options. Mirrors the destructuring defaults the plugins
+ * use, so a documented default and the resolved value never drift.
+ */
+export function resolveOptions(options: Options): ResolvedOptions {
+  const {
+    output = { path: 'clients', barrel: { type: 'named' } },
+    exclude = [],
+    include,
+    override = [],
+    baseURL,
+    parser = false,
+    group,
+    resolver: userResolver,
+  } = options
+
+  return {
+    output,
+    exclude,
+    include,
+    override,
+    group: createGroupConfig(group),
+    baseURL,
+    parser,
+    resolver: userResolver ? { ...resolverClient, ...userResolver } : resolverClient,
+  }
+}

--- a/internals/client/src/resolver.ts
+++ b/internals/client/src/resolver.ts
@@ -1,0 +1,32 @@
+import { camelCase, ensureValidVarName, toFilePath } from '@internals/utils'
+import { defineResolver } from '@kubb/core'
+import type { PluginSlimClient } from './types.ts'
+
+/**
+ * Default resolver shared by the slim client plugins. Functions and files use camelCase; URL helpers
+ * get a `get<Operation>Url` name.
+ *
+ * @example
+ * ```ts
+ * resolverClient.resolveName('show pet by id') // 'showPetById'
+ * resolverClient.resolveUrlName(operationNode) // 'getShowPetByIdUrl'
+ * ```
+ */
+export const resolverClient = defineResolver<PluginSlimClient>(() => ({
+  name: 'default',
+  pluginName: 'plugin-slim-client',
+  default(name, type) {
+    if (type === 'file') return toFilePath(name)
+    return ensureValidVarName(camelCase(name))
+  },
+  resolveName(name) {
+    return this.default(name, 'function')
+  },
+  resolvePathName(name, type) {
+    return this.default(name, type)
+  },
+  resolveUrlName(node) {
+    const name = this.resolveName(node.operationId)
+    return `get${name.charAt(0).toUpperCase()}${name.slice(1)}Url`
+  },
+}))

--- a/internals/client/src/templates/runtime.source.ts
+++ b/internals/client/src/templates/runtime.source.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+// @ts-expect-error - import attributes are handled at build time by importAttributeTextPlugin
+import content from '../../templates/runtime.ts' with { type: 'text' }
+
+// At build time `importAttributeTextPlugin` replaces this whole module with the inlined string. The
+// fs fallback only runs when that transform is absent (unit tests against source).
+export const source: string =
+  typeof content === 'string' ? content : readFileSync(fileURLToPath(new URL('../../templates/runtime.ts', import.meta.url)), 'utf-8')

--- a/internals/client/src/types.ts
+++ b/internals/client/src/types.ts
@@ -1,0 +1,98 @@
+import type { ast, Exclude, Generator, Group, Include, Output, OutputOptions, Override, PluginFactoryOptions, Resolver } from '@kubb/core'
+
+/**
+ * Validator applied to request and response bodies using schemas from `@kubb/plugin-zod`.
+ * - `false`: no validation.
+ * - `'zod'`: validates success (2xx) response bodies only.
+ * - `{ request?: 'zod'; response?: 'zod' }`: opt in per direction. `request` validates the request
+ *   body and query parameters before the call; `response` validates the success response body.
+ */
+export type ParserOptions = false | 'zod' | { request?: 'zod'; response?: 'zod' }
+
+/**
+ * The resolver shared by the slim client plugins. Functions and files use camelCase; URL helpers get
+ * a `get<Operation>Url` name.
+ */
+export type ResolverClient = Resolver & {
+  /**
+   * Resolves the function name for a raw operation name.
+   *
+   * @example
+   * `resolver.resolveName('show pet by id') // -> 'showPetById'`
+   */
+  resolveName(this: ResolverClient, name: string): string
+  /**
+   * Resolves the output file name for a generated client module.
+   */
+  resolvePathName(this: ResolverClient, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
+  /**
+   * Resolves the URL helper function name for an operation.
+   *
+   * @example
+   * `resolver.resolveUrlName(node) // -> 'getShowPetByIdUrl'`
+   */
+  resolveUrlName(this: ResolverClient, node: ast.OperationNode): string
+}
+
+/**
+ * The slim, shared options surface for the client plugins. Deliberately small: there is one
+ * response contract and one grouped options object, so the knobs that drove plugin-client's
+ * combinatorial code paths are gone. Each plugin extends this with its own `transport` field.
+ */
+export type Options = OutputOptions & {
+  /**
+   * Skip operations matching at least one entry in the list.
+   */
+  exclude?: Array<Exclude>
+  /**
+   * Restrict generation to operations matching at least one entry in the list.
+   */
+  include?: Array<Include>
+  /**
+   * Apply a different options object to operations matching a pattern.
+   */
+  override?: Array<Override<ResolvedOptions>>
+  /**
+   * Base URL prepended to every request. When omitted, falls back to the adapter's server URL.
+   */
+  baseURL?: string
+  /**
+   * Validate request and response bodies with schemas from `@kubb/plugin-zod`.
+   *
+   * @default false
+   */
+  parser?: ParserOptions
+  /**
+   * Override how names and file paths are built. Methods you omit fall back to the default resolver.
+   */
+  resolver?: Partial<ResolverClient> & ThisType<ResolverClient>
+  /**
+   * Macros applied to each operation node before code is printed.
+   */
+  macros?: Array<ast.Macro>
+  /**
+   * Custom generators that run alongside the built-in client generator.
+   */
+  generators?: Array<Generator<PluginSlimClient>>
+}
+
+/**
+ * The resolved slim options after defaults are applied.
+ */
+export type ResolvedOptions = {
+  output: Output
+  exclude: Array<Exclude>
+  include: Array<Include> | undefined
+  override: Array<Override<ResolvedOptions>>
+  group: Group | null
+  baseURL: Options['baseURL']
+  parser: NonNullable<Options['parser']>
+  resolver: ResolverClient
+}
+
+/**
+ * The plugin factory type shared by the slim client plugins. Each concrete plugin (plugin-fetch,
+ * plugin-axios, plugin-ky) declares its own name and registers itself; this base ties the shared
+ * builders, resolver, and components to one option/resolver shape.
+ */
+export type PluginSlimClient = PluginFactoryOptions<'plugin-slim-client', Options, ResolvedOptions, ResolverClient>

--- a/internals/client/templates/runtime.test.ts
+++ b/internals/client/templates/runtime.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test, vi } from 'vitest'
+import {
+  type CallResult,
+  createClientCore,
+  createInterceptorStack,
+  defaultBodySerializer,
+  defaultQuerySerializer,
+  type ResolvedRequest,
+  ResponseError,
+  resolveAuth,
+  type Transport,
+  type TransportResult,
+} from './runtime.ts'
+
+type FakeResult = Partial<Pick<TransportResult, 'data' | 'status' | 'statusText'>>
+
+function fakeTransport(result: FakeResult = {}) {
+  const calls: Array<ResolvedRequest> = []
+  const transport: Transport<string, string> = async (request) => {
+    calls.push(request)
+    return {
+      data: result.data ?? { ok: true },
+      status: result.status ?? 200,
+      statusText: result.statusText ?? 'OK',
+      headers: new Headers(),
+      request: 'REQ',
+      response: 'RES',
+    }
+  }
+  return { transport, calls }
+}
+
+function createClient(result?: FakeResult) {
+  const { transport, calls } = fakeTransport(result)
+  const client = createClientCore<string, string>({ defaultTransport: transport })
+  return { client, calls }
+}
+
+describe('createInterceptorStack', () => {
+  test('runs interceptors in registration order', async () => {
+    const stack = createInterceptorStack<Array<string>>()
+    stack.use((value) => [...value, 'a'])
+    stack.use((value) => [...value, 'b'])
+    expect(await stack.run([])).toStrictEqual(['a', 'b'])
+  })
+
+  test('eject removes an interceptor by id', async () => {
+    const stack = createInterceptorStack<Array<string>>()
+    const id = stack.use((value) => [...value, 'a'])
+    stack.use((value) => [...value, 'b'])
+    stack.eject(id)
+    expect(await stack.run([])).toStrictEqual(['b'])
+  })
+
+  test('update swaps an interceptor in place without reordering', async () => {
+    const stack = createInterceptorStack<Array<string>>()
+    const id = stack.use((value) => [...value, 'a'])
+    stack.use((value) => [...value, 'b'])
+    stack.update(id, (value) => [...value, 'A'])
+    expect(await stack.run([])).toStrictEqual(['A', 'b'])
+  })
+})
+
+describe('defaultQuerySerializer', () => {
+  test('explodes arrays into repeated keys', () => {
+    expect(defaultQuerySerializer({ tags: ['a', 'b'] })).toBe('tags=a&tags=b')
+  })
+
+  test('serializes nested objects with the deepObject style', () => {
+    expect(defaultQuerySerializer({ filter: { name: 'odie' } })).toBe('filter%5Bname%5D=odie')
+  })
+
+  test('skips undefined and null members', () => {
+    expect(defaultQuerySerializer({ a: 1, b: undefined, c: null })).toBe('a=1')
+  })
+})
+
+describe('defaultBodySerializer', () => {
+  test('JSON-serializes plain objects', () => {
+    expect(defaultBodySerializer({ name: 'odie' })).toBe('{"name":"odie"}')
+  })
+
+  test('passes FormData through untouched', () => {
+    const formData = new FormData()
+    expect(defaultBodySerializer(formData)).toBe(formData)
+  })
+
+  test('encodes form-urlencoded objects as URLSearchParams', () => {
+    const body = defaultBodySerializer({ a: '1' }, 'application/x-www-form-urlencoded')
+    expect(body).toBeInstanceOf(URLSearchParams)
+  })
+})
+
+describe('createClientCore', () => {
+  test('builds the url from method, path interpolation, and query', async () => {
+    const { client, calls } = createClient()
+    await client({ method: 'GET', url: '/pet/{petId}', path: { petId: 7 }, query: { sort: 'name' } })
+    expect(calls[0]?.url).toBe('/pet/7?sort=name')
+    expect(calls[0]?.method).toBe('GET')
+  })
+
+  test('serializes the body and sets Content-Type', async () => {
+    const { client, calls } = createClient()
+    await client({ method: 'POST', url: '/pet', body: { name: 'odie' }, contentType: 'application/json' })
+    expect(calls[0]?.body).toBe('{"name":"odie"}')
+    expect(calls[0]?.headers['Content-Type']).toBe('application/json')
+  })
+
+  test('returns the success shape with data and an undefined error', async () => {
+    const { client } = createClient({ data: { id: 1 }, status: 200 })
+    const result = (await client({ method: 'GET', url: '/pet/1' })) as CallResult<string, string>
+    expect(result).toStrictEqual({ data: { id: 1 }, error: undefined, request: 'REQ', response: 'RES' })
+  })
+
+  test('throws a ResponseError for a non-2xx status by default', async () => {
+    const { client } = createClient({ data: { message: 'invalid' }, status: 405, statusText: 'Method Not Allowed' })
+    await expect(client({ method: 'POST', url: '/pet' })).rejects.toBeInstanceOf(ResponseError)
+    await expect(client({ method: 'POST', url: '/pet' })).rejects.toMatchObject({ status: 405, data: { message: 'invalid' } })
+  })
+
+  test('surfaces a non-2xx body as an error value when throwOnError is false', async () => {
+    const { client } = createClient({ data: { message: 'invalid' }, status: 405 })
+    const result = (await client({ method: 'POST', url: '/pet', throwOnError: false })) as CallResult<string, string>
+    expect(result).toStrictEqual({ data: undefined, error: { message: 'invalid' }, request: 'REQ', response: 'RES' })
+  })
+
+  test('resolves the per-call transport over the default', async () => {
+    const { client } = createClient()
+    const override = fakeTransport({ data: { from: 'override' } })
+    const result = (await client({ method: 'GET', url: '/pet', transport: override.transport })) as CallResult<string, string>
+    expect(override.calls).toHaveLength(1)
+    expect(result.data).toStrictEqual({ from: 'override' })
+  })
+
+  test('runs the request validator before the send and the response validator on success', async () => {
+    const { client, calls } = createClient({ data: { raw: true }, status: 200 })
+    const requestValidator = vi.fn((body: unknown) => ({ ...(body as object), validated: true }))
+    const responseValidator = vi.fn(() => ({ parsed: true }))
+    const result = (await client({ method: 'POST', url: '/pet', body: { name: 'odie' }, requestValidator, responseValidator })) as CallResult<string, string>
+    expect(requestValidator).toHaveBeenCalledTimes(1)
+    expect(calls[0]?.body).toBe('{"name":"odie","validated":true}')
+    expect(result.data).toStrictEqual({ parsed: true })
+  })
+
+  test('skips the response validator on a non-2xx body', async () => {
+    const { client } = createClient({ data: { message: 'invalid' }, status: 405 })
+    const responseValidator = vi.fn((value: unknown) => value)
+    await client({ method: 'POST', url: '/pet', throwOnError: false, responseValidator })
+    expect(responseValidator).not.toHaveBeenCalled()
+  })
+
+  test('runs request and response interceptors', async () => {
+    const { client, calls } = createClient()
+    client.interceptors.request.use((request) => ({ ...request, headers: { ...request.headers, 'X-Trace': '1' } }))
+    const seen: Array<number> = []
+    client.interceptors.response.use((response) => {
+      seen.push(response.status)
+      return response
+    })
+    await client({ method: 'GET', url: '/pet' })
+    expect(calls[0]?.headers['X-Trace']).toBe('1')
+    expect(seen).toStrictEqual([200])
+  })
+
+  test('runs the error interceptor before throwing', async () => {
+    const { client } = createClient({ status: 500 })
+    const onError = vi.fn((error: ResponseError<unknown, string, string>) => error)
+    client.interceptors.error.use(onError)
+    await expect(client({ method: 'GET', url: '/pet' })).rejects.toBeInstanceOf(ResponseError)
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  test('setConfig merges and getConfig reflects it', () => {
+    const { client } = createClient()
+    client.setConfig({ baseURL: 'https://example.com' })
+    expect(client.getConfig().baseURL).toBe('https://example.com')
+  })
+
+  test('createClient produces an instance with isolated interceptors', () => {
+    const { client } = createClient()
+    const child = client.createClient()
+    child.interceptors.request.use((request) => request)
+    expect(child).not.toBe(client)
+  })
+})
+
+describe('resolveAuth', () => {
+  test('places a bearer token on the Authorization header', async () => {
+    const headers: Record<string, string> = {}
+    await resolveAuth({
+      security: [{ bearerAuth: [] }],
+      schemes: { bearerAuth: { type: 'http', scheme: 'bearer' } },
+      auth: () => 'token-123',
+      headers,
+      query: {},
+    })
+    expect(headers.Authorization).toBe('Bearer token-123')
+  })
+
+  test('encodes basic credentials', async () => {
+    const headers: Record<string, string> = {}
+    await resolveAuth({
+      security: [{ basicAuth: [] }],
+      schemes: { basicAuth: { type: 'http', scheme: 'basic' } },
+      auth: () => ({ username: 'user', password: 'pass' }),
+      headers,
+      query: {},
+    })
+    expect(headers.Authorization).toBe(`Basic ${btoa('user:pass')}`)
+  })
+
+  test('places an api key in the configured location', async () => {
+    const headers: Record<string, string> = {}
+    const query: Record<string, unknown> = {}
+    await resolveAuth({
+      security: [{ apiKey: [] }],
+      schemes: { apiKey: { type: 'apiKey', name: 'X-API-Key', in: 'header' } },
+      auth: () => 'secret',
+      headers,
+      query,
+    })
+    expect(headers['X-API-Key']).toBe('secret')
+    expect(query).toStrictEqual({})
+  })
+
+  test('does nothing without an auth callback', async () => {
+    const headers: Record<string, string> = {}
+    await resolveAuth({ security: [{ bearerAuth: [] }], schemes: {}, auth: undefined, headers, query: {} })
+    expect(headers).toStrictEqual({})
+  })
+})

--- a/internals/client/templates/runtime.ts
+++ b/internals/client/templates/runtime.ts
@@ -1,0 +1,481 @@
+/**
+ * Shared HTTP client runtime for the slim Kubb client plugins (plugin-fetch, plugin-axios,
+ * plugin-ky). It is injected once into the generated output as `.kubb/client.ts`; each plugin
+ * appends a small transport prelude that supplies the actual HTTP send and exports the default
+ * `client` / `createClient`.
+ *
+ * Everything here is transport-agnostic. The native request and response objects flow through as
+ * generic parameters (`TRequest` / `TResponse`, defaulting to `Request` / `Response`) so the axios
+ * and ky plugins can specialize them without touching this core.
+ */
+
+/**
+ * HTTP status codes treated as a success. A resolved call only ever carries a body from one of
+ * these; everything else is an error (thrown by default, or surfaced on `error`).
+ */
+export type SuccessStatusCode = '200' | '201' | '202' | '203' | '204' | '205' | '206' | '207' | '208' | '226'
+
+/**
+ * The success members of a per-status responses record (`{ '200': ...; '404': ... }`).
+ */
+export type SuccessOf<TResponses> = TResponses[Extract<keyof TResponses, SuccessStatusCode>]
+
+/**
+ * The error members of a per-status responses record — every documented status that is not a 2xx.
+ */
+export type ErrorOf<TResponses> = TResponses[Exclude<keyof TResponses, SuccessStatusCode>]
+
+/**
+ * The single shape every generated function returns. With `throwOnError` (the default) a resolved
+ * call always means success, so `data` is defined and `error` is `undefined`. Without it the result
+ * is discriminated by `error`, so narrowing on `error` narrows `data`.
+ */
+export type RequestResult<TResponses, ThrowOnError extends boolean = true, TRequest = Request, TResponse = Response> = ThrowOnError extends true
+  ? { data: SuccessOf<TResponses>; error: undefined; request: TRequest; response: TResponse }
+  : ({ data: SuccessOf<TResponses>; error: undefined } | { data: undefined; error: ErrorOf<TResponses> }) & { request: TRequest; response: TResponse }
+
+/**
+ * The data-shaped keys of the grouped options object. `Options` subtracts these from the runtime
+ * `RequestConfig` and adds them back, typed per operation, from the plugin-ts `<Name>Data` type.
+ */
+export type DataShape = { body?: unknown; headers?: unknown; path?: unknown; query?: unknown; url: string }
+
+export type HeaderValue = string | number | boolean | null | undefined | object
+export type HeadersInit = Array<[string, HeaderValue]> | Record<string, HeaderValue>
+export type RequestCredentials = 'omit' | 'same-origin' | 'include'
+export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
+
+/**
+ * Serializes the query object into a search string. Array and object members follow the configured
+ * style (`form` with `explode` by default; `deepObject` for nested objects).
+ */
+export type QuerySerializer = (params: Record<string, unknown>) => string
+
+/**
+ * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
+ * `ArrayBuffer`, and string bodies pass through untouched.
+ */
+export type BodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * Validates a value before it is sent or after it is received, returning the (optionally
+ * transformed) value. Used to wire zod parsing through `requestValidator` / `responseValidator`.
+ */
+export type Validator<T = unknown> = (value: T) => T | Promise<T>
+
+/**
+ * A single OpenAPI security requirement: scheme name to the scopes it needs.
+ */
+export type SecurityRequirement = Record<string, Array<string>>
+
+/**
+ * A resolved security scheme, narrowed to the kinds the runtime can place on a request.
+ */
+export type SecurityScheme = { type: 'http'; scheme: 'bearer' } | { type: 'http'; scheme: 'basic' } | { type: 'apiKey'; name: string; in: 'header' | 'query' }
+
+/**
+ * Credential a consumer returns for a scheme. A string is used directly (bearer token, api key);
+ * the object form is encoded as HTTP basic credentials.
+ */
+export type AuthCredential = string | { username: string; password: string } | undefined
+
+/**
+ * Resolves the credential for a security scheme. Called once per scheme on a guarded operation.
+ */
+export type AuthCallback = (params: { schemeName: string; scopes: Array<string> }) => AuthCredential | Promise<AuthCredential>
+
+/**
+ * The request a generated function hands to the runtime. `body` / `headers` / `path` / `query` come
+ * from the grouped options; everything else is plain request configuration.
+ */
+export type RequestConfig<TData = unknown, TRequest = Request, TResponse = Response> = {
+  baseURL?: string
+  url?: string
+  method?: 'GET' | 'PUT' | 'PATCH' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD'
+  path?: Record<string, unknown>
+  query?: unknown
+  params?: unknown
+  body?: TData
+  data?: TData
+  headers?: HeadersInit
+  signal?: AbortSignal
+  credentials?: RequestCredentials
+  contentType?: string
+  responseType?: ResponseType
+  throwOnError?: boolean
+  client?: ClientInstance<TRequest, TResponse>
+  transport?: Transport<TRequest, TResponse>
+  querySerializer?: QuerySerializer
+  bodySerializer?: BodySerializer
+  requestValidator?: Validator
+  responseValidator?: Validator
+  security?: Array<SecurityRequirement>
+  schemes?: Record<string, SecurityScheme>
+  auth?: AuthCallback
+}
+
+/**
+ * The grouped options object passed to every generated function: the request config minus the
+ * data-shaped keys, plus the per-operation `<Name>Data` (minus its literal `url`).
+ */
+export type Options<TData extends DataShape, ThrowOnError extends boolean = true, TRequest = Request, TResponse = Response> = Omit<
+  RequestConfig<unknown, TRequest, TResponse>,
+  keyof DataShape
+> &
+  Omit<TData, 'url'> & {
+    client?: ClientInstance<TRequest, TResponse>
+    throwOnError?: ThrowOnError
+  }
+
+/**
+ * Client-level configuration shared by every call an instance makes. Per-call `RequestConfig`
+ * overrides these.
+ */
+export type ClientConfig<TRequest = Request, TResponse = Response> = {
+  baseURL?: string
+  headers?: HeadersInit
+  credentials?: RequestCredentials
+  throwOnError?: boolean
+  transport?: Transport<TRequest, TResponse>
+  querySerializer?: QuerySerializer
+  bodySerializer?: BodySerializer
+  schemes?: Record<string, SecurityScheme>
+  auth?: AuthCallback
+}
+
+/**
+ * The normalized request the transport receives. The shared core does all serialization, auth, and
+ * header work; the transport only performs the send.
+ */
+export type ResolvedRequest = {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body?: BodyInit
+  signal?: AbortSignal
+  credentials?: RequestCredentials
+  responseType?: ResponseType
+}
+
+/**
+ * What a transport returns: the parsed body plus the native request/response objects, kept reachable
+ * so status, headers, and the raw body never have to grow the result type.
+ */
+export type TransportResult<TData = unknown, TRequest = Request, TResponse = Response> = {
+  data: TData
+  status: number
+  statusText: string
+  headers: Headers
+  request: TRequest
+  response: TResponse
+}
+
+/**
+ * The per-plugin send. plugin-fetch wraps `globalThis.fetch`, plugin-axios an axios instance, and
+ * plugin-ky a ky instance. Supplied to `createClientCore` as `defaultTransport`.
+ */
+export type Transport<TRequest = Request, TResponse = Response> = (request: ResolvedRequest) => Promise<TransportResult<unknown, TRequest, TResponse>>
+
+/**
+ * The result a resolved call produces before it is cast to `RequestResult` by the generated wrapper.
+ */
+export type CallResult<TRequest = Request, TResponse = Response> = {
+  data: unknown
+  error: unknown
+  request: TRequest
+  response: TResponse
+}
+
+/**
+ * A registered interceptor with its ejection id.
+ */
+export type InterceptorFn<T> = (value: T) => T | Promise<T>
+
+/**
+ * A single interceptor channel — request, response, or error — with a transport-agnostic
+ * `use` / `eject` / `update` API.
+ */
+export type InterceptorStack<T> = {
+  use: (fn: InterceptorFn<T>) => number
+  eject: (id: number) => void
+  update: (id: number, fn: InterceptorFn<T>) => void
+  run: (value: T) => Promise<T>
+}
+
+/**
+ * The three interceptor channels every client instance exposes.
+ */
+export type Interceptors<TRequest = Request, TResponse = Response> = {
+  request: InterceptorStack<ResolvedRequest>
+  response: InterceptorStack<TransportResult<unknown, TRequest, TResponse>>
+  error: InterceptorStack<ResponseError<unknown, TRequest, TResponse>>
+}
+
+/**
+ * A client instance: the callable send plus configuration, interceptors, and an isolated
+ * `createClient` factory bound to the same transport.
+ */
+export type ClientInstance<TRequest = Request, TResponse = Response> = {
+  <TData = unknown>(config: RequestConfig<TData, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>>
+  getConfig: () => ClientConfig<TRequest, TResponse>
+  setConfig: (config: ClientConfig<TRequest, TResponse>) => ClientConfig<TRequest, TResponse>
+  interceptors: Interceptors<TRequest, TResponse>
+  createClient: (config?: ClientConfig<TRequest, TResponse>) => ClientInstance<TRequest, TResponse>
+}
+
+/**
+ * Thrown for responses outside the 2xx range, so a resolved call always means success. The parsed
+ * error body and the native request/response stay reachable on the error.
+ */
+export class ResponseError<TError = unknown, TRequest = Request, TResponse = Response> extends Error {
+  data: TError
+  status: number
+  statusText: string
+  request: TRequest
+  response: TResponse
+
+  constructor(config: { data: TError; status: number; statusText: string; request: TRequest; response: TResponse }) {
+    super(`Request failed with status ${config.status}${config.statusText ? ` ${config.statusText}` : ''}`)
+    this.name = 'ResponseError'
+    this.data = config.data
+    this.status = config.status
+    this.statusText = config.statusText
+    this.request = config.request
+    this.response = config.response
+  }
+}
+
+export type ResponseErrorConfig<TError = unknown> = ResponseError<TError>
+
+function isFormBody(body: unknown): body is BodyInit {
+  return (
+    body instanceof FormData ||
+    body instanceof URLSearchParams ||
+    body instanceof Blob ||
+    body instanceof ArrayBuffer ||
+    ArrayBuffer.isView(body) ||
+    typeof body === 'string'
+  )
+}
+
+/**
+ * Default body serializer: passes binary/form bodies through and JSON-serializes everything else.
+ * For `application/x-www-form-urlencoded` plain objects become `URLSearchParams`.
+ */
+export const defaultBodySerializer: BodySerializer = (body, contentType) => {
+  if (body === undefined || body === null) return undefined
+  if (isFormBody(body)) return body as BodyInit
+  if (contentType?.includes('application/x-www-form-urlencoded')) {
+    return new URLSearchParams(body as Record<string, string>)
+  }
+  return JSON.stringify(body)
+}
+
+function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+  if (value === undefined || value === null) return
+  if (Array.isArray(value)) {
+    for (const item of value) appendQueryValue(search, key, item)
+    return
+  }
+  if (typeof value === 'object') {
+    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    }
+    return
+  }
+  search.append(key, String(value))
+}
+
+/**
+ * Default query serializer: arrays explode into repeated keys and nested objects use the
+ * `deepObject` style (`key[prop]=value`).
+ */
+export const defaultQuerySerializer: QuerySerializer = (params) => {
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(params)) {
+    appendQueryValue(search, key, value)
+  }
+  return search.toString()
+}
+
+function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) return {}
+  const entries = Array.isArray(headers) ? headers : Object.entries(headers)
+  const result: Record<string, string> = {}
+  for (const [key, value] of entries) {
+    if (value === undefined || value === null) continue
+    result[key] = typeof value === 'string' ? value : typeof value === 'object' ? JSON.stringify(value) : String(value)
+  }
+  return result
+}
+
+function mergeHeaders(...sources: Array<HeadersInit | undefined>): Record<string, string> {
+  return Object.assign({}, ...sources.map(serializeHeaders))
+}
+
+/**
+ * Creates a transport-agnostic interceptor channel. Interceptors run in registration order; `eject`
+ * removes one by id and `update` swaps its function in place without reordering.
+ */
+export function createInterceptorStack<T>(): InterceptorStack<T> {
+  let entries: Array<{ id: number; fn: InterceptorFn<T> }> = []
+  let counter = 0
+  return {
+    use(fn) {
+      const id = ++counter
+      entries.push({ id, fn })
+      return id
+    },
+    eject(id) {
+      entries = entries.filter((entry) => entry.id !== id)
+    },
+    update(id, fn) {
+      const entry = entries.find((item) => item.id === id)
+      if (entry) entry.fn = fn
+    },
+    async run(value) {
+      let result = value
+      for (const entry of entries) {
+        result = await entry.fn(result)
+      }
+      return result
+    },
+  }
+}
+
+/**
+ * Walks the per-operation security requirements and places each resolved credential on the request,
+ * mutating `headers` / `query` in place. Schemes with no resolved credential are skipped, and a
+ * requirement is satisfied as soon as one of its schemes resolves.
+ */
+export async function resolveAuth(params: {
+  security: Array<SecurityRequirement> | undefined
+  schemes: Record<string, SecurityScheme> | undefined
+  auth: AuthCallback | undefined
+  headers: Record<string, string>
+  query: Record<string, unknown>
+}): Promise<void> {
+  const { security, schemes, auth, headers, query } = params
+  if (!security?.length || !auth) return
+
+  for (const requirement of security) {
+    let satisfied = false
+    for (const [schemeName, scopes] of Object.entries(requirement)) {
+      const credential = await auth({ schemeName, scopes })
+      if (credential === undefined) continue
+
+      const scheme = schemes?.[schemeName]
+      if (scheme?.type === 'apiKey') {
+        if (scheme.in === 'query') query[scheme.name] = credential as string
+        else headers[scheme.name] = credential as string
+      } else if (scheme?.type === 'http' && scheme.scheme === 'basic' && typeof credential === 'object') {
+        headers.Authorization = `Basic ${btoa(`${credential.username}:${credential.password}`)}`
+      } else {
+        headers.Authorization = `Bearer ${credential as string}`
+      }
+      satisfied = true
+    }
+    if (satisfied) break
+  }
+}
+
+async function runValidator<T>(validator: Validator | undefined, value: T): Promise<T> {
+  if (!validator) return value
+  return (await validator(value)) as T
+}
+
+/**
+ * Builds the shared client core bound to a transport. Each plugin calls this with its
+ * `defaultTransport` and exports the resulting instance as `client`, plus a `createClient` factory.
+ */
+export function createClientCore<TRequest = Request, TResponse = Response>(
+  options: { defaultTransport: Transport<TRequest, TResponse> } & ClientConfig<TRequest, TResponse>,
+): ClientInstance<TRequest, TResponse> {
+  const { defaultTransport, ...initialConfig } = options
+  let config: ClientConfig<TRequest, TResponse> = { ...initialConfig }
+
+  const interceptors: Interceptors<TRequest, TResponse> = {
+    request: createInterceptorStack<ResolvedRequest>(),
+    response: createInterceptorStack<TransportResult<unknown, TRequest, TResponse>>(),
+    error: createInterceptorStack<ResponseError<unknown, TRequest, TResponse>>(),
+  }
+
+  const client = (async <TData = unknown>(requestConfig: RequestConfig<TData, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
+    const transport = requestConfig.transport ?? config.transport ?? defaultTransport
+    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
+
+    const headers = mergeHeaders(config.headers, requestConfig.headers)
+    if (requestConfig.contentType && requestConfig.contentType !== 'multipart/form-data') {
+      headers['Content-Type'] = requestConfig.contentType
+    }
+
+    const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
+
+    await resolveAuth({
+      security: requestConfig.security,
+      schemes: requestConfig.schemes ?? config.schemes,
+      auth: requestConfig.auth ?? config.auth,
+      headers,
+      query,
+    })
+
+    const rawBody = requestConfig.body ?? requestConfig.data
+    const validatedBody = await runValidator(requestConfig.requestValidator, rawBody)
+    const search = querySerializer(query)
+    const pathParams = requestConfig.path ?? {}
+    const interpolatedUrl = [config.baseURL, requestConfig.baseURL, requestConfig.url]
+      .filter(Boolean)
+      .join('')
+      .replace(/\{([^{}]+)\}/g, (_, key: string) => encodeURIComponent(String(pathParams[key] ?? '')))
+    const url = interpolatedUrl + (search ? `?${search}` : '')
+
+    let resolvedRequest: ResolvedRequest = {
+      url,
+      method: (requestConfig.method ?? 'GET').toUpperCase(),
+      headers,
+      body: bodySerializer(validatedBody, headers['Content-Type'] ?? headers['content-type']),
+      signal: requestConfig.signal,
+      credentials: requestConfig.credentials,
+      responseType: requestConfig.responseType,
+    }
+    resolvedRequest = await interceptors.request.run(resolvedRequest)
+
+    let result = await transport(resolvedRequest)
+    result = await interceptors.response.run(result)
+
+    const isSuccess = result.status >= 200 && result.status < 300
+    const throwOnError = requestConfig.throwOnError ?? config.throwOnError ?? true
+
+    if (!isSuccess && throwOnError) {
+      const error = new ResponseError({
+        data: result.data,
+        status: result.status,
+        statusText: result.statusText,
+        request: result.request,
+        response: result.response,
+      })
+      await interceptors.error.run(error)
+      throw error
+    }
+
+    const data = isSuccess ? await runValidator(requestConfig.responseValidator, result.data) : undefined
+
+    return {
+      data,
+      error: isSuccess ? undefined : result.data,
+      request: result.request,
+      response: result.response,
+    }
+  }) as ClientInstance<TRequest, TResponse>
+
+  client.getConfig = () => config
+  client.setConfig = (next) => {
+    config = { ...config, ...next, headers: { ...serializeHeaders(config.headers), ...serializeHeaders(next.headers) } }
+    return config
+  }
+  client.interceptors = interceptors
+  client.createClient = (next) => createClientCore({ defaultTransport, ...config, ...next })
+
+  return client
+}

--- a/internals/client/tsconfig.json
+++ b/internals/client/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@kubb/renderer-jsx",
+    "types": ["bun-types", "../../reset.d.ts"]
+  },
+  "include": ["src/**/*", "templates/**/*", "./package.json", "./tsdown.config.ts", "./vitest.config.ts"]
+}

--- a/internals/client/tsdown.config.ts
+++ b/internals/client/tsdown.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, type UserConfig } from 'tsdown'
+import { importAttributeTextPlugin } from '../../configs/importAttributeTextPlugin.ts'
+
+const entry = {
+  index: 'src/index.ts',
+  'templates/runtime.source': 'src/templates/runtime.source.ts',
+}
+
+const shared: Partial<UserConfig> = {
+  plugins: [importAttributeTextPlugin()],
+  platform: 'node',
+  sourcemap: true,
+  shims: true,
+  exports: true,
+  fixedExtension: false,
+  deps: {
+    neverBundle: [/^react/, /^@kubb\//],
+    alwaysBundle: [/@internals/],
+  },
+  outputOptions: {
+    keepNames: true,
+  },
+}
+
+export default defineConfig([
+  {
+    entry,
+    format: 'esm',
+    dts: true,
+    ...shared,
+  },
+  {
+    entry,
+    format: 'cjs',
+    dts: false,
+    ...shared,
+  },
+])

--- a/internals/client/vitest.config.ts
+++ b/internals/client/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['./src/**/*.test.{ts,tsx}', './templates/**/*.test.{ts,tsx}'],
+  },
+  resolve: {
+    tsconfigPaths: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -673,6 +673,34 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  internals/client:
+    dependencies:
+      '@internals/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@internals/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@kubb/ast':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.61
+      '@kubb/core':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.61(@kubb/renderer-jsx@5.0.0-beta.61)
+      '@kubb/plugin-ts':
+        specifier: workspace:*
+        version: link:../../packages/plugin-ts
+      '@kubb/plugin-zod':
+        specifier: workspace:*
+        version: link:../../packages/plugin-zod
+      '@kubb/renderer-jsx':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.61
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.21
+
   internals/shared:
     dependencies:
       '@internals/utils':


### PR DESCRIPTION
## Summary

Slice 1 / foundation of #384 — closes #386. Adds `@internals/client`, the bundled internal package the three slim HTTP client plugins (`plugin-fetch`, `plugin-axios`, `plugin-ky`) will build on. No changes to `packages/plugin-client`.

Everything is keyed to the #384 contract: every generated function takes **one grouped `options` object** and returns **one shape** `{ data, error, request, response }`, typed by a `RequestResult` generic with a per-call `throwOnError` flag defaulting to `true`.

## Generator side (`src/`)

- Slim shared `Options` / `ResolvedOptions` + `resolveOptions` (only `output`, `group`, `include`/`exclude`/`override`, `baseURL`, `parser` — no `bundle`/`client`/`importPath`/`dataReturnType`/`clientType`/`sdk`/`paramsType`/`urlType`/`operations`).
- Builders: `buildGroupedOptionsSignature` (single `options` arg, literal `url`, `ThrowOnError` generic), `buildRequestResultGenerics`, `buildReturnStatement`, `buildSecurityMetadata`, `buildValidatorHooks`, the parser resolvers, and the success-only `buildZodResponseParse`.
- `Operation` component and the shared `resolverClient`.
- Per the maintainer's call on the contract, the grouped data type uses the **#384 key names** (`body`/`path`/`query`/`headers`/`url`), derived from the plugin-ts `<Name>RequestConfig` via indexed access so the generated file only imports `<Name>RequestConfig` and `<Name>Responses` and never collides with the per-direction names.

## Shared runtime (`templates/runtime.ts`)

Injected once into the generated output as `.kubb/client.ts` via `injectClientRuntime`; each plugin appends a small transport prelude that supplies `defaultTransport` and exports `client` / `createClient`. The native request/response objects flow through as generic parameters (`TRequest`/`TResponse`, defaulting to `Request`/`Response`) so axios and ky can specialize without touching the core.

- Types: `RequestResult`, `SuccessOf`/`ErrorOf`, `ResponseError`, `DataShape`, `Options`, `RequestConfig`.
- `createClientCore` with per-call client and `transport` resolution, `setConfig`/`getConfig`, isolated `createClient`.
- Transport-agnostic interceptor stack (`use`/`eject`/`update`), default query (deepObject + array styles) and body (JSON + FormData passthrough) serializers, `resolveAuth` helper, and validator invocation (request before send, response on 2xx only).

## Composition seam

A single self-contained, standalone-typechecking runtime core + a per-plugin transport prelude (rather than loose concatenated fragments, which would cross-reference sibling symbols and break the foundation's own typecheck). `injectClientRuntime({ injectFile, root, transport })` composes the two and writes `.kubb/client.ts`, keeping #387/#388/#389 thin.

## Tests

Colocated Vitest covering every builder and the runtime stack (interceptor ordering, serializer defaults, per-call client + transport resolution, `throwOnError` / `ResponseError`, validator order, `resolveAuth`) and the injection helper — **49 tests**.

## Verification

- `tsc` typecheck clean (incl. `templates/runtime.ts`)
- `tsdown` build inlines the runtime into `dist/templates/runtime.source.*`
- `vitest` 49 passing
- `oxlint` clean, `oxfmt` formatted
- `@internals/client` is a private `0.0.0` package (changesets `ignore: @internals/*`), so no changeset

Part of #384. Foundation for #387/#388/#389, #390 (parser), and #395 (auth).

https://claude.ai/code/session_011SsYFRMcZJq14ou5k8Wz9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_011SsYFRMcZJq14ou5k8Wz9Q)_