### PR TITLE
docs: point plugin metadata note at docs-repo frontmatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,10 +50,10 @@ The `internals/` directory provides shared utilities:
 
 ### Plugin docs and metadata
 
-Plugin docs live in the platform repo ([kubb-labs/platform](https://github.com/kubb-labs/platform)). Each plugin has a hand-written page at `apps/kubb.dev/plugins/<name>.md` and a small metadata file at `extensions/plugins/<name>.yaml`, published on [kubb.dev](https://kubb.dev).
+Plugin docs live in the docs repo ([kubb-labs/docs](https://github.com/kubb-labs/docs)). Each plugin is a single hand-written page at `plugins/<name>.md` whose frontmatter carries the registry metadata (name, category, npm package, maintainers, compatibility), published on [kubb.dev](https://kubb.dev).
 
 > [!IMPORTANT]
-> **Changing a plugin's options? Update its kubb.dev page in the platform repo.**
+> **Changing a plugin's options? Update its kubb.dev page in the docs repo.**
 >
 > A documented option must exist in the plugin's `src/types.ts` `Options` type and be honored in `src/plugin.ts`. Keep the documented defaults matching the destructuring defaults in `plugin.ts`.
 


### PR DESCRIPTION
## What

Update the "Plugin docs and metadata" note in `AGENTS.md` (symlinked by `CLAUDE.md`). Extension metadata now lives in the frontmatter of each plugin's page in kubb-labs/docs, not a separate `extensions/plugins/<name>.yaml` file.

Companion to kubb-labs/docs and kubb-labs/platform PRs that perform the actual move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA4Z7dwFN6Pxh7rEM1o5MS)_