### PR TITLE
fix(plugin-faker): drop shapeless allOf members instead of spreading undefined

### DIFF
--- a/.changeset/faker-drop-shapeless-allof-members.md
+++ b/.changeset/faker-drop-shapeless-allof-members.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-faker": patch
+---
+
+Drop shapeless `allOf` members from generated mocks instead of spreading `...undefined`. An `allOf` that combines a `$ref` with a metadata-only schema (just `description`/`example`) produced invalid `{...createEquipmentCategory(), ...undefined}`. The metadata-only member now drops out, leaving `createEquipmentCategory()`.

--- a/packages/plugin-faker/src/printers/printerFaker.test.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.test.ts
@@ -173,6 +173,20 @@ describe('printerFaker', () => {
     )
   })
 
+  test('drops shapeless allOf members instead of spreading undefined', () => {
+    // `allOf: [{ $ref: EquipmentCategory }, { description }]` — the metadata-only member has no
+    // shape and mocks to `undefined`. It must be dropped, not spread as `{...x, ...undefined}`.
+    const node = ast.factory.createSchema({
+      type: 'intersection',
+      members: [
+        ast.factory.createSchema({ type: 'ref', name: 'EquipmentCategory', ref: '#/components/schemas/EquipmentCategory' }),
+        ast.factory.createSchema({ type: 'unknown' }),
+      ],
+    })
+
+    expect(printerFaker({ resolver: resolverFaker }).print(node)).toMatchInlineSnapshot(`"createEquipmentCategory()"`)
+  })
+
   test('memoizing getters return a stable reference and data overrides replace the getter', () => {
     // Simulate the runtime object-literal pattern the printer generates for cyclic
     // properties (e.g. Cat.friends → Pet → Cat).  The getter must memoize its value

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -340,7 +340,9 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
           }),
         )
           .map(({ output }) => output)
-          .filter((item): item is string => Boolean(item))
+          // An `allOf` member with no shape (any/unknown/void → 'undefined') adds no
+          // constraint. Keeping it would spread `...undefined` into the merged object.
+          .filter((item): item is string => Boolean(item) && item !== 'undefined')
 
         return fakerKeywordMapper.and(items)
       },


### PR DESCRIPTION
## Context

While validating [chrisdoc/hevy-mcp](https://github.com/chrisdoc/hevy-mcp) against Kubb v5 (`5.0.0-beta.68`), generated faker mocks failed to type-check.

## Problem

An `allOf` that combines a `$ref` with a metadata-only schema (just `description`/`example`) produced invalid TypeScript:

```ts
equipment_category: {...createEquipmentCategory(), ...undefined},
muscle_group: {...createMuscleGroup(), ...undefined},
```

The metadata-only member has no shape, so the `any`/`unknown`/`void` handlers mock it to the literal string `'undefined'`. That value is truthy, so it survived the `Boolean(item)` filter in the `intersection` handler and got spread into the merged object — `{...undefined}` is `TS2698: Spread types may only be created from object types`.

## Fix

The `intersection` handler now drops members that mock to `'undefined'` — a shapeless member adds no constraint to an `allOf` merge. With the metadata member removed, the single remaining item is returned directly, so the example above becomes:

```ts
equipment_category: createEquipmentCategory(),
muscle_group: createMuscleGroup(),
```

## Verification

- New regression test in `printerFaker.test.ts` (`drops shapeless allOf members instead of spreading undefined`); full `plugin-faker` suite green (25 tests).
- End-to-end: regenerated the full hevy-mcp faker mocks from the real Hevy OpenAPI spec with this build — no `...undefined` remains and the generated tree type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qi3mrqcDcqrgbu5SCnXi39)_