### PR TITLE
refactor: adopt adapter-oas server object and discriminator rename

### DIFF
--- a/examples/advanced/configs/kubb.config.ts
+++ b/examples/advanced/configs/kubb.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   },
   adapter: adapterOas({
     validate: true,
-    discriminator: 'strict',
+    discriminator: 'preserve',
     integerType: 'number',
   }),
   output: {

--- a/examples/fetch/kubb.config.ts
+++ b/examples/fetch/kubb.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(() => {
       format: false,
       lint: false,
     },
-    adapter: adapterOas({ serverIndex: 0 }),
+    adapter: adapterOas({ server: { index: 0 } }),
     plugins: [
       pluginTs({
         output: { path: 'models.ts', mode: 'file' },

--- a/tests/3.0.x/main.test.ts
+++ b/tests/3.0.x/main.test.ts
@@ -50,7 +50,7 @@ const configs = [
         path: './gen',
         barrel: false,
       },
-      adapter: adapterOas({ validate: false, discriminator: 'inherit' }),
+      adapter: adapterOas({ validate: false, discriminator: 'propagate' }),
       parsers: [parserTs],
       plugins: [
         pluginTs({


### PR DESCRIPTION
## Summary

Updates example and test configs to the new `@kubb/adapter-oas` API (companion to kubb-labs/kubb#3634):

- `examples/fetch/kubb.config.ts`: `serverIndex: 0` → `server: { index: 0 }`
- `examples/advanced/configs/kubb.config.ts`: `discriminator: 'strict'` → `'preserve'`
- `tests/3.0.x/main.test.ts`: `discriminator: 'inherit'` → `'propagate'`

## ⚠️ Release-gated

This repo consumes `@kubb/adapter-oas` via `catalog:` (currently a pre-rename beta). These configs only typecheck and pass once the adapter-oas release in kubb-labs/kubb#3634 is published and the catalog version is bumped. CI here is expected to stay red until that follow-up lands. Opening now as agreed so the changes are staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G7g1ahjaxBMiaHtPdSQFDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01G7g1ahjaxBMiaHtPdSQFDb)_