### PR TITLE
refactor(plugin-fetch): use RequestConfig directly as the function input

### DIFF
--- a/.changeset/plugin-fetch-request-config-input.md
+++ b/.changeset/plugin-fetch-request-config-input.md
@@ -1,0 +1,45 @@
+---
+"@kubb/plugin-ts": minor
+"@kubb/plugin-fetch": minor
+---
+
+Use the generated `<Operation>RequestConfig` type directly as the slim-client function input.
+
+`@kubb/plugin-ts` now emits the request-config type with the same field names the runtime client uses — `body`, `path`, `query`, `headers`, `url` — instead of `data`, `pathParams`, `queryParams`, `headerParams`, `url`. `body` is required when the operation has a request body.
+
+```ts
+// Before
+export type AddPetRequestConfig = {
+  data?: AddPetData
+  pathParams?: never
+  queryParams?: never
+  headerParams?: never
+  url: '/pet'
+}
+
+// After
+export type AddPetRequestConfig = {
+  body: AddPetData
+  path?: never
+  query?: never
+  headers?: never
+  url: '/pet'
+}
+```
+
+`@kubb/plugin-fetch` consumes that type as-is, so each operation no longer emits a separate file-local `<Operation>Request` type to rename the fields:
+
+```ts
+// Before
+type AddPetRequest = {
+  body: AddPetRequestConfig['data']
+  path?: AddPetRequestConfig['pathParams']
+  query?: AddPetRequestConfig['queryParams']
+  headers?: AddPetRequestConfig['headerParams']
+  url: AddPetRequestConfig['url']
+}
+export function addPet<ThrowOnError extends boolean = true>(options: Options<AddPetRequest, ThrowOnError>): ...
+
+// After
+export function addPet<ThrowOnError extends boolean = true>(options: Options<AddPetRequestConfig, ThrowOnError>): ...
+```

--- a/examples/fetch-slim/src/gen/clients/pet/addPet.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/addPet.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { AddPetRequestConfig, AddPetResponses } from '../../models/pet/AddPet.ts'
 import { client } from '../../.kubb/client.ts'
 
-type AddPetRequest = {
-  body: AddPetRequestConfig['data']
-  path?: AddPetRequestConfig['pathParams']
-  query?: AddPetRequestConfig['queryParams']
-  headers?: AddPetRequestConfig['headerParams']
-  url: AddPetRequestConfig['url']
-}
-
 /**
  * @description Add a new pet to the store
  * @summary Add a new pet to the store
  * {@link /pet}
  */
 export function addPet<ThrowOnError extends boolean = true>(
-  options: Options<AddPetRequest, ThrowOnError>,
+  options: Options<AddPetRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<AddPetResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/pet/deletePet.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/deletePet.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { DeletePetRequestConfig, DeletePetResponses } from '../../models/pet/DeletePet.ts'
 import { client } from '../../.kubb/client.ts'
 
-type DeletePetRequest = {
-  body?: DeletePetRequestConfig['data']
-  path?: DeletePetRequestConfig['pathParams']
-  query?: DeletePetRequestConfig['queryParams']
-  headers?: DeletePetRequestConfig['headerParams']
-  url: DeletePetRequestConfig['url']
-}
-
 /**
  * @description delete a pet
  * @summary Deletes a pet
  * {@link /pet/:petId}
  */
 export function deletePet<ThrowOnError extends boolean = true>(
-  options: Options<DeletePetRequest, ThrowOnError>,
+  options: Options<DeletePetRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<DeletePetResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/pet/findPetsByStatus.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/findPetsByStatus.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { FindPetsByStatusRequestConfig, FindPetsByStatusResponses } from '../../models/pet/FindPetsByStatus.ts'
 import { client } from '../../.kubb/client.ts'
 
-type FindPetsByStatusRequest = {
-  body?: FindPetsByStatusRequestConfig['data']
-  path?: FindPetsByStatusRequestConfig['pathParams']
-  query?: FindPetsByStatusRequestConfig['queryParams']
-  headers?: FindPetsByStatusRequestConfig['headerParams']
-  url: FindPetsByStatusRequestConfig['url']
-}
-
 /**
  * @description Multiple status values can be provided with comma separated strings
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
 export function findPetsByStatus<ThrowOnError extends boolean = true>(
-  options: Options<FindPetsByStatusRequest, ThrowOnError>,
+  options: Options<FindPetsByStatusRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/pet/findPetsByTags.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/findPetsByTags.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { FindPetsByTagsRequestConfig, FindPetsByTagsResponses } from '../../models/pet/FindPetsByTags.ts'
 import { client } from '../../.kubb/client.ts'
 
-type FindPetsByTagsRequest = {
-  body?: FindPetsByTagsRequestConfig['data']
-  path?: FindPetsByTagsRequestConfig['pathParams']
-  query?: FindPetsByTagsRequestConfig['queryParams']
-  headers?: FindPetsByTagsRequestConfig['headerParams']
-  url: FindPetsByTagsRequestConfig['url']
-}
-
 /**
  * @description Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
  * @summary Finds Pets by tags
  * {@link /pet/findByTags}
  */
 export function findPetsByTags<ThrowOnError extends boolean = true>(
-  options: Options<FindPetsByTagsRequest, ThrowOnError>,
+  options: Options<FindPetsByTagsRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/pet/getPetById.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/getPetById.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { GetPetByIdRequestConfig, GetPetByIdResponses } from '../../models/pet/GetPetById.ts'
 import { client } from '../../.kubb/client.ts'
 
-type GetPetByIdRequest = {
-  body?: GetPetByIdRequestConfig['data']
-  path?: GetPetByIdRequestConfig['pathParams']
-  query?: GetPetByIdRequestConfig['queryParams']
-  headers?: GetPetByIdRequestConfig['headerParams']
-  url: GetPetByIdRequestConfig['url']
-}
-
 /**
  * @description Returns a single pet
  * @summary Find pet by ID
  * {@link /pet/:petId}
  */
 export function getPetById<ThrowOnError extends boolean = true>(
-  options: Options<GetPetByIdRequest, ThrowOnError>,
+  options: Options<GetPetByIdRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<GetPetByIdResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/pet/updatePet.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/updatePet.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { UpdatePetRequestConfig, UpdatePetResponses } from '../../models/pet/UpdatePet.ts'
 import { client } from '../../.kubb/client.ts'
 
-type UpdatePetRequest = {
-  body: UpdatePetRequestConfig['data']
-  path?: UpdatePetRequestConfig['pathParams']
-  query?: UpdatePetRequestConfig['queryParams']
-  headers?: UpdatePetRequestConfig['headerParams']
-  url: UpdatePetRequestConfig['url']
-}
-
 /**
  * @description Update an existing pet by Id
  * @summary Update an existing pet
  * {@link /pet}
  */
 export function updatePet<ThrowOnError extends boolean = true>(
-  options: Options<UpdatePetRequest, ThrowOnError>,
+  options: Options<UpdatePetRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<UpdatePetResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/pet/updatePetWithForm.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/updatePetWithForm.ts
@@ -7,20 +7,12 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { UpdatePetWithFormRequestConfig, UpdatePetWithFormResponses } from '../../models/pet/UpdatePetWithForm.ts'
 import { client } from '../../.kubb/client.ts'
 
-type UpdatePetWithFormRequest = {
-  body?: UpdatePetWithFormRequestConfig['data']
-  path?: UpdatePetWithFormRequestConfig['pathParams']
-  query?: UpdatePetWithFormRequestConfig['queryParams']
-  headers?: UpdatePetWithFormRequestConfig['headerParams']
-  url: UpdatePetWithFormRequestConfig['url']
-}
-
 /**
  * @summary Updates a pet in the store with form data
  * {@link /pet/:petId}
  */
 export function updatePetWithForm<ThrowOnError extends boolean = true>(
-  options: Options<UpdatePetWithFormRequest, ThrowOnError>,
+  options: Options<UpdatePetWithFormRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<UpdatePetWithFormResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/pet/uploadFile.ts
+++ b/examples/fetch-slim/src/gen/clients/pet/uploadFile.ts
@@ -7,20 +7,12 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { UploadFileRequestConfig, UploadFileResponses } from '../../models/pet/UploadFile.ts'
 import { client } from '../../.kubb/client.ts'
 
-type UploadFileRequest = {
-  body: UploadFileRequestConfig['data']
-  path?: UploadFileRequestConfig['pathParams']
-  query?: UploadFileRequestConfig['queryParams']
-  headers?: UploadFileRequestConfig['headerParams']
-  url: UploadFileRequestConfig['url']
-}
-
 /**
  * @summary uploads an image
  * {@link /pet/:petId/uploadImage}
  */
 export function uploadFile<ThrowOnError extends boolean = true>(
-  options: Options<UploadFileRequest, ThrowOnError>,
+  options: Options<UploadFileRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<UploadFileResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/store/deleteOrder.ts
+++ b/examples/fetch-slim/src/gen/clients/store/deleteOrder.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { DeleteOrderRequestConfig, DeleteOrderResponses } from '../../models/store/DeleteOrder.ts'
 import { client } from '../../.kubb/client.ts'
 
-type DeleteOrderRequest = {
-  body?: DeleteOrderRequestConfig['data']
-  path?: DeleteOrderRequestConfig['pathParams']
-  query?: DeleteOrderRequestConfig['queryParams']
-  headers?: DeleteOrderRequestConfig['headerParams']
-  url: DeleteOrderRequestConfig['url']
-}
-
 /**
  * @description For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
  * @summary Delete purchase order by ID
  * {@link /store/order/:orderId}
  */
 export function deleteOrder<ThrowOnError extends boolean = true>(
-  options: Options<DeleteOrderRequest, ThrowOnError>,
+  options: Options<DeleteOrderRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<DeleteOrderResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/store/getInventory.ts
+++ b/examples/fetch-slim/src/gen/clients/store/getInventory.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { GetInventoryRequestConfig, GetInventoryResponses } from '../../models/store/GetInventory.ts'
 import { client } from '../../.kubb/client.ts'
 
-type GetInventoryRequest = {
-  body?: GetInventoryRequestConfig['data']
-  path?: GetInventoryRequestConfig['pathParams']
-  query?: GetInventoryRequestConfig['queryParams']
-  headers?: GetInventoryRequestConfig['headerParams']
-  url: GetInventoryRequestConfig['url']
-}
-
 /**
  * @description Returns a map of status codes to quantities
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
 export function getInventory<ThrowOnError extends boolean = true>(
-  options: Options<GetInventoryRequest, ThrowOnError>,
+  options: Options<GetInventoryRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/store/getOrderById.ts
+++ b/examples/fetch-slim/src/gen/clients/store/getOrderById.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { GetOrderByIdRequestConfig, GetOrderByIdResponses } from '../../models/store/GetOrderById.ts'
 import { client } from '../../.kubb/client.ts'
 
-type GetOrderByIdRequest = {
-  body?: GetOrderByIdRequestConfig['data']
-  path?: GetOrderByIdRequestConfig['pathParams']
-  query?: GetOrderByIdRequestConfig['queryParams']
-  headers?: GetOrderByIdRequestConfig['headerParams']
-  url: GetOrderByIdRequestConfig['url']
-}
-
 /**
  * @description For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
  * @summary Find purchase order by ID
  * {@link /store/order/:orderId}
  */
 export function getOrderById<ThrowOnError extends boolean = true>(
-  options: Options<GetOrderByIdRequest, ThrowOnError>,
+  options: Options<GetOrderByIdRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<GetOrderByIdResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/store/placeOrder.ts
+++ b/examples/fetch-slim/src/gen/clients/store/placeOrder.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { PlaceOrderRequestConfig, PlaceOrderResponses } from '../../models/store/PlaceOrder.ts'
 import { client } from '../../.kubb/client.ts'
 
-type PlaceOrderRequest = {
-  body: PlaceOrderRequestConfig['data']
-  path?: PlaceOrderRequestConfig['pathParams']
-  query?: PlaceOrderRequestConfig['queryParams']
-  headers?: PlaceOrderRequestConfig['headerParams']
-  url: PlaceOrderRequestConfig['url']
-}
-
 /**
  * @description Place a new order in the store
  * @summary Place an order for a pet
  * {@link /store/order}
  */
 export function placeOrder<ThrowOnError extends boolean = true>(
-  options: Options<PlaceOrderRequest, ThrowOnError>,
+  options: Options<PlaceOrderRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<PlaceOrderResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/store/placeOrderPatch.ts
+++ b/examples/fetch-slim/src/gen/clients/store/placeOrderPatch.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { PlaceOrderPatchRequestConfig, PlaceOrderPatchResponses } from '../../models/store/PlaceOrderPatch.ts'
 import { client } from '../../.kubb/client.ts'
 
-type PlaceOrderPatchRequest = {
-  body: PlaceOrderPatchRequestConfig['data']
-  path?: PlaceOrderPatchRequestConfig['pathParams']
-  query?: PlaceOrderPatchRequestConfig['queryParams']
-  headers?: PlaceOrderPatchRequestConfig['headerParams']
-  url: PlaceOrderPatchRequestConfig['url']
-}
-
 /**
  * @description Place a new order in the store with patch
  * @summary Place an order for a pet with patch
  * {@link /store/order}
  */
 export function placeOrderPatch<ThrowOnError extends boolean = true>(
-  options: Options<PlaceOrderPatchRequest, ThrowOnError>,
+  options: Options<PlaceOrderPatchRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<PlaceOrderPatchResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/user/createUser.ts
+++ b/examples/fetch-slim/src/gen/clients/user/createUser.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { CreateUserRequestConfig, CreateUserResponses } from '../../models/user/CreateUser.ts'
 import { client } from '../../.kubb/client.ts'
 
-type CreateUserRequest = {
-  body: CreateUserRequestConfig['data']
-  path?: CreateUserRequestConfig['pathParams']
-  query?: CreateUserRequestConfig['queryParams']
-  headers?: CreateUserRequestConfig['headerParams']
-  url: CreateUserRequestConfig['url']
-}
-
 /**
  * @description This can only be done by the logged in user.
  * @summary Create user
  * {@link /user}
  */
 export function createUser<ThrowOnError extends boolean = true>(
-  options: Options<CreateUserRequest, ThrowOnError>,
+  options: Options<CreateUserRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<CreateUserResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/user/createUsersWithListInput.ts
+++ b/examples/fetch-slim/src/gen/clients/user/createUsersWithListInput.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { CreateUsersWithListInputRequestConfig, CreateUsersWithListInputResponses } from '../../models/user/CreateUsersWithListInput.ts'
 import { client } from '../../.kubb/client.ts'
 
-type CreateUsersWithListInputRequest = {
-  body: CreateUsersWithListInputRequestConfig['data']
-  path?: CreateUsersWithListInputRequestConfig['pathParams']
-  query?: CreateUsersWithListInputRequestConfig['queryParams']
-  headers?: CreateUsersWithListInputRequestConfig['headerParams']
-  url: CreateUsersWithListInputRequestConfig['url']
-}
-
 /**
  * @description Creates list of users with given input array
  * @summary Creates list of users with given input array
  * {@link /user/createWithList}
  */
 export function createUsersWithListInput<ThrowOnError extends boolean = true>(
-  options: Options<CreateUsersWithListInputRequest, ThrowOnError>,
+  options: Options<CreateUsersWithListInputRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<CreateUsersWithListInputResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/user/deleteUser.ts
+++ b/examples/fetch-slim/src/gen/clients/user/deleteUser.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { DeleteUserRequestConfig, DeleteUserResponses } from '../../models/user/DeleteUser.ts'
 import { client } from '../../.kubb/client.ts'
 
-type DeleteUserRequest = {
-  body?: DeleteUserRequestConfig['data']
-  path?: DeleteUserRequestConfig['pathParams']
-  query?: DeleteUserRequestConfig['queryParams']
-  headers?: DeleteUserRequestConfig['headerParams']
-  url: DeleteUserRequestConfig['url']
-}
-
 /**
  * @description This can only be done by the logged in user.
  * @summary Delete user
  * {@link /user/:username}
  */
 export function deleteUser<ThrowOnError extends boolean = true>(
-  options: Options<DeleteUserRequest, ThrowOnError>,
+  options: Options<DeleteUserRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<DeleteUserResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/user/getUserByName.ts
+++ b/examples/fetch-slim/src/gen/clients/user/getUserByName.ts
@@ -7,20 +7,12 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { GetUserByNameRequestConfig, GetUserByNameResponses } from '../../models/user/GetUserByName.ts'
 import { client } from '../../.kubb/client.ts'
 
-type GetUserByNameRequest = {
-  body?: GetUserByNameRequestConfig['data']
-  path?: GetUserByNameRequestConfig['pathParams']
-  query?: GetUserByNameRequestConfig['queryParams']
-  headers?: GetUserByNameRequestConfig['headerParams']
-  url: GetUserByNameRequestConfig['url']
-}
-
 /**
  * @summary Get user by user name
  * {@link /user/:username}
  */
 export function getUserByName<ThrowOnError extends boolean = true>(
-  options: Options<GetUserByNameRequest, ThrowOnError>,
+  options: Options<GetUserByNameRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<GetUserByNameResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/user/loginUser.ts
+++ b/examples/fetch-slim/src/gen/clients/user/loginUser.ts
@@ -7,20 +7,12 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { LoginUserRequestConfig, LoginUserResponses } from '../../models/user/LoginUser.ts'
 import { client } from '../../.kubb/client.ts'
 
-type LoginUserRequest = {
-  body?: LoginUserRequestConfig['data']
-  path?: LoginUserRequestConfig['pathParams']
-  query?: LoginUserRequestConfig['queryParams']
-  headers?: LoginUserRequestConfig['headerParams']
-  url: LoginUserRequestConfig['url']
-}
-
 /**
  * @summary Logs user into the system
  * {@link /user/login}
  */
 export function loginUser<ThrowOnError extends boolean = true>(
-  options: Options<LoginUserRequest, ThrowOnError>,
+  options: Options<LoginUserRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<LoginUserResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/user/logoutUser.ts
+++ b/examples/fetch-slim/src/gen/clients/user/logoutUser.ts
@@ -7,20 +7,12 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { LogoutUserRequestConfig, LogoutUserResponses } from '../../models/user/LogoutUser.ts'
 import { client } from '../../.kubb/client.ts'
 
-type LogoutUserRequest = {
-  body?: LogoutUserRequestConfig['data']
-  path?: LogoutUserRequestConfig['pathParams']
-  query?: LogoutUserRequestConfig['queryParams']
-  headers?: LogoutUserRequestConfig['headerParams']
-  url: LogoutUserRequestConfig['url']
-}
-
 /**
  * @summary Logs out current logged in user session
  * {@link /user/logout}
  */
 export function logoutUser<ThrowOnError extends boolean = true>(
-  options: Options<LogoutUserRequest, ThrowOnError>,
+  options: Options<LogoutUserRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<LogoutUserResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/clients/user/updateUser.ts
+++ b/examples/fetch-slim/src/gen/clients/user/updateUser.ts
@@ -7,21 +7,13 @@ import type { Options, RequestResult } from '../../.kubb/client.ts'
 import type { UpdateUserRequestConfig, UpdateUserResponses } from '../../models/user/UpdateUser.ts'
 import { client } from '../../.kubb/client.ts'
 
-type UpdateUserRequest = {
-  body: UpdateUserRequestConfig['data']
-  path?: UpdateUserRequestConfig['pathParams']
-  query?: UpdateUserRequestConfig['queryParams']
-  headers?: UpdateUserRequestConfig['headerParams']
-  url: UpdateUserRequestConfig['url']
-}
-
 /**
  * @description This can only be done by the logged in user.
  * @summary Update user
  * {@link /user/:username}
  */
 export function updateUser<ThrowOnError extends boolean = true>(
-  options: Options<UpdateUserRequest, ThrowOnError>,
+  options: Options<UpdateUserRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<UpdateUserResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/examples/fetch-slim/src/gen/models/pet/AddPet.ts
+++ b/examples/fetch-slim/src/gen/models/pet/AddPet.ts
@@ -58,10 +58,10 @@ export type AddPetData = AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedDa
  * @type object
  */
 export type AddPetRequestConfig = {
-  data?: AddPetData
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body: AddPetData
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/pet/DeletePet.ts
+++ b/examples/fetch-slim/src/gen/models/pet/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any
  * @type object
  */
 export type DeletePetRequestConfig = {
-  data?: never
-  /**
-   * @type object
-   */
-  pathParams: {
-    petId: DeletePetPathPetId
-  }
-  queryParams?: never
+  body?: never
   /**
    * @type object | undefined
    */
-  headerParams?: {
+  path?: {
+    petId: DeletePetPathPetId
+  }
+  query?: never
+  /**
+   * @type object | undefined
+   */
+  headers?: {
     api_key?: DeletePetHeaderApiKey
   }
   /**

--- a/examples/fetch-slim/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/fetch-slim/src/gen/models/pet/FindPetsByStatus.ts
@@ -41,15 +41,15 @@ export type FindPetsByStatusStatus400 = any
  * @type object
  */
 export type FindPetsByStatusRequestConfig = {
-  data?: never
-  pathParams?: never
+  body?: never
+  path?: never
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     status?: FindPetsByStatusQueryStatus
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/fetch-slim/src/gen/models/pet/FindPetsByTags.ts
@@ -44,17 +44,17 @@ export type FindPetsByTagsStatus400 = any
  * @type object
  */
 export type FindPetsByTagsRequestConfig = {
-  data?: never
-  pathParams?: never
+  body?: never
+  path?: never
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     tags?: FindPetsByTagsQueryTags
     page?: FindPetsByTagsQueryPage
     pageSize?: FindPetsByTagsQueryPageSize
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/pet/GetPetById.ts
+++ b/examples/fetch-slim/src/gen/models/pet/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any
  * @type object
  */
 export type GetPetByIdRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: GetPetByIdPathPetId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/pet/UpdatePet.ts
+++ b/examples/fetch-slim/src/gen/models/pet/UpdatePet.ts
@@ -56,10 +56,10 @@ export type UpdatePetData = UpdatePetJsonData | UpdatePetXmlData | UpdatePetForm
  * @type object
  */
 export type UpdatePetRequestConfig = {
-  data?: UpdatePetData
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body: UpdatePetData
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/fetch-slim/src/gen/models/pet/UpdatePetWithForm.ts
@@ -32,21 +32,21 @@ export type UpdatePetWithFormStatus405 = any
  * @type object
  */
 export type UpdatePetWithFormRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: UpdatePetWithFormPathPetId
   }
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     name?: UpdatePetWithFormQueryName
     status?: UpdatePetWithFormQueryStatus
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/pet/UploadFile.ts
+++ b/examples/fetch-slim/src/gen/models/pet/UploadFile.ts
@@ -53,20 +53,20 @@ export type UploadFileData = UploadFileJsonData | UploadFileFormData
  * @type object
  */
 export type UploadFileRequestConfig = {
-  data?: UploadFileData
+  body: UploadFileData
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: UploadFilePathPetId
   }
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     additionalMetadata?: UploadFileQueryAdditionalMetadata
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/store/DeleteOrder.ts
+++ b/examples/fetch-slim/src/gen/models/store/DeleteOrder.ts
@@ -25,15 +25,15 @@ export type DeleteOrderStatus404 = any
  * @type object
  */
 export type DeleteOrderRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     orderId: DeleteOrderPathOrderId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/store/GetInventory.ts
+++ b/examples/fetch-slim/src/gen/models/store/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
  */
 export type GetInventoryRequestConfig = {
-  data?: never
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body?: never
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/store/GetOrderById.ts
+++ b/examples/fetch-slim/src/gen/models/store/GetOrderById.ts
@@ -39,15 +39,15 @@ export type GetOrderByIdStatus404 = any
  * @type object
  */
 export type GetOrderByIdRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     orderId: GetOrderByIdPathOrderId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/store/PlaceOrder.ts
+++ b/examples/fetch-slim/src/gen/models/store/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrder
  * @type object
  */
 export type PlaceOrderRequestConfig = {
-  data?: PlaceOrderData
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body: PlaceOrderData
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/fetch-slim/src/gen/models/store/PlaceOrderPatch.ts
@@ -36,10 +36,10 @@ export type PlaceOrderPatchData = PlaceOrderPatchJsonData | PlaceOrderPatchXmlDa
  * @type object
  */
 export type PlaceOrderPatchRequestConfig = {
-  data?: PlaceOrderPatchData
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body: PlaceOrderPatchData
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/user/CreateUser.ts
+++ b/examples/fetch-slim/src/gen/models/user/CreateUser.ts
@@ -41,10 +41,10 @@ export type CreateUserData = CreateUserJsonData | CreateUserXmlData | CreateUser
  * @type object
  */
 export type CreateUserRequestConfig = {
-  data?: CreateUserData
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body: CreateUserData
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/fetch-slim/src/gen/models/user/CreateUsersWithListInput.ts
@@ -31,10 +31,10 @@ export type CreateUsersWithListInputData = User[] | undefined
  * @type object
  */
 export type CreateUsersWithListInputRequestConfig = {
-  data?: CreateUsersWithListInputData
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body: CreateUsersWithListInputData
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/user/DeleteUser.ts
+++ b/examples/fetch-slim/src/gen/models/user/DeleteUser.ts
@@ -23,15 +23,15 @@ export type DeleteUserStatus404 = any
  * @type object
  */
 export type DeleteUserRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     username: DeleteUserPathUsername
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/user/GetUserByName.ts
+++ b/examples/fetch-slim/src/gen/models/user/GetUserByName.ts
@@ -37,15 +37,15 @@ export type GetUserByNameStatus404 = any
  * @type object
  */
 export type GetUserByNameRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     username: GetUserByNamePathUsername
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/user/LoginUser.ts
+++ b/examples/fetch-slim/src/gen/models/user/LoginUser.ts
@@ -36,16 +36,16 @@ export type LoginUserStatus400 = any
  * @type object
  */
 export type LoginUserRequestConfig = {
-  data?: never
-  pathParams?: never
+  body?: never
+  path?: never
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     username?: LoginUserQueryUsername
     password?: LoginUserQueryPassword
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/user/LogoutUser.ts
+++ b/examples/fetch-slim/src/gen/models/user/LogoutUser.ts
@@ -12,10 +12,10 @@ export type LogoutUserStatusDefault = any
  * @type object
  */
 export type LogoutUserRequestConfig = {
-  data?: never
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body?: never
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/examples/fetch-slim/src/gen/models/user/UpdateUser.ts
+++ b/examples/fetch-slim/src/gen/models/user/UpdateUser.ts
@@ -40,15 +40,15 @@ export type UpdateUserData = UpdateUserJsonData | UpdateUserXmlData | UpdateUser
  * @type object
  */
 export type UpdateUserRequestConfig = {
-  data?: UpdateUserData
+  body: UpdateUserData
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     username: UpdateUserPathUsername
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/internals/client/src/builders/signature.test.ts
+++ b/internals/client/src/builders/signature.test.ts
@@ -14,18 +14,10 @@ const addPet = ast.factory.createOperation({
   responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
 })
 
-const listPets = ast.factory.createOperation({
-  operationId: 'listPets',
-  method: 'GET',
-  path: '/pets',
-  tags: ['pet'],
-  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
-})
-
 describe('buildGroupedOptionsSignature', () => {
   test('emits a single grouped options parameter with a ThrowOnError generic', () => {
     const signature = buildGroupedOptionsSignature({ node: addPet, tsResolver: resolverTs })
-    expect(signature.paramsSignature).toBe('options: Options<AddPetRequest, ThrowOnError>')
+    expect(signature.paramsSignature).toBe('options: Options<AddPetRequestConfig, ThrowOnError>')
     expect(signature.generics).toStrictEqual(['ThrowOnError extends boolean = true'])
   })
 
@@ -34,19 +26,9 @@ describe('buildGroupedOptionsSignature', () => {
     expect(signature.returnType).toBe('Promise<RequestResult<AddPetResponses, ThrowOnError>>')
   })
 
-  test('derives the grouped data type from RequestConfig with the contract key names', () => {
+  test('uses the plugin-ts RequestConfig directly as the grouped data type', () => {
     const signature = buildGroupedOptionsSignature({ node: addPet, tsResolver: resolverTs })
-    expect(signature.dataTypeName).toBe('AddPetRequest')
-    expect(signature.dataTypeDefinition).toContain("body: AddPetRequestConfig['data']")
-    expect(signature.dataTypeDefinition).toContain("path?: AddPetRequestConfig['pathParams']")
-    expect(signature.dataTypeDefinition).toContain("query?: AddPetRequestConfig['queryParams']")
-    expect(signature.dataTypeDefinition).toContain("headers?: AddPetRequestConfig['headerParams']")
-    expect(signature.dataTypeDefinition).toContain("url: AddPetRequestConfig['url']")
-  })
-
-  test('marks the body optional when the operation has no request body', () => {
-    const signature = buildGroupedOptionsSignature({ node: listPets, tsResolver: resolverTs })
-    expect(signature.dataTypeDefinition).toContain("body?: ListPetsRequestConfig['data']")
+    expect(signature.dataTypeName).toBe('AddPetRequestConfig')
   })
 
   test('imports only the request-config and responses types', () => {

--- a/internals/client/src/builders/signature.ts
+++ b/internals/client/src/builders/signature.ts
@@ -1,5 +1,5 @@
 import { ast } from '@kubb/core'
-import { functionPrinter, type ResolverTs, renderType } from '@kubb/plugin-ts'
+import { functionPrinter, type ResolverTs } from '@kubb/plugin-ts'
 import { buildRequestResultGenerics } from './generics.ts'
 
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
@@ -9,16 +9,12 @@ const declarationPrinter = functionPrinter({ mode: 'declaration' })
  */
 export type GroupedOptionsSignature = {
   /**
-   * Name of the per-operation grouped data type (`<Name>Data`).
+   * Name of the per-operation grouped data type, the plugin-ts `<Name>RequestConfig` used directly
+   * as the function input.
    */
   dataTypeName: string
   /**
-   * Rendered body of the per-operation grouped data type, with the contract key names
-   * (`body` / `path` / `query` / `headers` / `url`) derived from the plugin-ts `<Name>RequestConfig`.
-   */
-  dataTypeDefinition: string
-  /**
-   * The single function parameter: `options: Options<<Name>Data, ThrowOnError>`.
+   * The single function parameter: `options: Options<<Name>RequestConfig, ThrowOnError>`.
    */
   paramsSignature: string
   /**
@@ -37,45 +33,26 @@ export type GroupedOptionsSignature = {
 
 /**
  * Builds the grouped-options signature for one operation: a single `options` object whose `TData`
- * carries a literal `url`, and a `RequestResult` return type keyed to the plugin-ts per-status
- * responses record. There are no positional arguments.
+ * is the plugin-ts `<Name>RequestConfig` (carrying a literal `url`), and a `RequestResult` return type
+ * keyed to the plugin-ts per-status responses record. There are no positional arguments.
  *
- * The grouped data type is an AST type literal whose members index into the plugin-ts
- * `<Name>RequestConfig`, so the generated file only imports `<Name>RequestConfig` and `<Name>Responses`
- * and never collides with the per-direction type names.
+ * The generated file imports `<Name>RequestConfig` and `<Name>Responses` and uses them directly, so no
+ * per-operation input type has to be emitted.
  */
 export function buildGroupedOptionsSignature({ node, tsResolver }: { node: ast.OperationNode; tsResolver: ResolverTs }): GroupedOptionsSignature {
   const requestConfigName = tsResolver.resolveRequestConfigName(node)
   const responsesName = tsResolver.resolveResponsesName(node)
-  // File-local type (not exported, never barreled), so it only has to stay distinct from the
-  // imported `<Name>RequestConfig` and `<Name>Responses` within the same file.
-  const dataTypeName = `${requestConfigName.replace(/RequestConfig$/, '')}Request`
-  const hasBody = Boolean(node.requestBody?.content?.[0]?.schema)
   const resultGenerics = buildRequestResultGenerics({ node, tsResolver })
-
-  const indexed = (key: string) => ast.factory.createIndexedAccessType({ target: requestConfigName, key })
-  const dataTypeDefinition = renderType(
-    ast.factory.createTypeLiteral({
-      members: [
-        { name: 'body', type: indexed('data'), optional: !hasBody },
-        { name: 'path', type: indexed('pathParams'), optional: true },
-        { name: 'query', type: indexed('queryParams'), optional: true },
-        { name: 'headers', type: indexed('headerParams'), optional: true },
-        { name: 'url', type: indexed('url'), optional: false },
-      ],
-    }),
-  )
 
   const paramsSignature =
     declarationPrinter.print(
       ast.factory.createFunctionParameters({
-        params: [ast.factory.createFunctionParameter({ name: 'options', type: `Options<${dataTypeName}, ThrowOnError>` })],
+        params: [ast.factory.createFunctionParameter({ name: 'options', type: `Options<${requestConfigName}, ThrowOnError>` })],
       }),
     ) ?? ''
 
   return {
-    dataTypeName,
-    dataTypeDefinition,
+    dataTypeName: requestConfigName,
     paramsSignature,
     returnType: `Promise<RequestResult<${resultGenerics}>>`,
     generics: ['ThrowOnError extends boolean = true'],

--- a/internals/client/src/components/Operation.tsx
+++ b/internals/client/src/components/Operation.tsx
@@ -2,7 +2,7 @@ import { buildOperationComments } from '@internals/shared'
 import { ast } from '@kubb/core'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
-import { File, Function, Type } from '@kubb/renderer-jsx'
+import { File, Function } from '@kubb/renderer-jsx'
 import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import { buildReturnStatement } from '../builders/returnStatement.ts'
 import { buildSecurityMetadata, type SecurityRequirement } from '../builders/security.ts'
@@ -63,27 +63,19 @@ export function Operation({ name, node, tsResolver, zodResolver, parser, securit
     .join(', ')} }`
 
   return (
-    <>
-      <File.Source name={signature.dataTypeName} isExportable={false} isIndexable={false}>
-        <Type export={false} name={signature.dataTypeName}>
-          {signature.dataTypeDefinition}
-        </Type>
-      </File.Source>
-      <br />
-      <File.Source name={name} isExportable={isExportable} isIndexable={isIndexable}>
-        <Function
-          name={name}
-          export={isExportable}
-          generics={signature.generics}
-          params={signature.paramsSignature}
-          returnType={signature.returnType}
-          JSDoc={{ comments: buildOperationComments(node, { link: 'urlPath', linkPosition: 'beforeDeprecated', splitLines: true }) }}
-        >
-          {'const { client: request = client, ...config } = options'}
-          <br />
-          {buildReturnStatement({ node, tsResolver, callConfig })}
-        </Function>
-      </File.Source>
-    </>
+    <File.Source name={name} isExportable={isExportable} isIndexable={isIndexable}>
+      <Function
+        name={name}
+        export={isExportable}
+        generics={signature.generics}
+        params={signature.paramsSignature}
+        returnType={signature.returnType}
+        JSDoc={{ comments: buildOperationComments(node, { link: 'urlPath', linkPosition: 'beforeDeprecated', splitLines: true }) }}
+      >
+        {'const { client: request = client, ...config } = options'}
+        <br />
+        {buildReturnStatement({ node, tsResolver, callConfig })}
+      </Function>
+    </File.Source>
   )
 }

--- a/packages/plugin-fetch/src/generators/__snapshots__/addPetMultiStatus/addPet.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/addPetMultiStatus/addPet.ts
@@ -4,19 +4,11 @@ import type { Options, RequestResult } from './.kubb/client'
 import type { AddPetRequestConfig, AddPetResponses } from './AddPet'
 import { client } from './.kubb/client'
 
-type AddPetRequest = {
-  body: AddPetRequestConfig['data']
-  path?: AddPetRequestConfig['pathParams']
-  query?: AddPetRequestConfig['queryParams']
-  headers?: AddPetRequestConfig['headerParams']
-  url: AddPetRequestConfig['url']
-}
-
 /**
  * {@link /pet}
  */
 export function addPet<ThrowOnError extends boolean = true>(
-  options: Options<AddPetRequest, ThrowOnError>,
+  options: Options<AddPetRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<AddPetResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/addPetMultiStatusWithZod/addPet.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/addPetMultiStatusWithZod/addPet.ts
@@ -5,19 +5,11 @@ import type { AddPetRequestConfig, AddPetResponses } from './AddPet'
 import { client } from './.kubb/client'
 import { AddPetResponse } from './AddPet'
 
-type AddPetRequest = {
-  body: AddPetRequestConfig['data']
-  path?: AddPetRequestConfig['pathParams']
-  query?: AddPetRequestConfig['queryParams']
-  headers?: AddPetRequestConfig['headerParams']
-  url: AddPetRequestConfig['url']
-}
-
 /**
  * {@link /pet}
  */
 export function addPet<ThrowOnError extends boolean = true>(
-  options: Options<AddPetRequest, ThrowOnError>,
+  options: Options<AddPetRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<AddPetResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/deletePetNoContent/deletePet.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/deletePetNoContent/deletePet.ts
@@ -4,19 +4,11 @@ import type { Options, RequestResult } from './.kubb/client'
 import type { DeletePetRequestConfig, DeletePetResponses } from './DeletePet'
 import { client } from './.kubb/client'
 
-type DeletePetRequest = {
-  body?: DeletePetRequestConfig['data']
-  path?: DeletePetRequestConfig['pathParams']
-  query?: DeletePetRequestConfig['queryParams']
-  headers?: DeletePetRequestConfig['headerParams']
-  url: DeletePetRequestConfig['url']
-}
-
 /**
  * {@link /pet/:petId}
  */
 export function deletePet<ThrowOnError extends boolean = true>(
-  options: Options<DeletePetRequest, ThrowOnError>,
+  options: Options<DeletePetRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<DeletePetResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/findPetsByTags/findPetsByTags.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/findPetsByTags/findPetsByTags.ts
@@ -4,19 +4,11 @@ import type { Options, RequestResult } from './.kubb/client'
 import type { FindPetsByTagsRequestConfig, FindPetsByTagsResponses } from './FindPetsByTags'
 import { client } from './.kubb/client'
 
-type FindPetsByTagsRequest = {
-  body?: FindPetsByTagsRequestConfig['data']
-  path?: FindPetsByTagsRequestConfig['pathParams']
-  query?: FindPetsByTagsRequestConfig['queryParams']
-  headers?: FindPetsByTagsRequestConfig['headerParams']
-  url: FindPetsByTagsRequestConfig['url']
-}
-
 /**
  * {@link /pet/findByTags}
  */
 export function findPetsByTags<ThrowOnError extends boolean = true>(
-  options: Options<FindPetsByTagsRequest, ThrowOnError>,
+  options: Options<FindPetsByTagsRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/getPetById/getPetById.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/getPetById/getPetById.ts
@@ -4,19 +4,11 @@ import type { Options, RequestResult } from './.kubb/client'
 import type { GetPetByIdRequestConfig, GetPetByIdResponses } from './GetPetById'
 import { client } from './.kubb/client'
 
-type GetPetByIdRequest = {
-  body?: GetPetByIdRequestConfig['data']
-  path?: GetPetByIdRequestConfig['pathParams']
-  query?: GetPetByIdRequestConfig['queryParams']
-  headers?: GetPetByIdRequestConfig['headerParams']
-  url: GetPetByIdRequestConfig['url']
-}
-
 /**
  * {@link /pet/:petId}
  */
 export function getPetById<ThrowOnError extends boolean = true>(
-  options: Options<GetPetByIdRequest, ThrowOnError>,
+  options: Options<GetPetByIdRequestConfig, ThrowOnError>,
 ): Promise<RequestResult<GetPetByIdResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 

--- a/packages/plugin-ts/src/generators/__snapshots__/addPetPOSTWithRequestBody/AddPet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/addPetPOSTWithRequestBody/AddPet.ts
@@ -22,10 +22,10 @@ export type AddPetData = object
  * @type object
  */
 export type AddPetRequestConfig = {
-  data?: AddPetData
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body: AddPetData
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/arrayOfObjectWithNestedEnumRegressionForKubbLabsKubb3475/GetArrayOfObject.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/arrayOfObjectWithNestedEnumRegressionForKubbLabsKubb3475/GetArrayOfObject.ts
@@ -28,10 +28,10 @@ export type GetArrayOfObjectStatus200 = {
  * @type object
  */
 export type GetArrayOfObjectRequestConfig = {
-  data?: never
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body?: never
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/deletePetDELETEWithNoResponseBody/DeletePet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/deletePetDELETEWithNoResponseBody/DeletePet.ts
@@ -17,15 +17,15 @@ export type DeletePetStatus204 = void
  * @type object
  */
 export type DeletePetRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: DeletePetPathPetId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/findArtifactsGETWithMultipleQueryParams/FindArtifacts.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/findArtifactsGETWithMultipleQueryParams/FindArtifacts.ts
@@ -27,17 +27,17 @@ export type FindArtifactsStatus200 = object
  * @type object
  */
 export type FindArtifactsRequestConfig = {
-  data?: never
-  pathParams?: never
+  body?: never
+  path?: never
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     page?: FindArtifactsQueryPage
     limit?: FindArtifactsQueryLimit
     sort?: FindArtifactsQuerySort
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/findPetsByStatusGETWithQueryParamEnum/FindPetsByStatus.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/findPetsByStatusGETWithQueryParamEnum/FindPetsByStatus.ts
@@ -17,15 +17,15 @@ export type FindPetsByStatusStatus200 = object
  * @type object
  */
 export type FindPetsByStatusRequestConfig = {
-  data?: never
-  pathParams?: never
+  body?: never
+  path?: never
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     status?: FindPetsByStatusQueryStatus
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/getPreferencesUnitsGETWithInlineArrayOfObjectResponseContainingANestedEnum/GetPreferencesUnits.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/getPreferencesUnitsGETWithInlineArrayOfObjectResponseContainingANestedEnum/GetPreferencesUnits.ts
@@ -33,10 +33,10 @@ export type GetPreferencesUnitsStatus200 = {
  * @type object
  */
 export type GetPreferencesUnitsRequestConfig = {
-  data?: never
-  pathParams?: never
-  queryParams?: never
-  headerParams?: never
+  body?: never
+  path?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/listPetsGETWithQueryParams/ListPets.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/listPetsGETWithQueryParams/ListPets.ts
@@ -22,15 +22,15 @@ export type ListPetsStatusDefault = object
  * @type object
  */
 export type ListPetsRequestConfig = {
-  data?: never
-  pathParams?: never
+  body?: never
+  path?: never
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     limit?: ListPetsQueryLimit
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/multiContentTypeGETWithJsonAndXmlResponseBody/GetPetById.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/multiContentTypeGETWithJsonAndXmlResponseBody/GetPetById.ts
@@ -34,15 +34,15 @@ export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200X
  * @type object
  */
 export type GetPetByIdRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: GetPetByIdPathPetId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/multiContentTypePOSTWithJsonAndFormDataRequestBody/UploadFile.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/multiContentTypePOSTWithJsonAndFormDataRequestBody/UploadFile.ts
@@ -39,15 +39,15 @@ export type UploadFileData = UploadFileJsonData | UploadFileFormData
  * @type object
  */
 export type UploadFileRequestConfig = {
-  data?: UploadFileData
+  body: UploadFileData
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: UploadFilePathPetId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/noTagsOperationGETWithNoTags/GetEnterpriseConfigurationsIdV20250.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/noTagsOperationGETWithNoTags/GetEnterpriseConfigurationsIdV20250.ts
@@ -17,15 +17,15 @@ export type GetEnterpriseConfigurationsIdV20250Status200 = object
  * @type object
  */
 export type GetEnterpriseConfigurationsIdV20250RequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     enterprise_id: GetEnterpriseConfigurationsIdV20250PathEnterpriseId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/paramsCasingCamelcase/UpdatePet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/paramsCasingCamelcase/UpdatePet.ts
@@ -37,21 +37,21 @@ export type UpdatePetData = {
  * @type object
  */
 export type UpdatePetRequestConfig = {
-  data?: UpdatePetData
+  body: UpdatePetData
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: UpdatePetPathPetId
   }
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     includeDeleted?: UpdatePetQueryIncludeDeleted
     requestSource?: UpdatePetQueryRequestSource
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/paramsCasingUndefined/UpdatePet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/paramsCasingUndefined/UpdatePet.ts
@@ -37,21 +37,21 @@ export type UpdatePetData = {
  * @type object
  */
 export type UpdatePetRequestConfig = {
-  data?: UpdatePetData
+  body: UpdatePetData
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     pet_id: UpdatePetPathPetId
   }
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     include_deleted?: UpdatePetQueryIncludeDeleted
     request_source?: UpdatePetQueryRequestSource
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/PlaceOrderPatch.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/PlaceOrderPatch.ts
@@ -28,15 +28,15 @@ export type PlaceOrderPatchData = object
  * @type object
  */
 export type PlaceOrderPatchRequestConfig = {
-  data?: PlaceOrderPatchData
+  body: PlaceOrderPatchData
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     orderId: PlaceOrderPatchPathOrderId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/showPetByIdGETWithPathParam/ShowPetById.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/showPetByIdGETWithPathParam/ShowPetById.ts
@@ -22,15 +22,15 @@ export type ShowPetByIdStatusDefault = object
  * @type object
  */
 export type ShowPetByIdRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: ShowPetByIdPathPetId
   }
-  queryParams?: never
-  headerParams?: never
+  query?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/updatePetWithFormPOSTWithPathAndQueryParams/UpdatePetWithForm.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/updatePetWithFormPOSTWithPathAndQueryParams/UpdatePetWithForm.ts
@@ -32,21 +32,21 @@ export type UpdatePetWithFormStatus405 = object
  * @type object
  */
 export type UpdatePetWithFormRequestConfig = {
-  data?: never
+  body?: never
   /**
-   * @type object
+   * @type object | undefined
    */
-  pathParams: {
+  path?: {
     petId: UpdatePetWithFormPathPetId
   }
   /**
    * @type object | undefined
    */
-  queryParams?: {
+  query?: {
     name?: UpdatePetWithFormQueryName
     status?: UpdatePetWithFormQueryStatus
   }
-  headerParams?: never
+  headers?: never
   /**
    * @type string
    */

--- a/packages/plugin-ts/src/resolvers/resolverTs.ts
+++ b/packages/plugin-ts/src/resolvers/resolverTs.ts
@@ -45,6 +45,8 @@ export const resolverTs = defineResolver<PluginTs>(() => {
       return this.resolveTypeName(`${node.operationId} Data`)
     },
     resolveRequestConfigName(node) {
+      // NOTE(v5-stable): the `RequestConfig` suffix is kept through the beta to avoid churn, but it
+      // overlaps with the runtime client's `RequestConfig`. Revisit renaming to `Request` before stable.
       return this.resolveTypeName(`${node.operationId} RequestConfig`)
     },
     resolveResponsesName(node) {

--- a/packages/plugin-ts/src/types.ts
+++ b/packages/plugin-ts/src/types.ts
@@ -38,6 +38,9 @@ export type ResolverTs = Resolver &
     /**
      * Resolves the name for an operation's request config (`RequestConfig`).
      *
+     * The `RequestConfig` suffix is kept through the v5 beta to avoid churn, but it overlaps with the
+     * runtime client's `RequestConfig`. Renaming to `Request` is on the table before stable.
+     *
      * @example Request config names
      * `resolver.resolveRequestConfigName(node) // → 'ListPetsRequestConfig'`
      */

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -49,15 +49,15 @@ describe('buildParams', () => {
 describe('buildData', () => {
   const baseNode = ast.factory.createOperation({ operationId: 'listPets', method: 'GET', path: '/pets' })
 
-  it('emits data?: never when no request body', () => {
+  it('emits body?: never when no request body', () => {
     const node = ast.factory.createOperation({ operationId: 'listPets', method: 'GET', path: '/pets' })
 
     expect(printSchema(buildData(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
       "{
-          data?: never;
-          pathParams?: never;
-          queryParams?: never;
-          headerParams?: never;
+          body?: never;
+          path?: never;
+          query?: never;
+          headers?: never;
           /**
            * @type string
           */
@@ -66,7 +66,7 @@ describe('buildData', () => {
     `)
   })
 
-  it('emits data? referencing the Data type when body exists', () => {
+  it('emits required body referencing the Data type when body exists', () => {
     const node = ast.factory.createOperation({
       operationId: 'createPet',
       method: 'POST',
@@ -76,10 +76,10 @@ describe('buildData', () => {
 
     expect(printSchema(buildData(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
       "{
-          data?: CreatePetData;
-          pathParams?: never;
-          queryParams?: never;
-          headerParams?: never;
+          body: CreatePetData;
+          path?: never;
+          query?: never;
+          headers?: never;
           /**
            * @type string
           */
@@ -88,7 +88,7 @@ describe('buildData', () => {
     `)
   })
 
-  it('emits required pathParams when path parameters exist', () => {
+  it('emits optional path when path parameters exist', () => {
     const node = ast.factory.createOperation({
       operationId: 'showPetById',
       method: 'GET',
@@ -98,15 +98,15 @@ describe('buildData', () => {
 
     expect(printSchema(buildData(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
       "{
-          data?: never;
+          body?: never;
           /**
-           * @type object
+           * @type object | undefined
           */
-          pathParams: {
+          path?: {
               petId: ShowPetByIdPathPetId;
           };
-          queryParams?: never;
-          headerParams?: never;
+          query?: never;
+          headers?: never;
           /**
            * @type string
           */
@@ -115,7 +115,7 @@ describe('buildData', () => {
     `)
   })
 
-  it('emits optional queryParams when query parameters exist', () => {
+  it('emits optional query when query parameters exist', () => {
     const node = ast.factory.createOperation({
       ...baseNode,
       operationId: 'listPets',
@@ -124,15 +124,15 @@ describe('buildData', () => {
 
     expect(printSchema(buildData(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
       "{
-          data?: never;
-          pathParams?: never;
+          body?: never;
+          path?: never;
           /**
            * @type object | undefined
           */
-          queryParams?: {
+          query?: {
               limit?: ListPetsQueryLimit;
           };
-          headerParams?: never;
+          headers?: never;
           /**
            * @type string
           */
@@ -141,7 +141,7 @@ describe('buildData', () => {
     `)
   })
 
-  it('emits JSDoc on queryParams properties when parameters have descriptions', () => {
+  it('emits JSDoc on query properties when parameters have descriptions', () => {
     const node = ast.factory.createOperation({
       ...baseNode,
       operationId: 'listPets',
@@ -157,15 +157,15 @@ describe('buildData', () => {
 
     expect(printSchema(buildData(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
       "{
-          data?: never;
-          pathParams?: never;
+          body?: never;
+          path?: never;
           /**
            * @type object | undefined
           */
-          queryParams?: {
+          query?: {
               limit?: ListPetsQueryLimit;
           };
-          headerParams?: never;
+          headers?: never;
           /**
            * @type string
           */

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -79,34 +79,35 @@ export function buildParams(node: ast.OperationNode, { params, resolver }: Build
 
 export function buildData(node: ast.OperationNode, { resolver }: BuildOperationSchemaOptions): ast.SchemaNode {
   const { path: pathParams, query: queryParams, header: headerParams } = getOperationParameters(node)
+  const hasBody = Boolean(node.requestBody?.content?.[0]?.schema)
 
   return ast.factory.createSchema({
     type: 'object',
     deprecated: node.deprecated,
     properties: [
       ast.factory.createProperty({
-        name: 'data',
-        schema: node.requestBody?.content?.[0]?.schema
-          ? ast.factory.createSchema({ type: 'ref', name: resolver.resolveDataName(node), optional: true })
+        name: 'body',
+        required: hasBody,
+        schema: hasBody
+          ? ast.factory.createSchema({ type: 'ref', name: resolver.resolveDataName(node) })
           : ast.factory.createSchema({ type: 'never', primitive: undefined, optional: true }),
       }),
       ast.factory.createProperty({
-        name: 'pathParams',
-        required: pathParams.length > 0,
+        name: 'path',
         schema:
           pathParams.length > 0
-            ? buildParams(node, { params: pathParams, resolver })
+            ? ast.factory.createSchema({ ...buildParams(node, { params: pathParams, resolver }), optional: true })
             : ast.factory.createSchema({ type: 'never', primitive: undefined, optional: true }),
       }),
       ast.factory.createProperty({
-        name: 'queryParams',
+        name: 'query',
         schema:
           queryParams.length > 0
             ? ast.factory.createSchema({ ...buildParams(node, { params: queryParams, resolver }), optional: true })
             : ast.factory.createSchema({ type: 'never', primitive: undefined, optional: true }),
       }),
       ast.factory.createProperty({
-        name: 'headerParams',
+        name: 'headers',
         schema:
           headerParams.length > 0
             ? ast.factory.createSchema({ ...buildParams(node, { params: headerParams, resolver }), optional: true })

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -81,6 +81,9 @@ export function buildData(node: ast.OperationNode, { resolver }: BuildOperationS
   const { path: pathParams, query: queryParams, header: headerParams } = getOperationParameters(node)
   const hasBody = Boolean(node.requestBody?.content?.[0]?.schema)
 
+  // NOTE(v5-stable): the fields were renamed from the legacy beta shape
+  // (`data`/`pathParams`/`queryParams`/`headerParams`) to `body`/`path`/`query`/`headers` so the
+  // type matches the runtime client. Drop this note once v5 leaves beta.
   return ast.factory.createSchema({
     type: 'object',
     deprecated: node.deprecated,

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/CreateConfigV20250.ts
@@ -20,10 +20,10 @@ export type CreateConfigV20250Data = ConfigCreate;
  * @type object
 */
 export type CreateConfigV20250RequestConfig = {
-    data?: CreateConfigV20250Data;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: CreateConfigV20250Data;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/GetConfigIdV20250.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/GetConfigIdV20250.ts
@@ -19,15 +19,15 @@ export type GetConfigIdV20250Status200 = Config;
  * @type object
 */
 export type GetConfigIdV20250RequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         config_id: GetConfigIdV20250PathConfigId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/CreateOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/CreateOrder.ts
@@ -29,10 +29,10 @@ export type CreateOrderData = {
  * @type object
 */
 export type CreateOrderRequestConfig = {
-    data?: CreateOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: CreateOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetProducts.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetProducts.ts
@@ -25,10 +25,10 @@ export type GetProductsStatus200 = {
  * @type object
 */
 export type GetProductsRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetVariants.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetVariants.ts
@@ -14,10 +14,10 @@ export type GetVariantsStatus200 = Variant;
  * @type object
 */
 export type GetVariantsRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/duplicateEnum/types/GetNotifications.ts
+++ b/tests/3.0.x/__snapshots__/main/duplicateEnum/types/GetNotifications.ts
@@ -15,10 +15,10 @@ export type GetNotificationsStatus200 = (NotificationTypeA | NotificationTypeB)[
  * @type object
 */
 export type GetNotificationsRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/GetEmployers.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/GetEmployers.ts
@@ -14,10 +14,10 @@ export type GetEmployersStatus200 = Employer[];
  * @type object
 */
 export type GetEmployersRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/GetMe.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/GetMe.ts
@@ -14,10 +14,10 @@ export type GetMeStatus200 = User;
  * @type object
 */
 export type GetMeRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/CreateConfigV20250.ts
@@ -20,10 +20,10 @@ export type CreateConfigV20250Data = ConfigCreate;
  * @type object
 */
 export type CreateConfigV20250RequestConfig = {
-    data?: CreateConfigV20250Data;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: CreateConfigV20250Data;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
+++ b/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
@@ -19,15 +19,15 @@ export type GetConfigIdV20250Status200 = Config;
  * @type object
 */
 export type GetConfigIdV20250RequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         config_id: GetConfigIdV20250PathConfigId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/main/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
@@ -17,15 +17,15 @@ export type CustomGetItemStatus200 = Item;
  * @type object
 */
 export type CustomGetItemRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         id: CustomGetItemPathId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/main/simple/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
@@ -21,15 +21,15 @@ export type GetItemStatus200 = Item;
  * @type object
 */
 export type GetItemRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         id: GetItemPathId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/baseURL/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/clientTypeClass/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/dataReturnTypeFull/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/groupByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/operations/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/operations/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsCasing/types/UpdatePet.ts
@@ -35,21 +35,21 @@ export type UpdatePetData = PetUpdate;
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    data?: UpdatePetData;
+    body: UpdatePetData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         pet_id: UpdatePetPathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         include_deleted?: UpdatePetQueryIncludeDeleted;
         request_source?: UpdatePetQueryRequestSource;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/paramsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZod/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/parserZodDateCoercion/types/CreateEvent.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/parserZodDateCoercion/types/CreateEvent.ts
@@ -25,10 +25,10 @@ export type CreateEventData = Event;
  * @type object
 */
 export type CreateEventRequestConfig = {
-    data?: CreateEventData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: CreateEventData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/pathParamsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginClient/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/UpdatePet.ts
@@ -35,21 +35,21 @@ export type UpdatePetData = PetUpdate;
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    data?: UpdatePetData;
+    body: UpdatePetData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         pet_id: UpdatePetPathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         include_deleted?: UpdatePetQueryIncludeDeleted;
         request_source?: UpdatePetQueryRequestSource;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/UpdatePet.ts
@@ -35,21 +35,21 @@ export type UpdatePetData = PetUpdate;
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    data?: UpdatePetData;
+    body: UpdatePetData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         pet_id: UpdatePetPathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         include_deleted?: UpdatePetQueryIncludeDeleted;
         request_source?: UpdatePetQueryRequestSource;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/UpdatePet.ts
@@ -35,21 +35,21 @@ export type UpdatePetData = PetUpdate;
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    data?: UpdatePetData;
+    body: UpdatePetData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         pet_id: UpdatePetPathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         include_deleted?: UpdatePetQueryIncludeDeleted;
         request_source?: UpdatePetQueryRequestSource;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/pathParamsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/dataReturnTypeFull/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/UpdatePet.ts
@@ -35,21 +35,21 @@ export type UpdatePetData = PetUpdate;
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    data?: UpdatePetData;
+    body: UpdatePetData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         pet_id: UpdatePetPathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         include_deleted?: UpdatePetQueryIncludeDeleted;
         request_source?: UpdatePetQueryRequestSource;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/pathParamsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/CreateConfigV20250.ts
@@ -20,10 +20,10 @@ export type CreateConfigV20250Data = ConfigCreate;
  * @type object
 */
 export type CreateConfigV20250RequestConfig = {
-    data?: CreateConfigV20250Data;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: CreateConfigV20250Data;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
@@ -19,15 +19,15 @@ export type GetConfigIdV20250Status200 = Config;
  * @type object
 */
 export type GetConfigIdV20250RequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         config_id: GetConfigIdV20250PathConfigId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/UpdatePet.ts
@@ -35,21 +35,21 @@ export type UpdatePetData = PetUpdate;
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    data?: UpdatePetData;
+    body: UpdatePetData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         pet_id: UpdatePetPathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         include_deleted?: UpdatePetQueryIncludeDeleted;
         request_source?: UpdatePetQueryRequestSource;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/pathParamsTypeObject/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPet.ts
@@ -47,10 +47,10 @@ export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedD
  * @type object
 */
 export type AddPetRequestConfig = {
-    data?: AddPetData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: AddPetData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeletePet.ts
@@ -25,18 +25,18 @@ export type DeletePetStatus400 = any;
  * @type object
 */
 export type DeletePetRequestConfig = {
-    data?: never;
-    /**
-     * @type object
-    */
-    pathParams: {
-        petId: DeletePetPathPetId;
-    };
-    queryParams?: never;
+    body?: never;
     /**
      * @type object | undefined
     */
-    headerParams?: {
+    path?: {
+        petId: DeletePetPathPetId;
+    };
+    query?: never;
+    /**
+     * @type object | undefined
+    */
+    headers?: {
         api_key?: DeletePetHeaderApiKey;
     };
     /**

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/FindPetsByStatus.ts
@@ -33,15 +33,15 @@ export type FindPetsByStatusStatus400 = any;
  * @type object
 */
 export type FindPetsByStatusRequestConfig = {
-    data?: never;
-    pathParams?: never;
+    body?: never;
+    path?: never;
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         status?: FindPetsByStatusQueryStatus;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetInventory.ts
@@ -14,10 +14,10 @@ export type GetInventoryStatus200 = {
  * @type object
 */
 export type GetInventoryRequestConfig = {
-    data?: never;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body?: never;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetPetById.ts
@@ -39,15 +39,15 @@ export type GetPetByIdStatus404 = any;
  * @type object
 */
 export type GetPetByIdRequestConfig = {
-    data?: never;
+    body?: never;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: GetPetByIdPathPetId;
     };
-    queryParams?: never;
-    headerParams?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/PlaceOrder.ts
@@ -36,10 +36,10 @@ export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrde
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    data?: PlaceOrderData;
-    pathParams?: never;
-    queryParams?: never;
-    headerParams?: never;
+    body: PlaceOrderData;
+    path?: never;
+    query?: never;
+    headers?: never;
     /**
      * @type string
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
@@ -33,20 +33,20 @@ export type UploadFileData = Blob | undefined;
  * @type object
 */
 export type UploadFileRequestConfig = {
-    data?: UploadFileData;
+    body: UploadFileData;
     /**
-     * @type object
+     * @type object | undefined
     */
-    pathParams: {
+    path?: {
         petId: UploadFilePathPetId;
     };
     /**
      * @type object | undefined
     */
-    queryParams?: {
+    query?: {
         additionalMetadata?: UploadFileQueryAdditionalMetadata;
     };
-    headerParams?: never;
+    headers?: never;
     /**
      * @type string
     */


### PR DESCRIPTION
## 🎯 Changes

Splits out the slim-client input-type cleanup from #426 so it can be reviewed on its own.

Today two types describe one operation's request input:

- **plugin-ts** emits `<Operation>RequestConfig` with `data` / `pathParams` / `queryParams` / `headerParams` / `url`.
- **plugin-fetch** then emits a throwaway, file-local `<Operation>Request` that only re-indexes that type to rename the fields to `body` / `path` / `query` / `headers` / `url` — the names the runtime `RequestConfig` / `DataShape` in `templates/fetch.ts` already use.

The remap existed purely to bridge that naming gap. This PR makes plugin-ts emit the final field names directly, and plugin-fetch uses the type as-is — deleting the per-operation remap entirely.

```ts
// Before
type AddPetRequest = {
  body: AddPetRequestConfig['data']
  path?: AddPetRequestConfig['pathParams']
  query?: AddPetRequestConfig['queryParams']
  headers?: AddPetRequestConfig['headerParams']
  url: AddPetRequestConfig['url']
}
export function addPet<ThrowOnError extends boolean = true>(options: Options<AddPetRequest, ThrowOnError>): ...

// After
export function addPet<ThrowOnError extends boolean = true>(options: Options<AddPetRequestConfig, ThrowOnError>): ...
```

### Implementation

- `packages/plugin-ts/src/utils.ts` (`buildData`): rename properties to `body` / `path` / `query` / `headers` / `url`; `body` is required when the operation has a request body. Absent params stay `never`.
- `internals/client/src/builders/signature.ts`: drop the indexed-access remap; the grouped data type is now the imported `<Operation>RequestConfig`.
- `internals/client/src/components/Operation.tsx`: stop emitting the file-local input type.

### Notes

- `<Operation>RequestConfig` (via `resolveRequestConfigName`) is consumed in source only by plugin-ts (emits it), plugin-fetch (imports it), and `internals/client` (built the remap). The query / client / swr / vue-query / mcp plugins use their own runtime `RequestConfig` from the client template, not plugin-ts's type — so the field rename is contained. The large snapshot diff is the `<Operation>RequestConfig` type regenerating across the e2e suites.
- Most of the diff is regenerated snapshots and the `examples/fetch-slim` output.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

### Verification

- `vitest run` for `plugin-ts`, `plugin-fetch`, and `internals/client` — green (snapshots updated)
- `turbo typecheck` for `@kubb/plugin-ts` + `@kubb/plugin-fetch` — green
- `oxlint` (packages + examples + `internals/client`) — clean
- `oxfmt` — clean
- Regenerated `examples/fetch-slim`; its `typecheck` generation hook passes, proving `Options<<Operation>RequestConfig, ThrowOnError>` type-checks end-to-end

> [!NOTE]
> Docs follow-up tracked separately: the old field names appear in `docs/5.x/migration-guide/plugin-client.md` in the docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018kYZ4JyfQSnpSSJtLbAm9y)_