### PR TITLE
refactor(shared): default getOperationParameters to camelcase

### DIFF
--- a/internals/shared/src/operation.test.ts
+++ b/internals/shared/src/operation.test.ts
@@ -214,23 +214,6 @@ describe('getOperationParameters', () => {
     expect(grouped.header.map((param) => param.name)).toStrictEqual(['xApiKey'])
     expect(grouped.cookie.map((param) => param.name)).toStrictEqual(['sessionId'])
   })
-
-  test('keeps the original spec names with paramsCasing: original', () => {
-    const node = ast.factory.createOperation({
-      operationId: 'showPet',
-      method: 'GET',
-      path: '/pets/{pet-id}',
-      parameters: [
-        ast.factory.createParameter({ name: 'pet-id', in: 'path', schema: ast.factory.createSchema({ type: 'string' }) }),
-        ast.factory.createParameter({ name: 'page-size', in: 'query', schema: ast.factory.createSchema({ type: 'number' }) }),
-      ],
-    })
-
-    const grouped = getOperationParameters(node, { paramsCasing: 'original' })
-
-    expect(grouped.path.map((param) => param.name)).toStrictEqual(['pet-id'])
-    expect(grouped.query.map((param) => param.name)).toStrictEqual(['page-size'])
-  })
 })
 
 describe('resolveOperationTypeNames', () => {

--- a/internals/shared/src/operation.test.ts
+++ b/internals/shared/src/operation.test.ts
@@ -207,12 +207,29 @@ describe('getOperationParameters', () => {
       ],
     })
 
-    const grouped = getOperationParameters(node, { paramsCasing: 'camelcase' })
+    const grouped = getOperationParameters(node)
 
     expect(grouped.path.map((param) => param.name)).toStrictEqual(['petId'])
     expect(grouped.query.map((param) => param.name)).toStrictEqual(['pageSize'])
     expect(grouped.header.map((param) => param.name)).toStrictEqual(['xApiKey'])
     expect(grouped.cookie.map((param) => param.name)).toStrictEqual(['sessionId'])
+  })
+
+  test('keeps the original spec names with paramsCasing: original', () => {
+    const node = ast.factory.createOperation({
+      operationId: 'showPet',
+      method: 'GET',
+      path: '/pets/{pet-id}',
+      parameters: [
+        ast.factory.createParameter({ name: 'pet-id', in: 'path', schema: ast.factory.createSchema({ type: 'string' }) }),
+        ast.factory.createParameter({ name: 'page-size', in: 'query', schema: ast.factory.createSchema({ type: 'number' }) }),
+      ],
+    })
+
+    const grouped = getOperationParameters(node, { paramsCasing: 'original' })
+
+    expect(grouped.path.map((param) => param.name)).toStrictEqual(['pet-id'])
+    expect(grouped.query.map((param) => param.name)).toStrictEqual(['page-size'])
   })
 })
 
@@ -236,7 +253,7 @@ describe('resolveOperationTypeNames', () => {
       ],
     })
 
-    expect(resolveOperationTypeNames(node, resolver, { paramsCasing: 'camelcase', exclude: ['Status200'] })).toStrictEqual([
+    expect(resolveOperationTypeNames(node, resolver, { exclude: ['Status200'] })).toStrictEqual([
       'petIdPathParams',
       'pageSizeQueryParams',
       'xApiKeyHeaderParams',

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -64,7 +64,7 @@ type ResponseLike = {
 export type OperationParameterGroups = Record<ast.ParameterNode['in'], Array<ast.ParameterNode>>
 
 export type ResolveOperationTypeNameOptions = {
-  paramsCasing?: 'camelcase'
+  paramsCasing?: 'camelcase' | 'original'
   responseStatusNames?: boolean | 'error'
   exclude?: ReadonlyArray<string | undefined>
   order?: 'params-first' | 'body-response-first'
@@ -286,8 +286,8 @@ export function buildOperationComments(node: ast.OperationNode, options: BuildOp
   return filteredComments.flatMap((text) => text.split(/\r?\n/).map((line) => line.trim())).filter((comment): comment is string => Boolean(comment))
 }
 
-export function getOperationParameters(node: ast.OperationNode, options: { paramsCasing?: 'camelcase' } = {}): OperationParameterGroups {
-  const params = caseParams(node.parameters, options.paramsCasing)
+export function getOperationParameters(node: ast.OperationNode, options: { paramsCasing?: 'camelcase' | 'original' } = {}): OperationParameterGroups {
+  const params = caseParams(node.parameters, options.paramsCasing === 'original' ? undefined : 'camelcase')
 
   return {
     path: params.filter((param) => param.in === 'path'),

--- a/internals/tanstack-query/src/utils.ts
+++ b/internals/tanstack-query/src/utils.ts
@@ -187,7 +187,7 @@ export function resolveQueryParamsParser(parser: ParserOption): 'zod' | null {
  */
 export function resolveZodSchemaNames(node: ast.OperationNode, zodResolver: ZodSchemaNameResolverLike | null | undefined, parser: ParserOption): Array<string> {
   if (!zodResolver || !parser) return []
-  const { query: queryParams } = getOperationParameters(node)
+  const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'original' })
   return [
     resolveResponseParser(parser) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
     resolveRequestParser(parser) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveDataName?.(node) : null,

--- a/packages/plugin-client/src/components/Client.tsx
+++ b/packages/plugin-client/src/components/Client.tsx
@@ -62,8 +62,8 @@ export function Client({
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
   const responseType = getResponseType(node)
 
-  const { query: originalQueryParams, header: originalHeaderParams } = getOperationParameters(node)
-  const { query: casedQueryParams, header: casedHeaderParams } = getOperationParameters(node, { paramsCasing: 'camelcase' })
+  const { query: originalQueryParams, header: originalHeaderParams } = getOperationParameters(node, { paramsCasing: 'original' })
+  const { query: casedQueryParams, header: casedHeaderParams } = getOperationParameters(node)
 
   const queryParamsMapping = buildParamsMapping(originalQueryParams, casedQueryParams)
   const headerParamsMapping = buildParamsMapping(originalHeaderParams, casedHeaderParams)

--- a/packages/plugin-client/src/components/Url.tsx
+++ b/packages/plugin-client/src/components/Url.tsx
@@ -24,7 +24,7 @@ type GetParamsProps = {
 const declarationPrinter = functionPrinter({ mode: 'declaration' })
 
 function buildUrlParamsNode({ node, tsResolver }: GetParamsProps): ast.FunctionParametersNode {
-  const { path: pathParams } = getOperationParameters(node)
+  const { path: pathParams } = getOperationParameters(node, { paramsCasing: 'original' })
 
   if (pathParams.length === 0) {
     return ast.factory.createFunctionParameters({ params: [] })

--- a/packages/plugin-client/src/generators/classClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/classClientGenerator.tsx
@@ -33,7 +33,7 @@ function resolveTypeImportNames(node: ast.OperationNode, tsResolver: ResolverTs)
 }
 
 function resolveZodImportNames(node: ast.OperationNode, zodResolver: ResolverZod, parser: PluginClient['resolvedOptions']['parser']): Array<string> {
-  const { query: queryParams } = getOperationParameters(node)
+  const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'original' })
   const names: Array<string | null | undefined> = [
     resolveResponseParser(parser) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
     resolveRequestParser(parser) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveDataName?.(node) : null,

--- a/packages/plugin-client/src/generators/clientGenerator.tsx
+++ b/packages/plugin-client/src/generators/clientGenerator.tsx
@@ -34,12 +34,9 @@ export const clientGenerator = defineGenerator<PluginClient>({
     const pluginZod = isParserEnabled(parser) ? driver.getPlugin(pluginZodName) : null
     const zodResolver = pluginZod ? driver.getResolver(pluginZodName) : null
 
-    const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'camelcase' })
+    const { query: queryParams } = getOperationParameters(node)
 
-    const importedTypeNames = [
-      tsResolver.resolveRequestConfigName(node),
-      ...resolveOperationTypeNames(node, tsResolver, { paramsCasing: 'camelcase', includeParams: false }),
-    ]
+    const importedTypeNames = [tsResolver.resolveRequestConfigName(node), ...resolveOperationTypeNames(node, tsResolver, { includeParams: false })]
 
     const importedZodNames = zodResolver
       ? [

--- a/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
+++ b/packages/plugin-client/src/generators/staticClassClientGenerator.tsx
@@ -31,7 +31,7 @@ function resolveTypeImportNames(node: ast.OperationNode, tsResolver: ResolverTs)
 }
 
 function resolveZodImportNames(node: ast.OperationNode, zodResolver: ResolverZod, parser: PluginClient['resolvedOptions']['parser']): Array<string> {
-  const { query: queryParams } = getOperationParameters(node)
+  const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'original' })
   const names: Array<string | null | undefined> = [
     resolveResponseParser(parser) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
     resolveRequestParser(parser) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveDataName?.(node) : null,

--- a/packages/plugin-client/src/utils.ts
+++ b/packages/plugin-client/src/utils.ts
@@ -182,7 +182,7 @@ function buildClassClientParams({
   zodQueryParamsName?: string | null
   queryParamsMapping?: Record<string, string> | null
 }) {
-  const { query: queryParams } = getOperationParameters(node)
+  const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'original' })
   const queryParamsName = queryParams.length > 0 ? tsResolver.resolveQueryParamsName(node, queryParams[0]!) : null
   const requestName = node.requestBody?.content?.[0]?.schema ? tsResolver.resolveDataName(node) : null
   const responseType = getResponseType(node)
@@ -258,7 +258,7 @@ function buildQueryParamsLine({
   zodResolver?: ResolverZod | null
 }): string {
   if (resolveQueryParamsParser(parser) !== 'zod' || !zodResolver) return ''
-  const { query: queryParams } = getOperationParameters(node)
+  const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'original' })
   if (queryParams.length === 0) return ''
   const zodQueryParamsName = zodResolver.resolveQueryParamsName?.(node, queryParams[0]!)
   if (!zodQueryParamsName) return ''
@@ -300,8 +300,8 @@ export function buildClassMethod({
   if (!ast.isHttpOperationNode(node)) return ''
   const { defaultContentType: contentType, isMultipleContentTypes, hasFormData } = getContentTypeInfo(node)
   const isFormData = !isMultipleContentTypes && contentType === 'multipart/form-data'
-  const { query: queryParams, header: headerParams } = getOperationParameters(node)
-  const { query: casedQueryParams, header: casedHeaderParams } = getOperationParameters(node, { paramsCasing: 'camelcase' })
+  const { query: queryParams, header: headerParams } = getOperationParameters(node, { paramsCasing: 'original' })
+  const { query: casedQueryParams, header: casedHeaderParams } = getOperationParameters(node)
 
   const queryParamsMapping = buildParamsMapping(queryParams, casedQueryParams)
   const headerParamsMapping = buildParamsMapping(headerParams, casedHeaderParams)

--- a/packages/plugin-cypress/src/components/Request.tsx
+++ b/packages/plugin-cypress/src/components/Request.tsx
@@ -26,8 +26,8 @@ type Props = {
 export function Request({ baseURL = '', name, dataReturnType, resolver, node }: Props): KubbReactNode {
   if (!ast.isHttpOperationNode(node)) return null
 
-  const { query: originalQueryParams, header: originalHeaderParams } = getOperationParameters(node)
-  const { query: casedQueryParams, header: casedHeaderParams } = getOperationParameters(node, { paramsCasing: 'camelcase' })
+  const { query: originalQueryParams, header: originalHeaderParams } = getOperationParameters(node, { paramsCasing: 'original' })
+  const { query: casedQueryParams, header: casedHeaderParams } = getOperationParameters(node)
 
   const queryParamsMapping = buildParamsMapping(originalQueryParams, casedQueryParams)
   const headerParamsMapping = buildParamsMapping(originalHeaderParams, casedHeaderParams)

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -26,10 +26,7 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
 
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const importedTypeNames = [
-      tsResolver.resolveRequestConfigName(node),
-      ...resolveOperationTypeNames(node, tsResolver, { paramsCasing: 'camelcase', includeParams: false }),
-    ]
+    const importedTypeNames = [tsResolver.resolveRequestConfigName(node), ...resolveOperationTypeNames(node, tsResolver, { includeParams: false })]
 
     const meta = {
       name: resolver.resolveName(node.operationId),

--- a/packages/plugin-mcp/src/components/McpHandler.tsx
+++ b/packages/plugin-mcp/src/components/McpHandler.tsx
@@ -51,8 +51,8 @@ export function McpHandler({ name, node, resolver, baseURL, dataReturnType }: Pr
   const contentType = node.requestBody?.content?.[0]?.contentType
   const isFormData = contentType === 'multipart/form-data'
 
-  const { query: queryParams, header: headerParams } = getOperationParameters(node, { paramsCasing: 'camelcase' })
-  const { query: originalQueryParams, header: originalHeaderParams } = getOperationParameters(node)
+  const { query: queryParams, header: headerParams } = getOperationParameters(node)
+  const { query: originalQueryParams, header: originalHeaderParams } = getOperationParameters(node, { paramsCasing: 'original' })
 
   const requestName = node.requestBody?.content?.[0]?.schema ? resolver.resolveDataName(node) : null
   const responseName = resolver.resolveResponseName(node)

--- a/packages/plugin-mcp/src/components/Server.tsx
+++ b/packages/plugin-mcp/src/components/Server.tsx
@@ -55,7 +55,7 @@ const keysPrinter = functionPrinter({ mode: 'call' })
 export function Server({ name, serverName, serverVersion, operations }: Props): KubbReactNode {
   const registrations = operations
     .map(({ tool, mcp, zod, node }) => {
-      const { path: pathParams } = getOperationParameters(node, { paramsCasing: 'camelcase' })
+      const { path: pathParams } = getOperationParameters(node)
 
       const pathEntries: Array<{ key: string; value: string }> = []
       const otherEntries: Array<{ key: string; value: string }> = []

--- a/packages/plugin-mcp/src/generators/mcpGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/mcpGenerator.tsx
@@ -28,7 +28,7 @@ export const mcpGenerator = defineGenerator<PluginMcp>({
 
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const importedTypeNames = resolveOperationTypeNames(node, tsResolver, { paramsCasing: 'camelcase', responseStatusNames: 'error' })
+    const importedTypeNames = resolveOperationTypeNames(node, tsResolver, { responseStatusNames: 'error' })
 
     const meta = {
       name: resolver.resolveHandlerName(node),

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -44,7 +44,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
     }
 
     const operationsMapped = nodes.filter(ast.isHttpOperationNode).map((node) => {
-      const { path: pathParams, query: queryParams, header: headerParams } = getOperationParameters(node, { paramsCasing: 'camelcase' })
+      const { path: pathParams, query: queryParams, header: headerParams } = getOperationParameters(node)
 
       const mcpFile = resolver.resolveFile(
         { name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path },

--- a/packages/plugin-react-query/src/components/InfiniteQuery.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQuery.tsx
@@ -84,7 +84,7 @@ export function InfiniteQuery({
           ? 'boolean'
           : 'unknown'
 
-  const rawQueryParams = getOperationParameters(node).query
+  const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {

--- a/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
@@ -60,7 +60,7 @@ export function InfiniteQueryOptions({
           ? 'boolean'
           : 'unknown'
 
-  const rawQueryParams = getOperationParameters(node).query
+  const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {

--- a/packages/plugin-react-query/src/components/SuspenseInfiniteQuery.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseInfiniteQuery.tsx
@@ -84,7 +84,7 @@ export function SuspenseInfiniteQuery({
           ? 'boolean'
           : 'unknown'
 
-  const rawQueryParams = getOperationParameters(node).query
+  const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {

--- a/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
@@ -60,7 +60,7 @@ export function SuspenseInfiniteQueryOptions({
           ? 'boolean'
           : 'unknown'
 
-  const rawQueryParams = getOperationParameters(node).query
+  const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {

--- a/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/hookOptionsGenerator.tsx
@@ -73,7 +73,7 @@ export const hookOptionsGenerator = defineGenerator<PluginReactQuery>({
         if (isInfiniteOp) {
           // Validate queryParam
           const normalizeKey = (key: string) => key.replace(/\?$/, '')
-          const queryParamKeys = getOperationParameters(node).query.map((p) => p.name)
+          const queryParamKeys = getOperationParameters(node, { paramsCasing: 'original' }).query.map((p) => p.name)
           const hasQueryParam = nodeInfiniteOptions!.queryParam ? queryParamKeys.some((k) => normalizeKey(k) === nodeInfiniteOptions!.queryParam) : false
 
           if (hasQueryParam) {

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -39,7 +39,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
 
     // Validate queryParam exists in operation's query parameters
     const normalizeKey = (key: string) => key.replace(/\?$/, '')
-    const queryParamKeys = getOperationParameters(node).query.map((p) => p.name)
+    const queryParamKeys = getOperationParameters(node, { paramsCasing: 'original' }).query.map((p) => p.name)
     const hasQueryParam = infiniteOptions.queryParam ? queryParamKeys.some((k) => normalizeKey(k) === infiniteOptions.queryParam) : false
     // cursorParam validation against response schema keys is skipped in v5 (complex schema inspection)
     const hasCursorParam = !infiniteOptions.cursorParam || true
@@ -63,7 +63,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
       }),
     }
 
-    const rawQueryParams = getOperationParameters(node).query
+    const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
     const queryParamsTypeName =
       rawQueryParams.length > 0 && tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
         ? tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
@@ -73,7 +73,6 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
       tsResolver.resolveRequestConfigName(node),
       queryParamsTypeName,
       ...resolveOperationTypeNames(node, tsResolver, {
-        paramsCasing: 'camelcase',
         exclude: [queryKeyTypeName],
         order: 'body-response-first',
         includeParams: false,

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -54,7 +54,7 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
 
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
-      ...resolveOperationTypeNames(node, tsResolver, { paramsCasing: 'camelcase', order: 'body-response-first', includeParams: false }),
+      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
     ]
 
     const pluginZod = isParserEnabled(parser) ? driver.getPlugin(pluginZodName) : null

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -56,7 +56,6 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
       ...resolveOperationTypeNames(node, tsResolver, {
-        paramsCasing: 'camelcase',
         exclude: [queryKeyTypeName],
         order: 'body-response-first',
         includeParams: false,

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -40,7 +40,7 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
 
     // Validate queryParam exists in operation's query parameters
     const normalizeKey = (key: string) => key.replace(/\?$/, '')
-    const queryParamKeys = getOperationParameters(node).query.map((p) => p.name)
+    const queryParamKeys = getOperationParameters(node, { paramsCasing: 'original' }).query.map((p) => p.name)
     const hasQueryParam = infiniteOptions.queryParam ? queryParamKeys.some((k) => normalizeKey(k) === infiniteOptions.queryParam) : false
     const hasCursorParam = !infiniteOptions.cursorParam || true
 
@@ -63,7 +63,7 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
       }),
     }
 
-    const rawQueryParams = getOperationParameters(node).query
+    const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
     const queryParamsTypeName =
       rawQueryParams.length > 0 && tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
         ? tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
@@ -72,7 +72,7 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
       queryParamsTypeName,
-      ...resolveOperationTypeNames(node, tsResolver, { paramsCasing: 'camelcase', order: 'body-response-first', includeParams: false }),
+      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
     ].filter((name): name is string => Boolean(name))
 
     const pluginZod = isParserEnabled(parser) ? driver.getPlugin(pluginZodName) : null

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -58,7 +58,6 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
       ...resolveOperationTypeNames(node, tsResolver, {
-        paramsCasing: 'camelcase',
         exclude: [queryKeyTypeName],
         order: 'body-response-first',
         includeParams: false,

--- a/packages/plugin-swr/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-swr/src/generators/mutationGenerator.tsx
@@ -53,7 +53,7 @@ export const mutationGenerator = defineGenerator<PluginSwr>({
 
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
-      ...resolveOperationTypeNames(node, tsResolver, { paramsCasing: 'camelcase', order: 'body-response-first', includeParams: false }),
+      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
     ]
 
     const pluginZod = isParserEnabled(parser) ? driver.getPlugin(pluginZodName) : undefined

--- a/packages/plugin-swr/src/generators/queryGenerator.tsx
+++ b/packages/plugin-swr/src/generators/queryGenerator.tsx
@@ -49,7 +49,6 @@ export const queryGenerator = defineGenerator<PluginSwr>({
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
       ...resolveOperationTypeNames(node, tsResolver, {
-        paramsCasing: 'camelcase',
         exclude: [queryKeyTypeName],
         order: 'body-response-first',
         includeParams: false,

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -78,7 +78,7 @@ export function buildParams(node: ast.OperationNode, { params, resolver }: Build
 }
 
 export function buildData(node: ast.OperationNode, { resolver }: BuildOperationSchemaOptions): ast.SchemaNode {
-  const { path: pathParams, query: queryParams, header: headerParams } = getOperationParameters(node)
+  const { path: pathParams, query: queryParams, header: headerParams } = getOperationParameters(node, { paramsCasing: 'original' })
   const hasBody = Boolean(node.requestBody?.content?.[0]?.schema)
   const hasRequiredPath = pathParams.some((param) => param.required)
   const hasRequiredQuery = queryParams.some((param) => param.required)

--- a/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
@@ -61,7 +61,7 @@ export function InfiniteQueryOptions({
           ? 'boolean'
           : 'unknown'
 
-  const rawQueryParams = getOperationParameters(node).query
+  const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -39,7 +39,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
 
     // Validate queryParam exists in operation's query parameters
     const normalizeKey = (key: string) => key.replace(/\?$/, '')
-    const queryParamKeys = getOperationParameters(node).query.map((p) => p.name)
+    const queryParamKeys = getOperationParameters(node, { paramsCasing: 'original' }).query.map((p) => p.name)
     const hasQueryParam = infiniteOptions.queryParam ? queryParamKeys.some((k) => normalizeKey(k) === infiniteOptions.queryParam) : false
     // cursorParam validation against response schema keys is skipped in v5 (complex schema inspection)
     const hasCursorParam = !infiniteOptions.cursorParam || true
@@ -63,7 +63,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
       }),
     }
 
-    const rawQueryParams = getOperationParameters(node).query
+    const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
     const queryParamsTypeName =
       rawQueryParams.length > 0 && tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
         ? tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
@@ -73,7 +73,6 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
       tsResolver.resolveRequestConfigName(node),
       queryParamsTypeName,
       ...resolveOperationTypeNames(node, tsResolver, {
-        paramsCasing: 'camelcase',
         exclude: [queryKeyTypeName],
         order: 'body-response-first',
         includeParams: false,

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -53,7 +53,7 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
 
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
-      ...resolveOperationTypeNames(node, tsResolver, { paramsCasing: 'camelcase', order: 'body-response-first', includeParams: false }),
+      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
     ]
 
     const pluginZod = isParserEnabled(parser) ? driver.getPlugin(pluginZodName) : null

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -55,7 +55,6 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
     const importedTypeNames = [
       tsResolver.resolveRequestConfigName(node),
       ...resolveOperationTypeNames(node, tsResolver, {
-        paramsCasing: 'camelcase',
         exclude: [queryKeyTypeName],
         order: 'body-response-first',
         includeParams: false,


### PR DESCRIPTION
## What this does

`paramsCasing` is always `camelcase` now that the per-plugin option was removed, so this makes camelcase the **default** for `getOperationParameters` and `resolveOperationTypeNames` instead of threading `{ paramsCasing: 'camelcase' }` through every call.

The bare call now returns camelCased names. The sites that build the original wire-name mapping (generated code uses `petId`, the request still sends `pet_id`) opt out explicitly with `{ paramsCasing: 'original' }`. So `'original'` now signals "this genuinely needs spec names," and the common cased path is the default.

## Behavior-preserving

This is a pure default flip, verified with the full snapshot suite: bare calls (previously original) became explicit `'original'` opt-outs, the `'camelcase'` calls became bare, and count/required-only reads (`getRequestGroups`, query-key presence checks) use the bare default since casing doesn't affect them. Generated output is byte-identical — no snapshot updates, no example drift.

One fix along the way: the MCP handler's `createOperationParams(...)` (a separate `@kubb/ast` API with its own casing) keeps its explicit `paramsCasing: 'camelcase'`.

## Verification

`pnpm typecheck` (15/15), `pnpm test` (941, zero snapshot drift), `pnpm build` + `pnpm generate` + `pnpm typecheck:examples` (15/15, no client/operation drift), `pnpm lint`, `pnpm format`. Added a unit test asserting `{ paramsCasing: 'original' }` preserves the spec names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZWQmXCtL8i8fQZMnhqS43)_