### PR TITLE
refactor(plugin-fetch): group request/response parsers under a single `parser` field

### DIFF
--- a/examples/fetch-slim/src/gen/.kubb/client.ts
+++ b/examples/fetch-slim/src/gen/.kubb/client.ts
@@ -47,10 +47,10 @@ export type QuerySerializer = (params: Record<string, unknown>) => string
 export type BodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
 
 /**
- * Validates a value before it is sent or after it is received, returning the (optionally
- * transformed) value. Used to wire zod parsing through `requestValidator` / `responseValidator`.
+ * Parses a value before it is sent or after it is received, returning the parsed (and optionally
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
  */
-export type Validator<T = unknown> = (value: T) => T | Promise<T>
+export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
 /**
  * A single OpenAPI security requirement: scheme name to the scopes it needs.
@@ -95,8 +95,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   transport?: Transport<TRequest, TResponse>
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  requestValidator?: Validator
-  responseValidator?: Validator
+  parser?: { request?: Parser; response?: Parser }
   security?: Array<SecurityRequirement>
   schemes?: Record<string, SecurityScheme>
   auth?: AuthCallback
@@ -367,9 +366,9 @@ export async function resolveAuth(params: {
   }
 }
 
-async function runValidator<T>(validator: Validator | undefined, value: T): Promise<T> {
-  if (!validator) return value
-  return (await validator(value)) as T
+async function runParser<T>(parser: Parser | undefined, value: T): Promise<T> {
+  if (!parser) return value
+  return (await parser(value)) as T
 }
 
 /**
@@ -409,7 +408,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     const rawBody = requestConfig.body
-    const validatedBody = await runValidator(requestConfig.requestValidator, rawBody)
+    const validatedBody = await runParser(requestConfig.parser?.request, rawBody)
     const search = querySerializer(query)
     const pathParams = requestConfig.path ?? {}
     const interpolatedUrl = [config.baseURL, requestConfig.baseURL, requestConfig.url]
@@ -447,7 +446,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
       throw error
     }
 
-    const data = isSuccess ? await runValidator(requestConfig.responseValidator, result.data) : undefined
+    const data = isSuccess ? await runParser(requestConfig.parser?.response, result.data) : undefined
 
     return {
       data,

--- a/internals/client/src/builders/validator.test.ts
+++ b/internals/client/src/builders/validator.test.ts
@@ -1,7 +1,7 @@
 import { ast } from '@kubb/core'
 import { resolverZod } from '@kubb/plugin-zod'
 import { describe, expect, test } from 'vitest'
-import { buildValidatorHooks } from './validator.ts'
+import { buildParserHooks } from './validator.ts'
 
 const addPet = ast.factory.createOperation({
   operationId: 'addPet',
@@ -14,33 +14,33 @@ const addPet = ast.factory.createOperation({
   responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
 })
 
-describe('buildValidatorHooks', () => {
-  test('emits no validators when the parser is off', () => {
-    expect(buildValidatorHooks({ node: addPet, parser: false, zodResolver: resolverZod })).toStrictEqual({
-      requestValidator: null,
-      responseValidator: null,
+describe('buildParserHooks', () => {
+  test('emits no parsers when the parser is off', () => {
+    expect(buildParserHooks({ node: addPet, parser: false, zodResolver: resolverZod })).toStrictEqual({
+      request: null,
+      response: null,
       importedZodNames: [],
     })
   })
 
-  test("the 'zod' shorthand wires the response validator only", () => {
-    const hooks = buildValidatorHooks({ node: addPet, parser: 'zod', zodResolver: resolverZod })
-    expect(hooks.requestValidator).toBeNull()
-    expect(hooks.responseValidator).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
+  test("the 'zod' shorthand wires the response parser only", () => {
+    const hooks = buildParserHooks({ node: addPet, parser: 'zod', zodResolver: resolverZod })
+    expect(hooks.request).toBeNull()
+    expect(hooks.response).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
     expect(hooks.importedZodNames).toStrictEqual(['addPetResponseSchema'])
   })
 
-  test('the object form wires the request validator from the data schema', () => {
-    const hooks = buildValidatorHooks({ node: addPet, parser: { request: 'zod' }, zodResolver: resolverZod })
-    expect(hooks.requestValidator).toBe('(data: unknown) => addPetDataSchema.parse(data)')
-    expect(hooks.responseValidator).toBeNull()
+  test('the object form wires the request parser from the data schema', () => {
+    const hooks = buildParserHooks({ node: addPet, parser: { request: 'zod' }, zodResolver: resolverZod })
+    expect(hooks.request).toBe('(data: unknown) => addPetDataSchema.parse(data)')
+    expect(hooks.response).toBeNull()
     expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema'])
   })
 
   test('wires both directions when both are enabled', () => {
-    const hooks = buildValidatorHooks({ node: addPet, parser: { request: 'zod', response: 'zod' }, zodResolver: resolverZod })
-    expect(hooks.requestValidator).toBe('(data: unknown) => addPetDataSchema.parse(data)')
-    expect(hooks.responseValidator).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
+    const hooks = buildParserHooks({ node: addPet, parser: { request: 'zod', response: 'zod' }, zodResolver: resolverZod })
+    expect(hooks.request).toBe('(data: unknown) => addPetDataSchema.parse(data)')
+    expect(hooks.response).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
     expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema', 'addPetResponseSchema'])
   })
 })

--- a/internals/client/src/builders/validator.ts
+++ b/internals/client/src/builders/validator.ts
@@ -4,19 +4,19 @@ import type { ParserOptions } from '../types.ts'
 import { buildZodResponseParse, resolveRequestParser, resolveResponseParser } from './parser.ts'
 
 /**
- * The per-call validator expressions a generated function wires into its request config. Both run
- * through the runtime's `requestValidator` / `responseValidator` hooks rather than inline parse
- * calls, and the response validator only ever sees success (2xx) bodies.
+ * The per-call parser expressions a generated function wires into its request config. Both run
+ * through the runtime's `parser.request` / `parser.response` hooks rather than inline parse calls,
+ * and the response parser only ever sees success (2xx) bodies.
  */
-export type ValidatorHooks = {
+export type ParserHooks = {
   /**
-   * Expression for the `requestValidator` field, or `null` when request parsing is off.
+   * Expression for the `parser.request` hook, or `null` when request parsing is off.
    */
-  requestValidator: string | null
+  request: string | null
   /**
-   * Expression for the `responseValidator` field, or `null` when response parsing is off.
+   * Expression for the `parser.response` hook, or `null` when response parsing is off.
    */
-  responseValidator: string | null
+  response: string | null
   /**
    * Zod schema names the generated file imports from the zod plugin output.
    */
@@ -24,11 +24,11 @@ export type ValidatorHooks = {
 }
 
 /**
- * Builds the validator-hook expressions for one operation. Request validation runs before the send;
- * response validation runs on the success body only. Returns `null` expressions when the matching
+ * Builds the parser-hook expressions for one operation. Request parsing runs before the send;
+ * response parsing runs on the success body only. Returns `null` expressions when the matching
  * parser direction is disabled or the schema is absent.
  */
-export function buildValidatorHooks({
+export function buildParserHooks({
   node,
   parser,
   zodResolver,
@@ -36,17 +36,17 @@ export function buildValidatorHooks({
   node: ast.OperationNode
   parser: ParserOptions | undefined
   zodResolver: ResolverZod | null | undefined
-}): ValidatorHooks {
+}): ParserHooks {
   const importedZodNames: Array<string> = []
 
   const hasRequestBody = Boolean(node.requestBody?.content?.[0]?.schema)
   const zodRequestName = zodResolver && resolveRequestParser(parser) === 'zod' && hasRequestBody ? zodResolver.resolveDataName?.(node) : null
-  const requestValidator = zodRequestName ? `(data: unknown) => ${zodRequestName}.parse(data)` : null
+  const request = zodRequestName ? `(data: unknown) => ${zodRequestName}.parse(data)` : null
   if (zodRequestName) importedZodNames.push(zodRequestName)
 
   const responseParse = zodResolver && resolveResponseParser(parser) === 'zod' ? buildZodResponseParse(node, zodResolver) : null
-  const responseValidator = responseParse ? `(data: unknown) => ${responseParse.expression}.parse(data)` : null
+  const response = responseParse ? `(data: unknown) => ${responseParse.expression}.parse(data)` : null
   if (responseParse) importedZodNames.push(...responseParse.importNames)
 
-  return { requestValidator, responseValidator, importedZodNames }
+  return { request, response, importedZodNames }
 }

--- a/internals/client/src/components/Operation.tsx
+++ b/internals/client/src/components/Operation.tsx
@@ -7,7 +7,7 @@ import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import { buildReturnStatement } from '../builders/returnStatement.ts'
 import { buildSecurityMetadata, type SecurityRequirement } from '../builders/security.ts'
 import { buildGroupedOptionsSignature } from '../builders/signature.ts'
-import { buildValidatorHooks } from '../builders/validator.ts'
+import { buildParserHooks } from '../builders/validator.ts'
 import type { ParserOptions } from '../types.ts'
 
 type Props = {
@@ -48,15 +48,17 @@ export function Operation({ name, node, tsResolver, zodResolver, parser, securit
   if (!ast.isHttpOperationNode(node)) return null
 
   const signature = buildGroupedOptionsSignature({ node, tsResolver })
-  const validators = buildValidatorHooks({ node, parser, zodResolver })
+  const parsers = buildParserHooks({ node, parser, zodResolver })
   const securityLiteral = buildSecurityMetadata({ security })
+
+  const parserEntries = [parsers.request ? `request: ${parsers.request}` : null, parsers.response ? `response: ${parsers.response}` : null].filter(Boolean)
+  const parserLiteral = parserEntries.length ? `parser: { ${parserEntries.join(', ')} }` : null
 
   const callConfig = `{ ${[
     `method: '${node.method.toUpperCase()}'`,
     `url: '${node.path}'`,
     securityLiteral ? `security: ${securityLiteral}` : null,
-    validators.requestValidator ? `requestValidator: ${validators.requestValidator}` : null,
-    validators.responseValidator ? `responseValidator: ${validators.responseValidator}` : null,
+    parserLiteral,
     '...config',
   ]
     .filter(Boolean)

--- a/internals/client/src/index.ts
+++ b/internals/client/src/index.ts
@@ -10,7 +10,7 @@ export {
 export { buildReturnStatement } from './builders/returnStatement.ts'
 export { buildSecurityMetadata, type SecurityRequirement } from './builders/security.ts'
 export { buildGroupedOptionsSignature, type GroupedOptionsSignature } from './builders/signature.ts'
-export { buildValidatorHooks, type ValidatorHooks } from './builders/validator.ts'
+export { buildParserHooks, type ParserHooks } from './builders/validator.ts'
 export { Operation } from './components/Operation.tsx'
 export { defaultMacros } from './macros.ts'
 export { resolveOptions } from './options.ts'

--- a/packages/plugin-fetch/src/generators/__snapshots__/addPetMultiStatusWithZod/addPet.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/addPetMultiStatusWithZod/addPet.ts
@@ -13,7 +13,7 @@ export function addPet<ThrowOnError extends boolean = true>(
 ): Promise<RequestResult<AddPetResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'POST', url: '/pet', responseValidator: (data: unknown) => AddPetResponse.parse(data), ...config }) as Promise<
+  return request({ method: 'POST', url: '/pet', parser: { response: (data: unknown) => AddPetResponse.parse(data) }, ...config }) as Promise<
     RequestResult<AddPetResponses, ThrowOnError>
   >
 }

--- a/packages/plugin-fetch/templates/fetch.test.ts
+++ b/packages/plugin-fetch/templates/fetch.test.ts
@@ -132,21 +132,21 @@ describe('createClientCore', () => {
     expect(result.data).toStrictEqual({ from: 'override' })
   })
 
-  test('runs the request validator before the send and the response validator on success', async () => {
+  test('runs the request parser before the send and the response parser on success', async () => {
     const { client, calls } = createClient({ data: { raw: true }, status: 200 })
-    const requestValidator = vi.fn((body: unknown) => ({ ...(body as object), validated: true }))
-    const responseValidator = vi.fn(() => ({ parsed: true }))
-    const result = (await client({ method: 'POST', url: '/pet', body: { name: 'odie' }, requestValidator, responseValidator })) as CallResult<string, string>
-    expect(requestValidator).toHaveBeenCalledTimes(1)
+    const request = vi.fn((body: unknown) => ({ ...(body as object), validated: true }))
+    const response = vi.fn(() => ({ parsed: true }))
+    const result = (await client({ method: 'POST', url: '/pet', body: { name: 'odie' }, parser: { request, response } })) as CallResult<string, string>
+    expect(request).toHaveBeenCalledTimes(1)
     expect(calls[0]?.body).toBe('{"name":"odie","validated":true}')
     expect(result.data).toStrictEqual({ parsed: true })
   })
 
-  test('skips the response validator on a non-2xx body', async () => {
+  test('skips the response parser on a non-2xx body', async () => {
     const { client } = createClient({ data: { message: 'invalid' }, status: 405 })
-    const responseValidator = vi.fn((value: unknown) => value)
-    await client({ method: 'POST', url: '/pet', throwOnError: false, responseValidator })
-    expect(responseValidator).not.toHaveBeenCalled()
+    const response = vi.fn((value: unknown) => value)
+    await client({ method: 'POST', url: '/pet', throwOnError: false, parser: { response } })
+    expect(response).not.toHaveBeenCalled()
   })
 
   test('runs request and response interceptors', async () => {

--- a/packages/plugin-fetch/templates/fetch.ts
+++ b/packages/plugin-fetch/templates/fetch.ts
@@ -47,10 +47,10 @@ export type QuerySerializer = (params: Record<string, unknown>) => string
 export type BodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
 
 /**
- * Validates a value before it is sent or after it is received, returning the (optionally
- * transformed) value. Used to wire zod parsing through `requestValidator` / `responseValidator`.
+ * Parses a value before it is sent or after it is received, returning the parsed (and optionally
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
  */
-export type Validator<T = unknown> = (value: T) => T | Promise<T>
+export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
 /**
  * A single OpenAPI security requirement: scheme name to the scopes it needs.
@@ -95,8 +95,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   transport?: Transport<TRequest, TResponse>
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  requestValidator?: Validator
-  responseValidator?: Validator
+  parser?: { request?: Parser; response?: Parser }
   security?: Array<SecurityRequirement>
   schemes?: Record<string, SecurityScheme>
   auth?: AuthCallback
@@ -367,9 +366,9 @@ export async function resolveAuth(params: {
   }
 }
 
-async function runValidator<T>(validator: Validator | undefined, value: T): Promise<T> {
-  if (!validator) return value
-  return (await validator(value)) as T
+async function runParser<T>(parser: Parser | undefined, value: T): Promise<T> {
+  if (!parser) return value
+  return (await parser(value)) as T
 }
 
 /**
@@ -409,7 +408,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     const rawBody = requestConfig.body
-    const validatedBody = await runValidator(requestConfig.requestValidator, rawBody)
+    const validatedBody = await runParser(requestConfig.parser?.request, rawBody)
     const search = querySerializer(query)
     const pathParams = requestConfig.path ?? {}
     const interpolatedUrl = [config.baseURL, requestConfig.baseURL, requestConfig.url]
@@ -447,7 +446,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
       throw error
     }
 
-    const data = isSuccess ? await runValidator(requestConfig.responseValidator, result.data) : undefined
+    const data = isSuccess ? await runParser(requestConfig.parser?.response, result.data) : undefined
 
     return {
       data,


### PR DESCRIPTION
## What

Renames the slim-client validation hooks emitted into the generated call config. The two flat fields `requestValidator` / `responseValidator` become a single grouped `parser: { request, response }` object.

```ts
// before
return request({
  method: 'POST',
  url: '/pet',
  responseValidator: (data: unknown) => AddPetResponse.parse(data),
  ...config,
})

// after
return request({
  method: 'POST',
  url: '/pet',
  parser: { response: (data: unknown) => AddPetResponse.parse(data) },
  ...config,
})
```

## Why

Addresses the naming question in #390. The `parser` plugin option already takes `{ request, response }` (`parser: { request: 'zod', response: 'zod' }`), so emitting a grouped `parser` object makes the configured shape and the generated shape match 1:1. `parser` is also the accurate verb: these hooks return a parsed, transformed value (`z.output`, date string → `Date` via codecs), not a boolean — "parse, don't validate". The field stays library-agnostic, so a non-zod parser can slot into the same two hooks later.

These names are unreleased (the slim client plugins haven't shipped), so this is a pure rename with no user migration.

## Changes

- Runtime (`packages/plugin-fetch/templates/fetch.ts`): `Validator` → `Parser`, `runValidator` → `runParser`, and the two `RequestConfig` fields collapse into `parser?: { request?: Parser; response?: Parser }`.
- Generator (`internals/client`): `buildValidatorHooks`/`ValidatorHooks` → `buildParserHooks`/`ParserHooks` with `request`/`response` fields; `Operation.tsx` emits the grouped `parser` literal, with only the active directions included.
- Refreshed the plugin-fetch snapshot and the `fetch-slim` example runtime.
- Updated the design in #390 and #384 to describe the grouped `parser` object.

## Notes

No changeset: the renamed fields never shipped, so a "rename" changeset would reference names users never saw. The existing `@kubb/plugin-fetch` changesets describe the unchanged `parser` *option* and stay as-is. No docs changes — the slim-client `parser` hook isn't documented yet.

## Verification

- `vitest` for `@kubb/plugin-fetch` (30) and `@internals/client` (20) pass; snapshot updated.
- `oxlint` and `tsc` clean for both packages.
- `fetch-slim` example regenerated and its `typecheck` hook passes (the runtime change was applied without reformatting the rest of the generated output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BJGSB2K9B4XfxQYGiHfHMo)_