### PR TITLE
refactor: build grouped params through createFunctionParameter

### DIFF
--- a/.changeset/function-parameter-factory.md
+++ b/.changeset/function-parameter-factory.md
@@ -1,0 +1,9 @@
+---
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-client": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-mcp": patch
+---
+
+Build grouped `{ path, query, body, headers }` parameters through `ast.factory.createFunctionParameter` instead of hand-written `{ kind: 'FunctionParameter' }` node literals, and target `@kubb/ast` `5.0.0-beta.71`. The generated output is unchanged.

--- a/internals/tanstack-query/src/utils.ts
+++ b/internals/tanstack-query/src/utils.ts
@@ -61,22 +61,20 @@ export function buildGroupedRequestParam(
       optional: !requiredByGroup[name],
     }))
 
-    return {
-      kind: 'FunctionParameter',
+    return ast.factory.createFunctionParameter({
       name: ast.factory.createObjectBindingPattern({ elements: names.map((name) => ({ name })) }),
       type: ast.factory.createTypeLiteral({ members }),
       optional: false,
       ...(isOptional ? { default: '{}' } : {}),
-    }
+    })
   }
 
-  return {
-    kind: 'FunctionParameter',
+  return ast.factory.createFunctionParameter({
     name: ast.factory.createObjectBindingPattern({ elements: names.map((name) => ({ name })) }),
     type: requestConfigType,
     optional: false,
     ...(isOptional ? { default: '{}' } : {}),
-  }
+  })
 }
 
 /**

--- a/packages/plugin-client/src/functionParams.ts
+++ b/packages/plugin-client/src/functionParams.ts
@@ -30,22 +30,21 @@ function groupEntries(group: ParamGroup): Array<[string, ParamLeaf]> {
 
 /**
  * Assembles a destructured group parameter from a binding pattern and an optional
- * type literal. Built directly because `createFunctionParameter({ properties })`
- * requires every member to carry a type, while these groups also hold untyped,
- * value-only call entries.
+ * type literal. It passes the binding pattern as the parameter name rather than
+ * `createFunctionParameter({ properties })`, since that form requires every member to
+ * carry a type, while these groups also hold untyped, value-only call entries.
  */
 function createGroupParam(
   elements: Array<{ name: string }>,
   members: Array<{ name: string; type: string; optional?: boolean }>,
   default_?: string,
 ): ast.FunctionParameterNode {
-  return {
-    kind: 'FunctionParameter',
+  return ast.factory.createFunctionParameter({
     name: ast.factory.createObjectBindingPattern({ elements }),
     type: members.length ? ast.factory.createTypeLiteral({ members }) : undefined,
     default: default_,
     optional: false,
-  }
+  })
 }
 
 function createDeclarationLeaf(name: string, spec: ParamLeaf): ast.FunctionParameterNode {

--- a/packages/plugin-mcp/src/components/Server.tsx
+++ b/packages/plugin-mcp/src/components/Server.tsx
@@ -83,7 +83,10 @@ export function Server({ name, serverName, serverVersion, operations }: Props): 
       const paramsNode = entries.length
         ? ast.factory.createFunctionParameters({
             params: [
-              { kind: 'FunctionParameter', name: ast.factory.createObjectBindingPattern({ elements: entries.map((e) => ({ name: e.key })) }), optional: false },
+              ast.factory.createFunctionParameter({
+                name: ast.factory.createObjectBindingPattern({ elements: entries.map((e) => ({ name: e.key })) }),
+                optional: false,
+              }),
             ],
           })
         : null

--- a/packages/plugin-ts/src/printers/functionPrinter.test.ts
+++ b/packages/plugin-ts/src/printers/functionPrinter.test.ts
@@ -8,7 +8,7 @@ import { functionPrinter, renderType } from './functionPrinter.ts'
  * express (a reference type, or an untyped binding).
  */
 function group(elements: Array<{ name: string; propertyName?: string }>, type?: ast.TypeExpression, default_?: string): ast.FunctionParameterNode {
-  return { kind: 'FunctionParameter', name: ast.factory.createObjectBindingPattern({ elements }), type, default: default_, optional: false }
+  return ast.factory.createFunctionParameter({ name: ast.factory.createObjectBindingPattern({ elements }), type, default: default_, optional: false })
 }
 
 describe('renderType', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,23 +7,23 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     '@kubb/ast':
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     '@kubb/core':
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     '@kubb/parser-ts':
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     '@kubb/plugin-barrel':
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     '@kubb/renderer-jsx':
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     '@types/node':
       specifier: ^22.19.21
       version: 22.19.21
@@ -37,8 +37,8 @@ catalogs:
       specifier: ^4.1.9
       version: 4.1.9
     kubb:
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     oxfmt:
       specifier: ^0.47.0
       version: 0.47.0
@@ -55,8 +55,8 @@ catalogs:
       specifier: ^6.0.3
       version: 6.0.3
     unplugin-kubb:
-      specifier: 5.0.0-beta.69
-      version: 5.0.0-beta.69
+      specifier: 5.0.0-beta.71
+      version: 5.0.0-beta.71
     vitest:
       specifier: ^4.1.9
       version: 4.1.9
@@ -73,16 +73,16 @@ importers:
         version: 2.31.0(@types/node@22.19.21)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69))
+        version: 5.0.0-beta.71(@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71))
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -203,13 +203,13 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -218,13 +218,13 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -233,13 +233,13 @@ importers:
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       axios:
         specifier: ^1.18.0
         version: 1.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -261,7 +261,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -280,7 +280,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -295,7 +295,7 @@ importers:
         version: 1.11.21
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -308,7 +308,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -317,7 +317,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
     devDependencies:
       react:
         specifier: ^19.2.7
@@ -330,7 +330,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -339,7 +339,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -349,7 +349,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-mcp':
         specifier: workspace:*
         version: link:../../packages/plugin-mcp
@@ -367,7 +367,7 @@ importers:
         version: 1.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -383,7 +383,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -401,7 +401,7 @@ importers:
         version: 0.10.3(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -420,10 +420,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -444,7 +444,7 @@ importers:
         version: 1.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -453,7 +453,7 @@ importers:
         version: 19.2.7(react@19.2.7)
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69))(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.71(@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71))(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@types/react':
         specifier: 'catalog:'
@@ -478,7 +478,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -487,7 +487,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -497,7 +497,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -521,7 +521,7 @@ importers:
         version: 1.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -536,7 +536,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -551,7 +551,7 @@ importers:
         version: 1.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -570,7 +570,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -579,7 +579,7 @@ importers:
         version: 1.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -589,7 +589,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -610,7 +610,7 @@ importers:
         version: 1.18.0
       unplugin-kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69))(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.71(@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71))(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0))
       vue:
         specifier: ^3.5.38
         version: 3.5.38(typescript@6.0.3)
@@ -644,7 +644,7 @@ importers:
         version: 1.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -665,10 +665,10 @@ importers:
         version: link:../utils
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -677,7 +677,7 @@ importers:
         version: link:../../packages/plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -690,10 +690,10 @@ importers:
         version: link:../utils
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -709,16 +709,16 @@ importers:
         version: link:../utils
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -734,10 +734,10 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
@@ -746,7 +746,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -762,16 +762,16 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -784,16 +784,16 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -812,10 +812,10 @@ importers:
         version: link:../../internals/shared
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../plugin-ts
@@ -824,7 +824,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -837,10 +837,10 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -852,7 +852,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -865,10 +865,10 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../plugin-faker
@@ -877,7 +877,7 @@ importers:
         version: link:../plugin-ts
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -890,10 +890,10 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -905,7 +905,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -921,10 +921,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
     devDependencies:
       '@internals/utils':
         specifier: workspace:*
@@ -934,10 +934,10 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -949,7 +949,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -965,16 +965,16 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -990,10 +990,10 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../plugin-client
@@ -1005,7 +1005,7 @@ importers:
         version: link:../plugin-zod
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -1021,13 +1021,13 @@ importers:
     dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69
+        version: 5.0.0-beta.71
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -1043,13 +1043,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1098,7 +1098,7 @@ importers:
         version: 10.4.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1134,7 +1134,7 @@ importers:
         version: 15.17.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.6.2)(typescript@6.0.3)
@@ -1165,10 +1165,10 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+        version: 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@kubb/plugin-client':
         specifier: workspace:*
         version: link:../../packages/plugin-client
@@ -1183,7 +1183,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3)
+        version: 5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3)
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1426,56 +1426,56 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kubb/adapter-oas@5.0.0-beta.69':
-    resolution: {integrity: sha512-7avrh6uFSn8QrUy3EFdrU5o9+IArHwXwv+Nl4KCa/QyuyprWz6SKasID2k/4TNYdyimOvG78oqsmjB4sno99uA==}
+  '@kubb/adapter-oas@5.0.0-beta.71':
+    resolution: {integrity: sha512-9Hy+kCTHmF14wgGknb6Sr4TwJCZViwqbWX/2xBwghipQl63jb1BMZ5Q53LZh5jlY7sUGOGHjdV9ddIZjqiYzHQ==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-beta.69':
-    resolution: {integrity: sha512-VqdRn40AbSR+pyute+FdH17ZEQrjcnuSZ10Y3ZkJxMIR/fJZ35FFEjJtIghFESUmmjAVEmEMj1AEexEYF3cxbg==}
+  '@kubb/ast@5.0.0-beta.71':
+    resolution: {integrity: sha512-E08B7wH/hgskMCk978rjasZ4s3pa39qT2OM8anbQdZ5u3hdRbPaTE7RrdUrnyd4lwxxRkUPdbp8ZGUtHF2DsGg==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-beta.69':
-    resolution: {integrity: sha512-KBEUyYupkAXa2y5+5zl/VcC7Oce+a3rGU7BFHmi1K/aQ+H+ryX4vZ85EgVlCAyYPmGUqWeAIw2hHv4Z/e7IuxA==}
+  '@kubb/cli@5.0.0-beta.71':
+    resolution: {integrity: sha512-vqg1/rie2NzUIWLPkyYf+er00qEL6ivN8KiitsEVrMOVYlBOKF2mSr6VtpytiICHy8o93hbk3oUQ4b6E4VEHYw==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.69
-      '@kubb/mcp': 5.0.0-beta.69
+      '@kubb/adapter-oas': 5.0.0-beta.71
+      '@kubb/mcp': 5.0.0-beta.71
     peerDependenciesMeta:
       '@kubb/adapter-oas':
         optional: true
       '@kubb/mcp':
         optional: true
 
-  '@kubb/core@5.0.0-beta.69':
-    resolution: {integrity: sha512-GNWzs/ARQjSjSKYd9+zt6Xag+/ju7JeO/hWSsbWtaqIejzsSqSzYlgcoHeDIaBRIwtg+K7fQVsRs+Xc1tuxNyw==}
+  '@kubb/core@5.0.0-beta.71':
+    resolution: {integrity: sha512-LQmb2d/a4YU39++wFozitupesCo+QH/t+oGIgfH8RDWTYALkdblRL7i6ujoklzKHShtcEQPxMn/DLV38MN4CUQ==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.69
+      '@kubb/renderer-jsx': 5.0.0-beta.71
 
-  '@kubb/mcp@5.0.0-beta.69':
-    resolution: {integrity: sha512-AE/n1h5rurGmj7Md41MWzV3Gjw6PJBrZYHm6qRbrNmw4AdWlrVgnMVgeznFfbS+UBKAPcpp1Y0ay4oyb2SwVGw==}
+  '@kubb/mcp@5.0.0-beta.71':
+    resolution: {integrity: sha512-gUniTQjmuwAdYQ0m6rUyTcfLAk+nNerA72dYPSP1GkVpxJRjQUXOZ/TAFYHu6BloxGYZKaDLFZoCkfG504U2cA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.69
+      '@kubb/renderer-jsx': 5.0.0-beta.71
 
-  '@kubb/parser-md@5.0.0-beta.69':
-    resolution: {integrity: sha512-cpOkg/6IeHuDMKvxDfNbRpDBf1b+sPhVJYVs1lGLciqIEJFtBQ2//vY+jSZThqzulvPJKU04YtS7KZjVJuYG6g==}
+  '@kubb/parser-md@5.0.0-beta.71':
+    resolution: {integrity: sha512-z1uEPukotizHoiPgjm5q5nGYbBOzI5M+5zVQKtvNvu+QcEzmK3WSRnZKunCqh028l9wv8JnQ3nPhJAFLZhMiXw==}
     engines: {node: '>=22'}
 
-  '@kubb/parser-ts@5.0.0-beta.69':
-    resolution: {integrity: sha512-8DFg3YRWiJ6sZSQTjAHId8dagrfQ2Cy7eFNdrVbpHUh0f8hrqA4WQYsGceeW1WokGrMhXVzIX1C4eXDQkLSrpw==}
+  '@kubb/parser-ts@5.0.0-beta.71':
+    resolution: {integrity: sha512-ijtVQbrCoN8amarYPyr/pUm6DfMnE6OSwJPr/H9qP0qYwz6kU3rp6azbLJjBzBVOmWtXWs8nxBVRV1Ydgfln8Q==}
     engines: {node: '>=22'}
 
-  '@kubb/plugin-barrel@5.0.0-beta.69':
-    resolution: {integrity: sha512-rU01gVKXJni6Bb8YUrRqZHdGgjaMnBFzkGDszDn9JjjTQMuaWqSCMWNFTiIoO3uzYTyL8L/NXuUwFG1IZdmsNQ==}
+  '@kubb/plugin-barrel@5.0.0-beta.71':
+    resolution: {integrity: sha512-cBkLhyvpYvk5M3J5ukGh3Vz2R7G4HrQgGOs9VhFiCZIU9nytM4UrIJHFo8s0HBD1gXB7o1j1/ppcfciYFm0ObA==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-beta.69
+      '@kubb/core': 5.0.0-beta.71
 
-  '@kubb/renderer-jsx@5.0.0-beta.69':
-    resolution: {integrity: sha512-i5pi0t6DzwSRmgXhu0GszZHwWcnLDUpsB/B7IFRrkifxTeV3sY4qKlbctru5SMWX4Lg0H2pdu4hXAi4ry+dwiw==}
+  '@kubb/renderer-jsx@5.0.0-beta.71':
+    resolution: {integrity: sha512-YdSL73ImtnBmLW4dMTNswxGOKhq/pWfpFR2NkAJGUnwGLqqf1ByEuSTN6wtBAKF6cvoV08nsVCNt6y4r5VcjWw==}
     engines: {node: '>=22'}
 
   '@manypkg/find-root@1.1.0':
@@ -3185,8 +3185,8 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-beta.69:
-    resolution: {integrity: sha512-LsW8COszkyaN2obPjgQzQfTGDR00s3Hx+IEmGcslttoHZ3gTGyHdk6TzXJjgX6Nl1A0OmwtdoqBqd+Q6E0WjeQ==}
+  kubb@5.0.0-beta.71:
+    resolution: {integrity: sha512-yJAh5Yki2/Si/1S3EMuhw1wL0yFqydi/Qld7rvEglwkf/HaChCy4PTZzzGUCA2eQf0u03n3Dk1X1K2ffm9I5rA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4113,8 +4113,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-beta.69:
-    resolution: {integrity: sha512-6kNLybFDMkX4kGvGNwMwRcPYj9XWBWTE7z1h7Pyl022f4Hc9PVyjL3eJWWaa93Z7S84h2SQbboHj9ZXJkkTd8g==}
+  unplugin-kubb@5.0.0-beta.71:
+    resolution: {integrity: sha512-YPBLZ0Q1zjTZX0x+FemEWgdV81PsK6vxvNMxX34G2svnhsKg5rMzgPlFXiCmcc9LeADnT4QNQ4lfi0gkcN37gQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -4725,10 +4725,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kubb/adapter-oas@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)':
+  '@kubb/adapter-oas@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.69
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+      '@kubb/ast': 5.0.0-beta.71
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       '@readme/openapi-parser': 6.1.3(openapi-types@12.1.3)
       '@scalar/openapi-upgrader': 0.2.9
       api-ref-bundler: 0.5.1
@@ -4737,32 +4737,32 @@ snapshots:
       - '@kubb/renderer-jsx'
       - openapi-types
 
-  '@kubb/ast@5.0.0-beta.69': {}
+  '@kubb/ast@5.0.0-beta.71': {}
 
-  '@kubb/cli@5.0.0-beta.69(@kubb/adapter-oas@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.69)':
+  '@kubb/cli@5.0.0-beta.71(@kubb/adapter-oas@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.71)':
     dependencies:
       '@clack/prompts': 1.5.1
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       chokidar: 5.0.0
       jiti: 2.7.0
       tinyexec: 1.2.4
       unconfig: 7.5.0
     optionalDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
-      '@kubb/mcp': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/adapter-oas': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
+      '@kubb/mcp': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(typescript@6.0.3)
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)':
+  '@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.69
-      '@kubb/renderer-jsx': 5.0.0-beta.69
+      '@kubb/ast': 5.0.0-beta.71
+      '@kubb/renderer-jsx': 5.0.0-beta.71
 
-  '@kubb/mcp@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(typescript@6.0.3)':
+  '@kubb/mcp@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(typescript@6.0.3)':
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
-      '@kubb/renderer-jsx': 5.0.0-beta.69
+      '@kubb/adapter-oas': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
+      '@kubb/renderer-jsx': 5.0.0-beta.71
       '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.1(typescript@6.0.3))
       '@tmcp/transport-stdio': 0.4.3(tmcp@1.19.4(typescript@6.0.3))
       jiti: 2.7.0
@@ -4772,29 +4772,29 @@ snapshots:
       - openapi-types
       - typescript
 
-  '@kubb/parser-md@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)':
+  '@kubb/parser-md@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.69
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+      '@kubb/ast': 5.0.0-beta.71
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/parser-ts@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)':
+  '@kubb/parser-ts@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)':
     dependencies:
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@kubb/renderer-jsx'
 
-  '@kubb/plugin-barrel@5.0.0-beta.69(@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69))':
+  '@kubb/plugin-barrel@5.0.0-beta.71(@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71))':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.69
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
+      '@kubb/ast': 5.0.0-beta.71
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
 
-  '@kubb/renderer-jsx@5.0.0-beta.69':
+  '@kubb/renderer-jsx@5.0.0-beta.71':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.69
+      '@kubb/ast': 5.0.0-beta.71
       yaml: 2.9.0
 
   '@manypkg/find-root@1.1.0':
@@ -6343,16 +6343,16 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-beta.69(openapi-types@12.1.3)(typescript@6.0.3):
+  kubb@5.0.0-beta.71(openapi-types@12.1.3)(typescript@6.0.3):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
-      '@kubb/cli': 5.0.0-beta.69(@kubb/adapter-oas@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.69)
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
-      '@kubb/mcp': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(typescript@6.0.3)
-      '@kubb/parser-md': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
-      '@kubb/parser-ts': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
-      '@kubb/plugin-barrel': 5.0.0-beta.69(@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69))
-      '@kubb/renderer-jsx': 5.0.0-beta.69
+      '@kubb/adapter-oas': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
+      '@kubb/cli': 5.0.0-beta.71(@kubb/adapter-oas@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(typescript@6.0.3))(@kubb/renderer-jsx@5.0.0-beta.71)
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
+      '@kubb/mcp': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/parser-md': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
+      '@kubb/parser-ts': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
+      '@kubb/plugin-barrel': 5.0.0-beta.71(@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71))
+      '@kubb/renderer-jsx': 5.0.0-beta.71
     transitivePeerDependencies:
       - openapi-types
       - typescript
@@ -7298,12 +7298,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-beta.69(@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69))(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.71(@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71))(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.6.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
-      '@kubb/parser-ts': 5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69)
-      '@kubb/plugin-barrel': 5.0.0-beta.69(@kubb/core@5.0.0-beta.69(@kubb/renderer-jsx@5.0.0-beta.69))
+      '@kubb/adapter-oas': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
+      '@kubb/parser-ts': 5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71)
+      '@kubb/plugin-barrel': 5.0.0-beta.71(@kubb/core@5.0.0-beta.71(@kubb/renderer-jsx@5.0.0-beta.71))
       unplugin: 3.0.0
     optionalDependencies:
       rolldown: 1.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,23 +12,23 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.69
-  '@kubb/ast': 5.0.0-beta.69
-  '@kubb/core': 5.0.0-beta.69
-  '@kubb/plugin-barrel': 5.0.0-beta.69
-  '@kubb/parser-ts': 5.0.0-beta.69
-  '@kubb/renderer-jsx': 5.0.0-beta.69
+  '@kubb/adapter-oas': 5.0.0-beta.71
+  '@kubb/ast': 5.0.0-beta.71
+  '@kubb/core': 5.0.0-beta.71
+  '@kubb/plugin-barrel': 5.0.0-beta.71
+  '@kubb/parser-ts': 5.0.0-beta.71
+  '@kubb/renderer-jsx': 5.0.0-beta.71
   '@types/node': ^22.19.21
   '@types/react': ^19.2.17
   '@vitest/coverage-v8': ^4.1.9
   '@vitest/ui': ^4.1.9
-  kubb: 5.0.0-beta.69
+  kubb: 5.0.0-beta.71
   oxfmt: ^0.47.0
   oxlint: ^1.70.0
   prettier: ^3.8.4
   tsdown: ^0.22.3
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.69
+  unplugin-kubb: 5.0.0-beta.71
   vitest: ^4.1.9
 #
 #overrides:


### PR DESCRIPTION
## What

Routes the grouped `{ path, query, body, headers }` parameter construction through `ast.factory.createFunctionParameter` instead of the hand-written `{ kind: 'FunctionParameter' }` node literals that were scattered across the plugins.

Touched:
- `internals/tanstack-query/src/utils.ts` — `buildGroupedRequestParam` (both the wrapped-member and single-reference branches)
- `packages/plugin-client/src/functionParams.ts` — `createGroupParam`
- `packages/plugin-mcp/src/components/Server.tsx` — registration params
- `packages/plugin-ts/src/printers/functionPrinter.test.ts` — the `group` test helper

## Why

The `@kubb/ast` factory now exposes the binding-pattern name form (`createFunctionParameter({ name: createObjectBindingPattern({...}), type, default })`), so callers no longer have to assemble the node shape by hand. This keeps node construction in one place and lets the factory own the `kind` tag and defaults.

This requires `@kubb/ast` `5.0.0-beta.71`, so the catalog in `pnpm-workspace.yaml` bumps the `@kubb/*` core packages from `5.0.0-beta.69` to `5.0.0-beta.71`.

## Output

Pure refactor: the generated output is unchanged. Verified with `pnpm generate` (no source drift) on top of typecheck, build, the full test suite (941 passing), `typecheck:examples`, lint, and format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZWQmXCtL8i8fQZMnhqS43)_