### PR TITLE
fix(plugins): bundle private @internals/* packages instead of declaring them as runtime deps

### DIFF
--- a/.changeset/internals-dev-dependencies.md
+++ b/.changeset/internals-dev-dependencies.md
@@ -1,0 +1,10 @@
+---
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-axios": patch
+"@kubb/plugin-fetch": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-mcp": patch
+---
+
+Bundle the private internal helper packages into the published output instead of declaring them as runtime dependencies. The published packages no longer reference workspace-only packages that are not on npm, and the release step can version the plugins again.

--- a/packages/plugin-axios/package.json
+++ b/packages/plugin-axios/package.json
@@ -61,8 +61,6 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@internals/client": "workspace:*",
-    "@internals/shared": "workspace:*",
     "@kubb/ast": "catalog:",
     "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
@@ -70,6 +68,8 @@
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
+    "@internals/client": "workspace:*",
+    "@internals/shared": "workspace:*",
     "@internals/utils": "workspace:*",
     "axios": "^1.18.0",
     "typescript": "catalog:"

--- a/packages/plugin-fetch/package.json
+++ b/packages/plugin-fetch/package.json
@@ -61,8 +61,6 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@internals/client": "workspace:*",
-    "@internals/shared": "workspace:*",
     "@kubb/ast": "catalog:",
     "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
@@ -70,6 +68,8 @@
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
+    "@internals/client": "workspace:*",
+    "@internals/shared": "workspace:*",
     "@internals/utils": "workspace:*",
     "typescript": "catalog:"
   },

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -56,9 +56,6 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@internals/client": "workspace:*",
-    "@internals/shared": "workspace:*",
-    "@internals/utils": "workspace:*",
     "@kubb/ast": "catalog:",
     "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
@@ -66,6 +63,7 @@
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
+    "@internals/client": "workspace:*",
     "@internals/shared": "workspace:*",
     "@internals/utils": "workspace:*"
   },

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -69,7 +69,6 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@internals/client": "workspace:*",
     "@kubb/ast": "catalog:",
     "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
@@ -77,6 +76,7 @@
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
+    "@internals/client": "workspace:*",
     "@internals/shared": "workspace:*",
     "@internals/tanstack-query": "workspace:*",
     "@internals/utils": "workspace:*"

--- a/packages/plugin-swr/package.json
+++ b/packages/plugin-swr/package.json
@@ -67,7 +67,6 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@internals/client": "workspace:*",
     "@kubb/ast": "catalog:",
     "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
@@ -75,6 +74,7 @@
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
+    "@internals/client": "workspace:*",
     "@internals/shared": "workspace:*",
     "@internals/tanstack-query": "workspace:*",
     "@internals/utils": "workspace:*"

--- a/packages/plugin-vue-query/package.json
+++ b/packages/plugin-vue-query/package.json
@@ -71,7 +71,6 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@internals/client": "workspace:*",
     "@kubb/ast": "catalog:",
     "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
@@ -79,6 +78,7 @@
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
+    "@internals/client": "workspace:*",
     "@internals/shared": "workspace:*",
     "@internals/tanstack-query": "workspace:*",
     "@internals/utils": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,12 +641,6 @@ importers:
 
   packages/plugin-axios:
     dependencies:
-      '@internals/client':
-        specifier: workspace:*
-        version: link:../../internals/client
-      '@internals/shared':
-        specifier: workspace:*
-        version: link:../../internals/shared
       '@kubb/ast':
         specifier: 'catalog:'
         version: 5.0.0-beta.73
@@ -663,6 +657,12 @@ importers:
         specifier: 'catalog:'
         version: 5.0.0-beta.73
     devDependencies:
+      '@internals/client':
+        specifier: workspace:*
+        version: link:../../internals/client
+      '@internals/shared':
+        specifier: workspace:*
+        version: link:../../internals/shared
       '@internals/utils':
         specifier: workspace:*
         version: link:../../internals/utils
@@ -719,12 +719,6 @@ importers:
 
   packages/plugin-fetch:
     dependencies:
-      '@internals/client':
-        specifier: workspace:*
-        version: link:../../internals/client
-      '@internals/shared':
-        specifier: workspace:*
-        version: link:../../internals/shared
       '@kubb/ast':
         specifier: 'catalog:'
         version: 5.0.0-beta.73
@@ -741,15 +735,6 @@ importers:
         specifier: 'catalog:'
         version: 5.0.0-beta.73
     devDependencies:
-      '@internals/utils':
-        specifier: workspace:*
-        version: link:../../internals/utils
-      typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
-
-  packages/plugin-mcp:
-    dependencies:
       '@internals/client':
         specifier: workspace:*
         version: link:../../internals/client
@@ -759,6 +744,12 @@ importers:
       '@internals/utils':
         specifier: workspace:*
         version: link:../../internals/utils
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+
+  packages/plugin-mcp:
+    dependencies:
       '@kubb/ast':
         specifier: 'catalog:'
         version: 5.0.0-beta.73
@@ -774,6 +765,16 @@ importers:
       '@kubb/renderer-jsx':
         specifier: 'catalog:'
         version: 5.0.0-beta.73
+    devDependencies:
+      '@internals/client':
+        specifier: workspace:*
+        version: link:../../internals/client
+      '@internals/shared':
+        specifier: workspace:*
+        version: link:../../internals/shared
+      '@internals/utils':
+        specifier: workspace:*
+        version: link:../../internals/utils
 
   packages/plugin-msw:
     dependencies:
@@ -802,9 +803,6 @@ importers:
 
   packages/plugin-react-query:
     dependencies:
-      '@internals/client':
-        specifier: workspace:*
-        version: link:../../internals/client
       '@kubb/ast':
         specifier: 'catalog:'
         version: 5.0.0-beta.73
@@ -821,6 +819,9 @@ importers:
         specifier: 'catalog:'
         version: 5.0.0-beta.73
     devDependencies:
+      '@internals/client':
+        specifier: workspace:*
+        version: link:../../internals/client
       '@internals/shared':
         specifier: workspace:*
         version: link:../../internals/shared
@@ -846,9 +847,6 @@ importers:
 
   packages/plugin-swr:
     dependencies:
-      '@internals/client':
-        specifier: workspace:*
-        version: link:../../internals/client
       '@kubb/ast':
         specifier: 'catalog:'
         version: 5.0.0-beta.73
@@ -865,6 +863,9 @@ importers:
         specifier: 'catalog:'
         version: 5.0.0-beta.73
     devDependencies:
+      '@internals/client':
+        specifier: workspace:*
+        version: link:../../internals/client
       '@internals/shared':
         specifier: workspace:*
         version: link:../../internals/shared
@@ -902,9 +903,6 @@ importers:
 
   packages/plugin-vue-query:
     dependencies:
-      '@internals/client':
-        specifier: workspace:*
-        version: link:../../internals/client
       '@kubb/ast':
         specifier: 'catalog:'
         version: 5.0.0-beta.73
@@ -921,6 +919,9 @@ importers:
         specifier: 'catalog:'
         version: 5.0.0-beta.73
     devDependencies:
+      '@internals/client':
+        specifier: workspace:*
+        version: link:../../internals/client
       '@internals/shared':
         specifier: workspace:*
         version: link:../../internals/shared


### PR DESCRIPTION
## Problem

The changesets release (`pnpm exec changeset version`) failed on `main`:

```
error The package "@kubb/plugin-axios" depends on the skipped package "@internals/client"
(either by `ignore` option or by `privatePackages.version`), but "@kubb/plugin-axios" is not
being skipped. Please pass "@kubb/plugin-axios" to the `--ignore` flag.
```

The changeset config sets `"ignore": ["@internals/*"]`, so those private packages are skipped during versioning. But six publishable plugins listed `@internals/*` in their runtime `dependencies`, and changesets refuses to version a published package that has a non-dev dependency on a skipped package.

## Root cause

`@internals/*` are private workspace packages (`"private": true`, never published to npm). They are meant to be bundled into each plugin at build time. tsdown externalizes `dependencies` but bundles everything else, so listing them under `dependencies` both broke the release and left the published output requiring packages that don't exist on npm. The telling detail in the CI log: `@internals/utils`, already declared as a `devDependency`, produced no error — only the ones under `dependencies` did.

## Fix

Move every `@internals/*` entry from `dependencies` to `devDependencies` in the six affected plugins, matching how `@internals/utils` and the kubb repo already declare them. This bundles them into the output and lets `changeset version` run without listing any internals in a changeset.

- `plugin-axios`, `plugin-fetch`: `@internals/client`, `@internals/shared`
- `plugin-mcp`: `@internals/client`, `@internals/shared`, `@internals/utils`
- `plugin-react-query`, `plugin-swr`, `plugin-vue-query`: `@internals/client`

Lockfile refreshed, and a patch changeset added for the six plugins (no `@internals/*` in its frontmatter). Verified locally that `changeset version` now passes the skipped-package validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)