### PR TITLE
chore(changeset): drop @kubb/plugin-client from changeset frontmatter

### DIFF
--- a/.changeset/enforce-array-type-syntax.md
+++ b/.changeset/enforce-array-type-syntax.md
@@ -1,5 +1,4 @@
 ---
-'@kubb/plugin-client': patch
 '@kubb/plugin-cypress': patch
 '@kubb/plugin-faker': patch
 '@kubb/plugin-mcp': patch

--- a/.changeset/migrate-plugins-param-type-model.md
+++ b/.changeset/migrate-plugins-param-type-model.md
@@ -1,6 +1,5 @@
 ---
 '@kubb/plugin-ts': major
-'@kubb/plugin-client': major
 '@kubb/plugin-react-query': major
 '@kubb/plugin-vue-query': major
 '@kubb/plugin-swr': major

--- a/.changeset/plugin-client-parser-request-direction.md
+++ b/.changeset/plugin-client-parser-request-direction.md
@@ -1,5 +1,4 @@
 ---
-'@kubb/plugin-client': minor
 '@kubb/plugin-react-query': patch
 '@kubb/plugin-swr': patch
 '@kubb/plugin-vue-query': patch

--- a/.changeset/refresh-package-descriptions.md
+++ b/.changeset/refresh-package-descriptions.md
@@ -1,5 +1,4 @@
 ---
-'@kubb/plugin-client': patch
 '@kubb/plugin-cypress': patch
 '@kubb/plugin-faker': patch
 '@kubb/plugin-mcp': patch

--- a/.changeset/remove-extension-yaml-manifests.md
+++ b/.changeset/remove-extension-yaml-manifests.md
@@ -1,5 +1,4 @@
 ---
-'@kubb/plugin-client': patch
 '@kubb/plugin-cypress': patch
 '@kubb/plugin-faker': patch
 '@kubb/plugin-mcp': patch

--- a/.changeset/standardize-client-runtime-symbol.md
+++ b/.changeset/standardize-client-runtime-symbol.md
@@ -1,5 +1,4 @@
 ---
-'@kubb/plugin-client': patch
 '@kubb/plugin-react-query': patch
 '@kubb/plugin-vue-query': patch
 '@kubb/plugin-mcp': patch


### PR DESCRIPTION
## Summary

`@kubb/plugin-client` was removed from the workspace (its source is gone, only a stale `node_modules` remains). Several changesets still listed it as a version-bump key in their frontmatter, which would break `changeset version` because the package no longer exists.

This removes `@kubb/plugin-client` from the frontmatter of the six affected changesets, keeping every bump for packages that still ship:

- `enforce-array-type-syntax.md`
- `migrate-plugins-param-type-model.md`
- `plugin-client-parser-request-direction.md`
- `refresh-package-descriptions.md`
- `remove-extension-yaml-manifests.md`
- `standardize-client-runtime-symbol.md`

Prose mentions of `@kubb/plugin-client` (migration context, including the canonical `remove-plugin-client.md`) are left intact.

## Verification

- No changeset frontmatter references `@kubb/plugin-client` anymore.
- `remove-plugin-client.md` already bumps only existing packages, so it was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XW7qP93MkVmp6vataqwf9r)_