### PR TITLE
test(plugin-zod): cover nullable schema inside allOf (#3661)

### DIFF
--- a/schemas/3.0.x/nullableAllOf.yaml
+++ b/schemas/3.0.x/nullableAllOf.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: Minimal API
+  version: 1.0.0
+  description: A minimal OpenAPI 3.0 specification
+paths:
+  /health:
+    get:
+      summary: Health check
+      operationId: getHealth
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/NullableString'
+components:
+  schemas:
+    NullableString:
+      type: string
+      nullable: true
+    NullableAllOf:
+      allOf:
+        - $ref: '#/components/schemas/NullableString'
+    NullableAllOfMulti:
+      allOf:
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/NullableString'
+    Base:
+      type: object
+      properties:
+        id:
+          type: string

--- a/tests/3.0.x/nullableAllOf.test.ts
+++ b/tests/3.0.x/nullableAllOf.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { adapterOas } from '@kubb/adapter-oas'
+import { AsyncEventEmitter, type Config, createKubb, Diagnostics, type KubbHooks, fsStorage } from '@kubb/core'
+import { parserTs } from '@kubb/parser-ts'
+import { pluginZod } from '@kubb/plugin-zod'
+import { describe, expect, test } from 'vitest'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// https://github.com/kubb-labs/kubb/issues/3661
+// A nullable member inside an `allOf` must not leak into a broken `.and(.nullable())`.
+describe('nullable allOf (issue #3661)', () => {
+  test('generates valid zod for a nullable string inside allOf', async () => {
+    const tmpDir = path.join(os.tmpdir(), `kubb-test-nullableAllOf-${Date.now()}`)
+    const { files, diagnostics } = await createKubb(
+      {
+        root: __dirname,
+        input: { path: '../../schemas/3.0.x/nullableAllOf.yaml' },
+        output: { path: tmpDir, barrel: false },
+        adapter: adapterOas({ validate: false, enums: 'root' }),
+        parsers: [parserTs],
+        storage: fsStorage(),
+        plugins: [pluginZod({ output: { path: './zod', barrel: false } })],
+      } as Config,
+      { hooks: new AsyncEventEmitter<KubbHooks>() },
+    ).safeBuild()
+
+    expect(Diagnostics.hasError(diagnostics)).toBe(false)
+    expect(files.length).toBeGreaterThan(0)
+
+    const sources = await Promise.all(files.map((file) => fs.readFile(file.path, 'utf-8')))
+    const combined = sources.join('\n')
+
+    // The original bug emitted invalid syntax such as `.and(.nullable())`.
+    expect(combined).not.toMatch(/\.and\(\s*\./)
+    expect(combined).toContain('nullableStringSchema.nullable()')
+
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+})


### PR DESCRIPTION
## What

Adds an end-to-end regression test for #3661 (v5).

## Context

In v4, a nullable schema inside an `allOf` emitted invalid Zod (`z.lazy(() => nullableStringSchema).and(.nullable())`). That fix lives in `kubb-labs/kubb` on the `v4` branch.

v5 does **not** have the bug: `@kubb/adapter-oas` flattens a single-member `allOf` and propagates `nullable`, so the printer emits valid output:

```ts
export const getHealthStatus200Schema = nullableStringSchema.nullable()
```

This PR locks that behavior in with a test, so a future regression in the adapter or printer is caught.

## How

`tests/3.0.x/nullableAllOf.test.ts` runs the real `adapter-oas` → `plugin-zod` pipeline on a spec with a nullable string in `allOf` (single- and multi-member) and asserts the output contains no broken `.and(.` and a valid `.nullable()`.

No production code change, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUhMV6aMGjVezMYmfzEyQs)_