### PR TITLE
refactor(plugins): spread generators into addGenerator

### DIFF
--- a/.changeset/spread-generators-into-add-generator.md
+++ b/.changeset/spread-generators-into-add-generator.md
@@ -1,0 +1,9 @@
+---
+"@kubb/plugin-axios": patch
+"@kubb/plugin-fetch": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-vue-query": patch
+---
+
+Spread the selected generators into `ctx.addGenerator` so the call matches the narrowed `@kubb/core` signature, which now takes generators as separate arguments instead of a bare array.

--- a/packages/plugin-axios/src/plugin.ts
+++ b/packages/plugin-axios/src/plugin.ts
@@ -75,7 +75,7 @@ export const pluginAxios = definePlugin<PluginAxios>((options) => {
         ctx.setResolver(resolved.resolver)
         ctx.setMacros([...defaultMacros, ...(options.macros ?? [])])
 
-        ctx.addGenerator(selectedGenerators)
+        ctx.addGenerator(...selectedGenerators)
 
         const root = path.resolve(ctx.config.root, ctx.config.output.path)
 

--- a/packages/plugin-fetch/src/plugin.ts
+++ b/packages/plugin-fetch/src/plugin.ts
@@ -75,7 +75,7 @@ export const pluginFetch = definePlugin<PluginFetch>((options) => {
         ctx.setResolver(resolved.resolver)
         ctx.setMacros([...defaultMacros, ...(options.macros ?? [])])
 
-        ctx.addGenerator(selectedGenerators)
+        ctx.addGenerator(...selectedGenerators)
 
         const root = path.resolve(ctx.config.root, ctx.config.output.path)
 

--- a/packages/plugin-react-query/src/plugin.ts
+++ b/packages/plugin-react-query/src/plugin.ts
@@ -142,7 +142,7 @@ export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
           ctx.setMacros(userMacros)
         }
 
-        ctx.addGenerator(selectedGenerators)
+        ctx.addGenerator(...selectedGenerators)
       },
     },
   }

--- a/packages/plugin-swr/src/plugin.ts
+++ b/packages/plugin-swr/src/plugin.ts
@@ -83,7 +83,7 @@ export const pluginSwr = definePlugin<PluginSwr>((options) => {
           ctx.setMacros(userMacros)
         }
 
-        ctx.addGenerator(selectedGenerators)
+        ctx.addGenerator(...selectedGenerators)
       },
     },
   }

--- a/packages/plugin-vue-query/src/plugin.ts
+++ b/packages/plugin-vue-query/src/plugin.ts
@@ -125,7 +125,7 @@ export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
           ctx.setMacros(userMacros)
         }
 
-        ctx.addGenerator(selectedGenerators)
+        ctx.addGenerator(...selectedGenerators)
       },
     },
   }


### PR DESCRIPTION
## What

Follow-up to the narrowed `addGenerator` signature in `@kubb/core` ([kubb-labs/kubb#3667](https://github.com/kubb-labs/kubb/pull/3667)). That method no longer accepts a bare array, so the client plugins now spread their selected generators:

```ts
// before
ctx.addGenerator(selectedGenerators)

// after
ctx.addGenerator(...selectedGenerators)
```

Updated in `plugin-axios`, `plugin-fetch`, `plugin-react-query`, `plugin-swr`, and `plugin-vue-query`. `plugin-mcp` already passes generators as separate arguments, so it needs no change.

## Notes

- Spreading is compatible with the catalog-pinned `@kubb/core@5.0.0-beta.74` (each element matches the `Generator` arm of the current signature) as well as the narrowed signature, so CI stays green either way.
- Added a `patch` changeset for the five affected plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WB9DA2f2gjmpe6TY3qszqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WB9DA2f2gjmpe6TY3qszqC)_