### PR TITLE
feat(plugin-zod): support patternProperties via .catchall()

### DIFF
--- a/.changeset/ts-pattern-properties.md
+++ b/.changeset/ts-pattern-properties.md
@@ -1,0 +1,11 @@
+---
+"@kubb/plugin-ts": minor
+---
+
+Improve `patternProperties` handling in the TypeScript printer.
+
+- Multiple patterns now contribute their value types to a single index signature instead of only the first pattern being used (`{ [key: string]: string | number }`), with identical value types deduplicated.
+- `additionalProperties` and `patternProperties` declared together now merge into one string index signature instead of emitting two, which TypeScript rejects.
+- When the object also has fixed properties, the index signature value falls back to `unknown` so it stays assignable from the named properties.
+
+The key regex of `patternProperties` still cannot be expressed by a TypeScript index signature and is dropped, matching how the type is generated elsewhere.

--- a/.changeset/zod-pattern-properties.md
+++ b/.changeset/zod-pattern-properties.md
@@ -2,8 +2,11 @@
 "@kubb/plugin-zod": minor
 ---
 
-Add `patternProperties` support to the Zod printer.
+Add `patternProperties` support to the Zod and Zod Mini printers.
 
-- Without fixed `properties`, an object emits `z.record(z.string().regex(<pattern>), <value>)`, so the generated schema validates both the key pattern and the value. Multiple patterns combine into one alternation key regex with a union value.
-- With fixed `properties`, the object falls back to `.catchall(<value>)` (value validated, key pattern not), because a regex-constrained `z.record` inside an intersection rejects the fixed keys at runtime.
+- Without fixed `properties`, an object emits `z.record(z.string().regex(<pattern>), <value>)` (`z.record(z.string().check(z.regex(...)), ...)` in mini), so the generated schema validates both the key pattern and the value. Multiple patterns combine into one alternation key regex with a union value.
+- With fixed `properties`, the object falls back to `.catchall(<value>)` (`z.catchall(...)` in mini), because a regex-constrained `z.record` inside an intersection rejects the fixed keys at runtime.
+- `additionalProperties: false` combined with `patternProperties` now keeps the pattern record instead of emitting `.strict()`, which would have rejected the pattern-matched keys.
 - `additionalProperties` still takes precedence when both are present.
+
+The Zod Mini printer also now honors `additionalProperties` itself: a schema maps to `z.catchall(...)`, `true` to `z.catchall(object, z.unknown())`, and `false` to `z.strictObject(...)`.

--- a/.changeset/zod-pattern-properties.md
+++ b/.changeset/zod-pattern-properties.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-zod": minor
+---
+
+Add `patternProperties` support to the Zod printer. Objects that declare `patternProperties` now emit a `.catchall(...)` built from the first pattern's value schema, mirroring the index signature the TypeScript plugin already generates. `additionalProperties` still takes precedence when both are present.

--- a/.changeset/zod-pattern-properties.md
+++ b/.changeset/zod-pattern-properties.md
@@ -2,4 +2,8 @@
 "@kubb/plugin-zod": minor
 ---
 
-Add `patternProperties` support to the Zod printer. Objects that declare `patternProperties` now emit `z.record(z.string().regex(<pattern>), <value>)`, so the generated schema validates both the key pattern and the value type. When fixed `properties` are present the records are intersected with the base object (`z.object({...}).and(z.record(...))`), and multiple patterns are intersected together. `additionalProperties` still takes precedence when both are present.
+Add `patternProperties` support to the Zod printer.
+
+- Without fixed `properties`, an object emits `z.record(z.string().regex(<pattern>), <value>)`, so the generated schema validates both the key pattern and the value. Multiple patterns combine into one alternation key regex with a union value.
+- With fixed `properties`, the object falls back to `.catchall(<value>)` (value validated, key pattern not), because a regex-constrained `z.record` inside an intersection rejects the fixed keys at runtime.
+- `additionalProperties` still takes precedence when both are present.

--- a/.changeset/zod-pattern-properties.md
+++ b/.changeset/zod-pattern-properties.md
@@ -2,4 +2,4 @@
 "@kubb/plugin-zod": minor
 ---
 
-Add `patternProperties` support to the Zod printer. Objects that declare `patternProperties` now emit a `.catchall(...)` built from the first pattern's value schema, mirroring the index signature the TypeScript plugin already generates. `additionalProperties` still takes precedence when both are present.
+Add `patternProperties` support to the Zod printer. Objects that declare `patternProperties` now emit `z.record(z.string().regex(<pattern>), <value>)`, so the generated schema validates both the key pattern and the value type. When fixed `properties` are present the records are intersected with the base object (`z.object({...}).and(z.record(...))`), and multiple patterns are intersected together. `additionalProperties` still takes precedence when both are present.

--- a/examples/zod/src/mini/zod/getInventorySchema.ts
+++ b/examples/zod/src/mini/zod/getInventorySchema.ts
@@ -5,6 +5,6 @@
 
 import * as z from 'zod/mini'
 
-export const getInventoryStatus200Schema = z.object({})
+export const getInventoryStatus200Schema = z.catchall(z.object({}), z.int())
 
 export const getInventoryResponseSchema = getInventoryStatus200Schema

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -938,35 +938,41 @@ export function buildPropertyType(
   return type
 }
 
+const indexSignaturePrinter = ts.createPrinter()
+const indexSignatureSource = ts.createSourceFile('', '', ts.ScriptTarget.Latest)
+
 /**
- * Creates TypeScript index signatures for `additionalProperties` and `patternProperties` on an object schema node.
+ * Creates a TypeScript index signature for `additionalProperties` and `patternProperties` on an
+ * object schema node. TypeScript allows only one string index signature and its value must be
+ * assignable from every named property, so both keywords collapse into a single signature: the
+ * union of all value types (deduplicated), or `unknown` when the object also has fixed properties.
+ * The key regex of `patternProperties` cannot be expressed by an index signature and is dropped.
  */
 export function buildIndexSignatures(
   node: { additionalProperties?: ast.SchemaNode | boolean; patternProperties?: Record<string, ast.SchemaNode> },
   propertyCount: number,
   print: (node: ast.SchemaNode) => ts.TypeNode | null | undefined,
 ): Array<ts.TypeElement> {
-  const elements: Array<ts.TypeElement> = []
+  const valueTypes: Array<ts.TypeNode> = []
 
   if (node.additionalProperties && node.additionalProperties !== true) {
-    const additionalType = print(node.additionalProperties) ?? keywordTypeNodes.unknown
-
-    elements.push(createIndexSignature(propertyCount > 0 ? keywordTypeNodes.unknown : additionalType))
+    valueTypes.push(print(node.additionalProperties) ?? keywordTypeNodes.unknown)
   } else if (node.additionalProperties === true) {
-    elements.push(createIndexSignature(keywordTypeNodes.unknown))
+    valueTypes.push(keywordTypeNodes.unknown)
   }
 
-  if (node.patternProperties) {
-    const first = Object.values(node.patternProperties)[0]
-    if (first) {
-      let patternType = print(first) ?? keywordTypeNodes.unknown
-
-      if (first.nullable) {
-        patternType = createUnionDeclaration({ nodes: [patternType, keywordTypeNodes.null] })
-      }
-      elements.push(createIndexSignature(patternType))
-    }
+  for (const schema of Object.values(node.patternProperties ?? {})) {
+    const patternType = print(schema) ?? keywordTypeNodes.unknown
+    valueTypes.push(schema.nullable ? createUnionDeclaration({ nodes: [patternType, keywordTypeNodes.null] }) : patternType)
   }
 
-  return elements
+  if (valueTypes.length === 0) return []
+
+  const seen = new Set<string>()
+  const distinct = valueTypes.filter((type) => {
+    const key = indexSignaturePrinter.printNode(ts.EmitHint.Unspecified, type, indexSignatureSource)
+    return seen.has(key) ? false : (seen.add(key), true)
+  })
+
+  return [createIndexSignature(propertyCount > 0 ? keywordTypeNodes.unknown : createUnionDeclaration({ nodes: distinct }))]
 }

--- a/packages/plugin-ts/src/printers/printerTs.test.ts
+++ b/packages/plugin-ts/src/printers/printerTs.test.ts
@@ -593,11 +593,9 @@ describe('printerTs', () => {
         }),
       )
 
-      expect(await formatTS(result)).toMatchInlineSnapshot(`
-        "{
-          [key: string]: string
-        }"
-      `)
+      expect(await formatTS(result)).toBe(`{
+  [key: string]: string
+}`)
     })
 
     it('additionalProperties with existing properties uses unknown for index', async () => {
@@ -609,15 +607,13 @@ describe('printerTs', () => {
         }),
       )
 
-      expect(await formatTS(result)).toMatchInlineSnapshot(`
-        "{
-          /**
-           * @type number
-           */
-          id: number
-          [key: string]: unknown
-        }"
-      `)
+      expect(await formatTS(result)).toBe(`{
+  /**
+   * @type number
+   */
+  id: number
+  [key: string]: unknown
+}`)
     })
 
     it('patternProperties adds index signature', async () => {
@@ -629,11 +625,9 @@ describe('printerTs', () => {
         }),
       )
 
-      expect(await formatTS(result)).toMatchInlineSnapshot(`
-        "{
-          [key: string]: string
-        }"
-      `)
+      expect(await formatTS(result)).toBe(`{
+  [key: string]: string
+}`)
     })
 
     it('patternProperties with nullable adds | null to index type', async () => {
@@ -645,11 +639,76 @@ describe('printerTs', () => {
         }),
       )
 
-      expect(await formatTS(result)).toMatchInlineSnapshot(`
-        "{
-          [key: string]: string | null
-        }"
-      `)
+      expect(await formatTS(result)).toBe(`{
+  [key: string]: string | null
+}`)
+    })
+
+    it('multiple patternProperties union their value types in one index signature', async () => {
+      const result = printer.transform(
+        ast.factory.createSchema({
+          type: 'object',
+          properties: [],
+          patternProperties: {
+            '^S_': ast.factory.createSchema({ type: 'string' }),
+            '^I_': ast.factory.createSchema({ type: 'number' }),
+          },
+        }),
+      )
+
+      expect(await formatTS(result)).toBe(`{
+  [key: string]: string | number
+}`)
+    })
+
+    it('multiple patternProperties with identical value types dedupe to one type', async () => {
+      const result = printer.transform(
+        ast.factory.createSchema({
+          type: 'object',
+          properties: [],
+          patternProperties: {
+            '^S_': ast.factory.createSchema({ type: 'string' }),
+            '^T_': ast.factory.createSchema({ type: 'string' }),
+          },
+        }),
+      )
+
+      expect(await formatTS(result)).toBe(`{
+  [key: string]: string
+}`)
+    })
+
+    it('additionalProperties and patternProperties merge into a single index signature', async () => {
+      const result = printer.transform(
+        ast.factory.createSchema({
+          type: 'object',
+          properties: [],
+          additionalProperties: ast.factory.createSchema({ type: 'number' }),
+          patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
+        }),
+      )
+
+      expect(await formatTS(result)).toBe(`{
+  [key: string]: number | string
+}`)
+    })
+
+    it('patternProperties with fixed properties uses unknown for the index type', async () => {
+      const result = printer.transform(
+        ast.factory.createSchema({
+          type: 'object',
+          properties: [ast.factory.createProperty({ name: 'id', required: true, schema: ast.factory.createSchema({ type: 'number' }) })],
+          patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
+        }),
+      )
+
+      expect(await formatTS(result)).toBe(`{
+  /**
+   * @type number
+   */
+  id: number
+  [key: string]: unknown
+}`)
     })
 
     it('nullish property with optionalType=questionToken adds ?', async () => {

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -256,24 +256,47 @@ describe('printerZod', () => {
       expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.string())"`)
     })
 
-    test('object with patternProperties → .catchall(schema)', () => {
+    test('object with patternProperties → z.record(regex key, value)', () => {
       const node = ast.factory.createSchema({
         type: 'object',
         primitive: 'object',
         properties: [],
         patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
       })
-      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.string())"`)
+      expect(printer.print(node)).toBe('z.record(z.string().regex(/^S_/), z.string())')
     })
 
-    test('object with nullable patternProperties → .catchall(schema.nullable())', () => {
+    test('object with nullable patternProperties value → record value gets .nullable()', () => {
       const node = ast.factory.createSchema({
         type: 'object',
         primitive: 'object',
         properties: [],
         patternProperties: { '^S_': ast.factory.createSchema({ type: 'string', nullable: true }) },
       })
-      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.string().nullable())"`)
+      expect(printer.print(node)).toBe('z.record(z.string().regex(/^S_/), z.string().nullable())')
+    })
+
+    test('patternProperties with fixed properties → intersected with the base object', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [ast.factory.createProperty({ name: 'id', required: true, schema: ast.factory.createSchema({ type: 'integer' }) })],
+        patternProperties: { '^meta_': ast.factory.createSchema({ type: 'string' }) },
+      })
+      expect(printer.print(node)).toBe('z.object({\n  id: z.int(),\n}).and(z.record(z.string().regex(/^meta_/), z.string()))')
+    })
+
+    test('multiple patternProperties → records intersected', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        patternProperties: {
+          '^S_': ast.factory.createSchema({ type: 'string' }),
+          '^I_': ast.factory.createSchema({ type: 'integer' }),
+        },
+      })
+      expect(printer.print(node)).toBe('z.record(z.string().regex(/^S_/), z.string()).and(z.record(z.string().regex(/^I_/), z.int()))')
     })
 
     test('additionalProperties takes precedence over patternProperties', () => {

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -322,6 +322,17 @@ describe('printerZod', () => {
       })
       expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.number())"`)
     })
+
+    test('additionalProperties:false with patternProperties keeps the pattern record (not .strict)', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        additionalProperties: false,
+        patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
+      })
+      expect(printer.print(node)).toBe('z.record(z.string().regex(/^S_/), z.string())')
+    })
   })
 
   describe('array', () => {

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -255,6 +255,37 @@ describe('printerZod', () => {
       })
       expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.string())"`)
     })
+
+    test('object with patternProperties → .catchall(schema)', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
+      })
+      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.string())"`)
+    })
+
+    test('object with nullable patternProperties → .catchall(schema.nullable())', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        patternProperties: { '^S_': ast.factory.createSchema({ type: 'string', nullable: true }) },
+      })
+      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.string().nullable())"`)
+    })
+
+    test('additionalProperties takes precedence over patternProperties', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        additionalProperties: ast.factory.createSchema({ type: 'number' }),
+        patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
+      })
+      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.number())"`)
+    })
   })
 
   describe('array', () => {

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -238,12 +238,12 @@ describe('printerZod', () => {
 
     test('object with additionalProperties: true → .catchall(z.unknown())', () => {
       const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], additionalProperties: true })
-      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.unknown())"`)
+      expect(printer.print(node)).toBe('z.object({}).catchall(z.unknown())')
     })
 
     test('object with additionalProperties: false → .strict()', () => {
       const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], additionalProperties: false })
-      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).strict()"`)
+      expect(printer.print(node)).toBe('z.object({}).strict()')
     })
 
     test('object with additionalProperties schema → .catchall(schema)', () => {
@@ -253,7 +253,7 @@ describe('printerZod', () => {
         properties: [],
         additionalProperties: ast.factory.createSchema({ type: 'string' }),
       })
-      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.string())"`)
+      expect(printer.print(node)).toBe('z.object({}).catchall(z.string())')
     })
 
     test('object with patternProperties → z.record(regex key, value)', () => {
@@ -320,7 +320,7 @@ describe('printerZod', () => {
         additionalProperties: ast.factory.createSchema({ type: 'number' }),
         patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
       })
-      expect(printer.print(node)).toMatchInlineSnapshot(`"z.object({}).catchall(z.number())"`)
+      expect(printer.print(node)).toBe('z.object({}).catchall(z.number())')
     })
 
     test('additionalProperties:false with patternProperties keeps the pattern record (not .strict)', () => {

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -276,17 +276,17 @@ describe('printerZod', () => {
       expect(printer.print(node)).toBe('z.record(z.string().regex(/^S_/), z.string().nullable())')
     })
 
-    test('patternProperties with fixed properties → intersected with the base object', () => {
+    test('patternProperties with fixed properties → .catchall (record cannot coexist with a fixed shape)', () => {
       const node = ast.factory.createSchema({
         type: 'object',
         primitive: 'object',
         properties: [ast.factory.createProperty({ name: 'id', required: true, schema: ast.factory.createSchema({ type: 'integer' }) })],
         patternProperties: { '^meta_': ast.factory.createSchema({ type: 'string' }) },
       })
-      expect(printer.print(node)).toBe('z.object({\n  id: z.int(),\n}).and(z.record(z.string().regex(/^meta_/), z.string()))')
+      expect(printer.print(node)).toBe('z.object({\n  id: z.int(),\n}).catchall(z.string())')
     })
 
-    test('multiple patternProperties → records intersected', () => {
+    test('multiple patternProperties → alternation key regex with a union value', () => {
       const node = ast.factory.createSchema({
         type: 'object',
         primitive: 'object',
@@ -296,7 +296,20 @@ describe('printerZod', () => {
           '^I_': ast.factory.createSchema({ type: 'integer' }),
         },
       })
-      expect(printer.print(node)).toBe('z.record(z.string().regex(/^S_/), z.string()).and(z.record(z.string().regex(/^I_/), z.int()))')
+      expect(printer.print(node)).toBe('z.record(z.string().regex(/(^S_)|(^I_)/), z.union([z.string(), z.int()]))')
+    })
+
+    test('multiple patternProperties with identical value types → single value, no union', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        patternProperties: {
+          '^S_': ast.factory.createSchema({ type: 'string' }),
+          '^T_': ast.factory.createSchema({ type: 'string' }),
+        },
+      })
+      expect(printer.print(node)).toBe('z.record(z.string().regex(/(^S_)|(^T_)/), z.string())')
     })
 
     test('additionalProperties takes precedence over patternProperties', () => {

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -278,7 +278,7 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
 
         const objectBase = `z.object(${buildObject(entries)})`
 
-        // Handle additionalProperties as .catchall() or .strict()
+        // Handle additionalProperties as .catchall() or .strict(), falling back to patternProperties.
         const result = (() => {
           if (node.additionalProperties && node.additionalProperties !== true) {
             const catchallType = this.transform(node.additionalProperties)
@@ -286,6 +286,14 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
           }
           if (node.additionalProperties === true) return `${objectBase}.catchall(${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
           if (node.additionalProperties === false) return `${objectBase}.strict()`
+
+          // Zod has no per-pattern key validation, so the first pattern's value schema becomes the
+          // catchall, mirroring the index signature emitted by the TypeScript plugin.
+          const patternValue = node.patternProperties && Object.values(node.patternProperties)[0]
+          if (patternValue) {
+            const patternType = this.transform(patternValue)
+            if (patternType) return `${objectBase}.catchall(${patternValue.nullable ? `${patternType}.nullable()` : patternType})`
+          }
           return objectBase
         })()
 

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -13,7 +13,7 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyModifiers, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, shouldCoerce } from '../utils.ts'
+import { applyModifiers, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, patternKeySchema, shouldCoerce } from '../utils.ts'
 import type { AdapterOas } from '@kubb/adapter-oas'
 
 /**
@@ -287,12 +287,20 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
           if (node.additionalProperties === true) return `${objectBase}.catchall(${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
           if (node.additionalProperties === false) return `${objectBase}.strict()`
 
-          // Zod has no per-pattern key validation, so the first pattern's value schema becomes the
-          // catchall, mirroring the index signature emitted by the TypeScript plugin.
-          const patternValue = node.patternProperties && Object.values(node.patternProperties)[0]
-          if (patternValue) {
-            const patternType = this.transform(patternValue)
-            if (patternType) return `${objectBase}.catchall(${patternValue.nullable ? `${patternType}.nullable()` : patternType})`
+          // patternProperties maps regex key patterns to value schemas. z.record(keySchema, value)
+          // validates both the key pattern and the value, which .catchall() cannot express. When
+          // fixed properties coexist, intersect the records with the base object.
+          if (node.patternProperties) {
+            const records = Object.entries(node.patternProperties).map(([pattern, valueSchema]) => {
+              const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
+              const value = valueSchema.nullable ? `${valueType}.nullable()` : valueType
+              return `z.record(${patternKeySchema({ pattern, regexType: this.options.regexType })}, ${value})`
+            })
+            const [firstRecord, ...restRecords] = records
+            if (firstRecord) {
+              const base = entries.length > 0 ? `${objectBase}.and(${firstRecord})` : firstRecord
+              return restRecords.reduce((acc, record) => `${acc}.and(${record})`, base)
+            }
           }
           return objectBase
         })()

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -287,20 +287,21 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
           if (node.additionalProperties === true) return `${objectBase}.catchall(${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
           if (node.additionalProperties === false) return `${objectBase}.strict()`
 
-          // patternProperties maps regex key patterns to value schemas. z.record(keySchema, value)
-          // validates both the key pattern and the value, which .catchall() cannot express. When
-          // fixed properties coexist, intersect the records with the base object.
-          if (node.patternProperties) {
-            const records = Object.entries(node.patternProperties).map(([pattern, valueSchema]) => {
+          // patternProperties maps regex key patterns to value schemas. With no fixed properties,
+          // z.record(keySchema, value) validates both the key pattern and the value. Alongside
+          // fixed properties zod can't constrain the extra-key names (a record in an intersection
+          // rejects the fixed keys), so fall back to .catchall, which validates the value only.
+          const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
+          if (patterns.length > 0) {
+            const values = patterns.map(([, valueSchema]) => {
               const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
-              const value = valueSchema.nullable ? `${valueType}.nullable()` : valueType
-              return `z.record(${patternKeySchema({ pattern, regexType: this.options.regexType })}, ${value})`
+              return valueSchema.nullable ? `${valueType}.nullable()` : valueType
             })
-            const [firstRecord, ...restRecords] = records
-            if (firstRecord) {
-              const base = entries.length > 0 ? `${objectBase}.and(${firstRecord})` : firstRecord
-              return restRecords.reduce((acc, record) => `${acc}.and(${record})`, base)
-            }
+            const distinct = [...new Set(values)]
+            const value = distinct.length === 1 ? distinct[0]! : `z.union([${distinct.join(', ')}])`
+
+            if (entries.length > 0) return `${objectBase}.catchall(${value})`
+            return `z.record(${patternKeySchema({ patterns: patterns.map(([pattern]) => pattern), regexType: this.options.regexType })}, ${value})`
           }
           return objectBase
         })()

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -278,7 +278,6 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
 
         const objectBase = `z.object(${buildObject(entries)})`
 
-        // Handle additionalProperties as .catchall() or .strict(), falling back to patternProperties.
         const result = (() => {
           const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
 
@@ -287,14 +286,11 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
             return catchallType ? `${objectBase}.catchall(${catchallType})` : objectBase
           }
           if (node.additionalProperties === true) return `${objectBase}.catchall(${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
-          // `additionalProperties: false` with patternProperties still permits the pattern keys, so
-          // only emit `.strict()` when there are no patterns to honor.
+          // `additionalProperties: false` still permits patternProperties keys, so skip `.strict()` when patterns exist.
           if (node.additionalProperties === false && patterns.length === 0) return `${objectBase}.strict()`
 
-          // patternProperties maps regex key patterns to value schemas. With no fixed properties,
-          // z.record(keySchema, value) validates both the key pattern and the value. Alongside
-          // fixed properties zod can't constrain the extra-key names (a record in an intersection
-          // rejects the fixed keys), so fall back to .catchall, which validates the value only.
+          // No fixed properties: z.record enforces the key pattern. With fixed properties a record would
+          // reject the declared keys, so fall back to .catchall (value validated, key pattern not).
           if (patterns.length > 0) {
             const values = patterns.map(([, valueSchema]) => {
               const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -280,18 +280,21 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
 
         // Handle additionalProperties as .catchall() or .strict(), falling back to patternProperties.
         const result = (() => {
+          const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
+
           if (node.additionalProperties && node.additionalProperties !== true) {
             const catchallType = this.transform(node.additionalProperties)
             return catchallType ? `${objectBase}.catchall(${catchallType})` : objectBase
           }
           if (node.additionalProperties === true) return `${objectBase}.catchall(${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
-          if (node.additionalProperties === false) return `${objectBase}.strict()`
+          // `additionalProperties: false` with patternProperties still permits the pattern keys, so
+          // only emit `.strict()` when there are no patterns to honor.
+          if (node.additionalProperties === false && patterns.length === 0) return `${objectBase}.strict()`
 
           // patternProperties maps regex key patterns to value schemas. With no fixed properties,
           // z.record(keySchema, value) validates both the key pattern and the value. Alongside
           // fixed properties zod can't constrain the extra-key names (a record in an intersection
           // rejects the fixed keys), so fall back to .catchall, which validates the value only.
-          const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
           if (patterns.length > 0) {
             const values = patterns.map(([, valueSchema]) => {
               const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!

--- a/packages/plugin-zod/src/printers/printerZodMini.test.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.test.ts
@@ -187,6 +187,51 @@ describe('printerZodMini', () => {
         })"
       `)
     })
+
+    test('additionalProperties schema → z.catchall(object, schema)', () => {
+      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], additionalProperties: ast.factory.createSchema({ type: 'string' }) })
+      expect(printer.print(node)).toBe('z.catchall(z.object({}), z.string())')
+    })
+
+    test('additionalProperties: true → z.catchall(object, z.unknown())', () => {
+      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], additionalProperties: true })
+      expect(printer.print(node)).toBe('z.catchall(z.object({}), z.unknown())')
+    })
+
+    test('additionalProperties: false → z.strictObject', () => {
+      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], additionalProperties: false })
+      expect(printer.print(node)).toBe('z.strictObject({})')
+    })
+
+    test('patternProperties → z.record with a regex-checked key', () => {
+      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) } })
+      expect(printer.print(node)).toBe('z.record(z.string().check(z.regex(/^S_/)), z.string())')
+    })
+
+    test('nullable patternProperties value → z.nullable wraps the record value', () => {
+      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], patternProperties: { '^S_': ast.factory.createSchema({ type: 'string', nullable: true }) } })
+      expect(printer.print(node)).toBe('z.record(z.string().check(z.regex(/^S_/)), z.nullable(z.string()))')
+    })
+
+    test('multiple patternProperties → alternation key with a union value', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }), '^I_': ast.factory.createSchema({ type: 'integer' }) },
+      })
+      expect(printer.print(node)).toBe('z.record(z.string().check(z.regex(/(^S_)|(^I_)/)), z.union([z.string(), z.int()]))')
+    })
+
+    test('patternProperties with fixed properties → z.catchall(object, value)', () => {
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [ast.factory.createProperty({ name: 'id', required: true, schema: ast.factory.createSchema({ type: 'integer' }) })],
+        patternProperties: { '^meta_': ast.factory.createSchema({ type: 'string' }) },
+      })
+      expect(printer.print(node)).toBe('z.catchall(z.object({\n  id: z.int(),\n}), z.string())')
+    })
   })
 
   describe('array', () => {

--- a/packages/plugin-zod/src/printers/printerZodMini.test.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.test.ts
@@ -189,7 +189,12 @@ describe('printerZodMini', () => {
     })
 
     test('additionalProperties schema → z.catchall(object, schema)', () => {
-      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], additionalProperties: ast.factory.createSchema({ type: 'string' }) })
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        additionalProperties: ast.factory.createSchema({ type: 'string' }),
+      })
       expect(printer.print(node)).toBe('z.catchall(z.object({}), z.string())')
     })
 
@@ -204,12 +209,22 @@ describe('printerZodMini', () => {
     })
 
     test('patternProperties → z.record with a regex-checked key', () => {
-      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) } })
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        patternProperties: { '^S_': ast.factory.createSchema({ type: 'string' }) },
+      })
       expect(printer.print(node)).toBe('z.record(z.string().check(z.regex(/^S_/)), z.string())')
     })
 
     test('nullable patternProperties value → z.nullable wraps the record value', () => {
-      const node = ast.factory.createSchema({ type: 'object', primitive: 'object', properties: [], patternProperties: { '^S_': ast.factory.createSchema({ type: 'string', nullable: true }) } })
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        properties: [],
+        patternProperties: { '^S_': ast.factory.createSchema({ type: 'string', nullable: true }) },
+      })
       expect(printer.print(node)).toBe('z.record(z.string().check(z.regex(/^S_/)), z.nullable(z.string()))')
     })
 

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -221,9 +221,7 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
 
         const objectBase = `z.object(${buildObject(entries)})`
 
-        // zod/mini has no chainable `.catchall()`/`.strict()`, so additionalProperties and
-        // patternProperties route through the functional `z.catchall()`, `z.strictObject()`, and
-        // `z.record()` forms instead.
+        // zod/mini has no chainable `.catchall()`/`.strict()`, so route through the functional forms.
         const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
 
         if (node.additionalProperties && node.additionalProperties !== true) {

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -13,7 +13,7 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyMiniModifiers, formatLiteral, lengthChecksMini, numberChecksMini } from '../utils.ts'
+import { applyMiniModifiers, formatLiteral, lengthChecksMini, numberChecksMini, patternKeySchemaMini } from '../utils.ts'
 
 /**
  * Partial map of node-type overrides for the Zod Mini printer.
@@ -219,7 +219,32 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
           return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
         })
 
-        return `z.object(${buildObject(entries)})`
+        const objectBase = `z.object(${buildObject(entries)})`
+
+        // zod/mini has no chainable `.catchall()`/`.strict()`, so additionalProperties and
+        // patternProperties route through the functional `z.catchall()`, `z.strictObject()`, and
+        // `z.record()` forms instead.
+        const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
+
+        if (node.additionalProperties && node.additionalProperties !== true) {
+          const catchallType = this.transform(node.additionalProperties)
+          return catchallType ? `z.catchall(${objectBase}, ${catchallType})` : objectBase
+        }
+        if (node.additionalProperties === true) return `z.catchall(${objectBase}, ${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
+        if (node.additionalProperties === false && patterns.length === 0) return objectBase.replace(/^z\.object\(/, 'z.strictObject(')
+
+        if (patterns.length > 0) {
+          const values = patterns.map(([, valueSchema]) => {
+            const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
+            return valueSchema.nullable ? `z.nullable(${valueType})` : valueType
+          })
+          const distinct = [...new Set(values)]
+          const value = distinct.length === 1 ? distinct[0]! : `z.union([${distinct.join(', ')}])`
+
+          if (entries.length > 0) return `z.catchall(${objectBase}, ${value})`
+          return `z.record(${patternKeySchemaMini({ patterns: patterns.map(([pattern]) => pattern), regexType: this.options.regexType })}, ${value})`
+        }
+        return objectBase
       },
       array(node) {
         const items = mapSchemaItems(node, (item) => this.transform(item))

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -173,6 +173,14 @@ function regexFunc(regexType: PluginZod['resolvedOptions']['regexType'] | undefi
 }
 
 /**
+ * Build a Zod key schema that constrains `z.record` keys to a `patternProperties` regex, so the
+ * generated validator enforces the key pattern that a plain `.catchall()` would discard.
+ */
+export function patternKeySchema({ pattern, regexType }: { pattern: string; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
+  return `z.string().regex(${toRegExpString(pattern, regexFunc(regexType))})`
+}
+
+/**
  * Modifier options for applying chainable methods to Zod schema values.
  */
 export type ModifierOptions = {

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -178,8 +178,24 @@ function regexFunc(regexType: PluginZod['resolvedOptions']['regexType'] | undefi
  * discard. Multiple patterns are combined into a single alternation (`(^a)|(^b)`).
  */
 export function patternKeySchema({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
+  return `z.string().regex(${patternKeySource({ patterns, regexType })})`
+}
+
+/**
+ * `zod/mini` variant of {@link patternKeySchema}: the regex lives inside a `.check(z.regex(...))`
+ * rather than a chained `.regex(...)`.
+ */
+export function patternKeySchemaMini({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
+  return `z.string().check(z.regex(${patternKeySource({ patterns, regexType })}))`
+}
+
+/**
+ * Render the regex source shared by both `patternKeySchema` variants, combining multiple patterns
+ * into a single alternation (`(^a)|(^b)`).
+ */
+function patternKeySource({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
   const source = patterns.length === 1 ? patterns[0]! : patterns.map((pattern) => `(${pattern})`).join('|')
-  return `z.string().regex(${toRegExpString(source, regexFunc(regexType))})`
+  return toRegExpString(source, regexFunc(regexType))
 }
 
 /**

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -173,11 +173,13 @@ function regexFunc(regexType: PluginZod['resolvedOptions']['regexType'] | undefi
 }
 
 /**
- * Build a Zod key schema that constrains `z.record` keys to a `patternProperties` regex, so the
- * generated validator enforces the key pattern that a plain `.catchall()` would discard.
+ * Build a Zod key schema that constrains `z.record` keys to one or more `patternProperties`
+ * regexes, so the generated validator enforces the key pattern that a plain `.catchall()` would
+ * discard. Multiple patterns are combined into a single alternation (`(^a)|(^b)`).
  */
-export function patternKeySchema({ pattern, regexType }: { pattern: string; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
-  return `z.string().regex(${toRegExpString(pattern, regexFunc(regexType))})`
+export function patternKeySchema({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
+  const source = patterns.length === 1 ? patterns[0]! : patterns.map((pattern) => `(${pattern})`).join('|')
+  return `z.string().regex(${toRegExpString(source, regexFunc(regexType))})`
 }
 
 /**

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -173,26 +173,20 @@ function regexFunc(regexType: PluginZod['resolvedOptions']['regexType'] | undefi
 }
 
 /**
- * Build a Zod key schema that constrains `z.record` keys to one or more `patternProperties`
- * regexes, so the generated validator enforces the key pattern that a plain `.catchall()` would
- * discard. Multiple patterns are combined into a single alternation (`(^a)|(^b)`).
+ * Builds a Zod record key schema that enforces the `patternProperties` regexes a plain
+ * `.catchall()` would drop. Several patterns combine into one alternation (`(^a)|(^b)`).
  */
 export function patternKeySchema({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
   return `z.string().regex(${patternKeySource({ patterns, regexType })})`
 }
 
 /**
- * `zod/mini` variant of {@link patternKeySchema}: the regex lives inside a `.check(z.regex(...))`
- * rather than a chained `.regex(...)`.
+ * `zod/mini` variant of {@link patternKeySchema}, wrapping the regex in `.check(z.regex(...))`.
  */
 export function patternKeySchemaMini({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
   return `z.string().check(z.regex(${patternKeySource({ patterns, regexType })}))`
 }
 
-/**
- * Render the regex source shared by both `patternKeySchema` variants, combining multiple patterns
- * into a single alternation (`(^a)|(^b)`).
- */
 function patternKeySource({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
   const source = patterns.length === 1 ? patterns[0]! : patterns.map((pattern) => `(${pattern})`).join('|')
   return toRegExpString(source, regexFunc(regexType))


### PR DESCRIPTION
Closes kubb-labs/plugins#260
Closes kubb-labs/plugins#506

## What

Adds `patternProperties` support across the **Zod**, **Zod Mini**, and **TypeScript** printers, and improves how the TypeScript printer collapses index signatures.

## Zod / Zod Mini

Output depends on whether the object also has fixed `properties`, because Zod v4 can't both pin a fixed shape and constrain extra-key names in one composable schema.

**No fixed properties** → constrained-key record (validates key pattern *and* value):
```ts
z.record(z.string().regex(/^S_/), z.string())                                  // standard
z.record(z.string().regex(/(^S_)|(^I_)/), z.union([z.string(), z.int()]))      // multiple patterns
z.record(z.string().check(z.regex(/^S_/)), z.string())                         // zod-mini
```

**Fixed properties present** → catchall (value validated; key pattern not enforceable alongside a fixed shape):
```ts
z.object({ id: z.int() }).catchall(z.string())        // standard
z.catchall(z.object({ id: z.int() }), z.string())     // zod-mini
```

`additionalProperties: false` + `patternProperties` keeps the pattern record instead of `.strict()`. `additionalProperties` keeps precedence when both are present. The Zod Mini printer also now honors `additionalProperties` itself (`z.catchall` / `z.strictObject`), which it previously dropped.

An earlier revision used the intersection form `z.object({...}).and(z.record(...))`, which is **broken at runtime in Zod v4** (a regex-constrained record rejects the fixed keys and cross-pattern keys). The current form avoids intersections; every emitted variant — standard and mini — was verified against `zod` and `zod/mini` 4.4.3 to accept valid input and reject invalid keys/values.

## TypeScript (#506)

`buildIndexSignatures` previously honored only the first pattern and could emit two string index signatures (which TypeScript rejects). Now:

- Every `patternProperties` value type unions into a single index signature (duplicates removed): `{ [key: string]: string | number }`.
- `additionalProperties` + `patternProperties` merge into one signature.
- With fixed properties present, the index value falls back to `unknown` so it stays assignable from the named properties.

The key regex still can't be expressed by a TS index signature and is dropped (inherent to index signatures).

## Tests

`printerZod.test.ts`, `printerZodMini.test.ts`, and `printerTs.test.ts` cover single/multiple patterns, nullable values, fixed-property fallback, `additionalProperties:false` + patterns, dedupe, merge, and precedence. Index-signature/record assertions use strict `toBe`. Suites pass (`plugin-zod` 303, `plugin-ts` 239); typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkLWs5KTFp17RFTjvptZDX