### PR TITLE
feat(zod,fetch,axios): validate error body with zod on the non-throw path

### DIFF
--- a/.changeset/parse-error-body-with-zod.md
+++ b/.changeset/parse-error-body-with-zod.md
@@ -1,0 +1,14 @@
+---
+"@kubb/plugin-fetch": minor
+"@kubb/plugin-axios": minor
+"@kubb/plugin-zod": minor
+---
+
+Validate the error body with zod on the non-throw path (kubb-labs/plugins#369).
+
+When a call resolves with a non-2xx status and `throwOnError: false`, the generated client now parses the error body against a new error-only `<operation>ErrorSchema` (a union of the documented non-2xx statuses), so `result.error` has a known, validated shape instead of being surfaced raw.
+
+- **plugin-zod**: emits `<operation>ErrorSchema` alongside the success-only `<operation>ResponseSchema` for every operation that documents an error response with a schema. The success path is unchanged.
+- **plugin-fetch / plugin-axios**: the `parser: 'zod'` shorthand (and the object form's `response: 'zod'`) now also wires an `error` parser hook; the runtime runs it on the error body only when a non-2xx call does not throw. The default `throwOnError: true` path still throws a raw `ResponseError`.
+
+This is a small behavioral change for existing `parser: 'zod'` users: error bodies on non-throw calls are now validated and can surface a `ZodError` when the server's error response does not match the spec.

--- a/internals/client/src/builders/parser.ts
+++ b/internals/client/src/builders/parser.ts
@@ -1,3 +1,4 @@
+import { isSuccessStatusCode } from '@internals/shared'
 import type { ast } from '@kubb/core'
 import type { ResolverZod } from '@kubb/plugin-zod'
 import type { ParserOptions } from '../types.ts'
@@ -60,5 +61,17 @@ export type ZodResponseParse = {
  */
 export function buildZodResponseParse(node: ast.OperationNode, zodResolver: ResolverZod): ZodResponseParse | null {
   const name = zodResolver.resolveResponseName?.(node)
+  return name ? { expression: name, importNames: [name] } : null
+}
+
+/**
+ * Resolves the zod expression a generated client validates an error body with on the non-throw path.
+ * Uses the error-only `<operation>ErrorSchema` (the union of non-2xx statuses); returns `null` when the
+ * operation documents no error responses with a schema.
+ */
+export function buildZodErrorParse(node: ast.OperationNode, zodResolver: ResolverZod): ZodResponseParse | null {
+  const hasErrorResponse = node.responses.some((res) => !isSuccessStatusCode(res.statusCode) && res.content?.some((entry) => entry.schema))
+  if (!hasErrorResponse) return null
+  const name = zodResolver.resolveErrorName?.(node)
   return name ? { expression: name, importNames: [name] } : null
 }

--- a/internals/client/src/builders/validator.test.ts
+++ b/internals/client/src/builders/validator.test.ts
@@ -14,26 +14,47 @@ const addPet = ast.factory.createOperation({
   responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
 })
 
+const addPetWithError = ast.factory.createOperation({
+  operationId: 'addPet',
+  method: 'POST',
+  path: '/pet',
+  tags: ['pet'],
+  responses: [
+    ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' }),
+    ast.factory.createResponse({ statusCode: '422', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'err' }),
+  ],
+})
+
 describe('buildParserHooks', () => {
   test('emits no parsers when the parser is off', () => {
     expect(buildParserHooks({ node: addPet, parser: false, zodResolver: resolverZod })).toStrictEqual({
       request: null,
       response: null,
+      error: null,
       importedZodNames: [],
     })
   })
 
-  test("the 'zod' shorthand wires the response parser only", () => {
+  test("the 'zod' shorthand wires the response parser only when there is no error response", () => {
     const hooks = buildParserHooks({ node: addPet, parser: 'zod', zodResolver: resolverZod })
     expect(hooks.request).toBeNull()
     expect(hooks.response).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
+    expect(hooks.error).toBeNull()
     expect(hooks.importedZodNames).toStrictEqual(['addPetResponseSchema'])
+  })
+
+  test("the 'zod' shorthand also wires the error parser when an error response is documented", () => {
+    const hooks = buildParserHooks({ node: addPetWithError, parser: 'zod', zodResolver: resolverZod })
+    expect(hooks.response).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
+    expect(hooks.error).toBe('(data: unknown) => addPetErrorSchema.parse(data)')
+    expect(hooks.importedZodNames).toStrictEqual(['addPetResponseSchema', 'addPetErrorSchema'])
   })
 
   test('the object form wires the request parser from the data schema', () => {
     const hooks = buildParserHooks({ node: addPet, parser: { request: 'zod' }, zodResolver: resolverZod })
     expect(hooks.request).toBe('(data: unknown) => addPetDataSchema.parse(data)')
     expect(hooks.response).toBeNull()
+    expect(hooks.error).toBeNull()
     expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema'])
   })
 
@@ -41,6 +62,7 @@ describe('buildParserHooks', () => {
     const hooks = buildParserHooks({ node: addPet, parser: { request: 'zod', response: 'zod' }, zodResolver: resolverZod })
     expect(hooks.request).toBe('(data: unknown) => addPetDataSchema.parse(data)')
     expect(hooks.response).toBe('(data: unknown) => addPetResponseSchema.parse(data)')
+    expect(hooks.error).toBeNull()
     expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema', 'addPetResponseSchema'])
   })
 })

--- a/internals/client/src/builders/validator.ts
+++ b/internals/client/src/builders/validator.ts
@@ -1,7 +1,7 @@
 import type { ast } from '@kubb/core'
 import type { ResolverZod } from '@kubb/plugin-zod'
 import type { ParserOptions } from '../types.ts'
-import { buildZodResponseParse, resolveRequestParser, resolveResponseParser } from './parser.ts'
+import { buildZodErrorParse, buildZodResponseParse, resolveRequestParser, resolveResponseParser } from './parser.ts'
 
 /**
  * The per-call parser expressions a generated function wires into its request config. Both run
@@ -17,6 +17,12 @@ export type ParserHooks = {
    * Expression for the `parser.response` hook, or `null` when response parsing is off.
    */
   response: string | null
+  /**
+   * Expression for the `parser.error` hook, or `null` when error parsing is off or the operation
+   * documents no error responses. The runtime runs this on the error body when a non-2xx call does
+   * not throw.
+   */
+  error: string | null
   /**
    * Zod schema names the generated file imports from the zod plugin output.
    */
@@ -48,5 +54,9 @@ export function buildParserHooks({
   const response = responseParse ? `(data: unknown) => ${responseParse.expression}.parse(data)` : null
   if (responseParse) importedZodNames.push(...responseParse.importNames)
 
-  return { request, response, importedZodNames }
+  const errorParse = zodResolver && resolveResponseParser(parser) === 'zod' ? buildZodErrorParse(node, zodResolver) : null
+  const error = errorParse ? `(data: unknown) => ${errorParse.expression}.parse(data)` : null
+  if (errorParse) importedZodNames.push(...errorParse.importNames)
+
+  return { request, response, error, importedZodNames }
 }

--- a/internals/client/src/components/Operation.tsx
+++ b/internals/client/src/components/Operation.tsx
@@ -52,7 +52,11 @@ export function Operation({ name, node, tsResolver, zodResolver, parser, securit
   const parsers = buildParserHooks({ node, parser, zodResolver })
   const securityLiteral = buildSecurityMetadata({ security })
 
-  const parserEntries = [parsers.request ? `request: ${parsers.request}` : null, parsers.response ? `response: ${parsers.response}` : null].filter(Boolean)
+  const parserEntries = [
+    parsers.request ? `request: ${parsers.request}` : null,
+    parsers.response ? `response: ${parsers.response}` : null,
+    parsers.error ? `error: ${parsers.error}` : null,
+  ].filter(Boolean)
   const parserLiteral = parserEntries.length ? `parser: { ${parserEntries.join(', ')} }` : null
 
   const callConfig = `{ ${[

--- a/internals/client/src/generators/sdkGenerator.tsx
+++ b/internals/client/src/generators/sdkGenerator.tsx
@@ -8,7 +8,7 @@ import { pluginTsName } from '@kubb/plugin-ts'
 import type { ResolverZod } from '@kubb/plugin-zod'
 import { pluginZodName } from '@kubb/plugin-zod'
 import { File, jsxRenderer } from '@kubb/renderer-jsx'
-import { isParserEnabled, resolveQueryParamsParser, resolveRequestParser, resolveResponseParser } from '../builders/parser.ts'
+import { buildZodErrorParse, isParserEnabled, resolveQueryParamsParser, resolveRequestParser, resolveResponseParser } from '../builders/parser.ts'
 import { type Auth, getOperationSecurity, type SecurityDocument } from '../builders/security.ts'
 import { SdkClient } from '../components/SdkClient.tsx'
 import { SdkFacade } from '../components/SdkFacade.tsx'
@@ -48,6 +48,7 @@ function resolveZodImportNames(node: ast.OperationNode, zodResolver: ResolverZod
   const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'original' })
   const names: Array<string | null | undefined> = [
     resolveResponseParser(parser) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
+    resolveResponseParser(parser) === 'zod' ? (buildZodErrorParse(node, zodResolver)?.expression ?? null) : null,
     resolveRequestParser(parser) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveDataName?.(node) : null,
     resolveQueryParamsParser(parser) === 'zod' && queryParams.length > 0 ? zodResolver.resolveQueryParamsName?.(node, queryParams[0]!) : null,
   ]

--- a/internals/client/src/index.ts
+++ b/internals/client/src/index.ts
@@ -1,5 +1,5 @@
 export { buildSdkMethod } from './builders/sdkMethod.ts'
-export { isParserEnabled, resolveQueryParamsParser, resolveRequestParser, resolveResponseParser } from './builders/parser.ts'
+export { buildZodErrorParse, isParserEnabled, resolveQueryParamsParser, resolveRequestParser, resolveResponseParser } from './builders/parser.ts'
 export { buildReturnStatement } from './builders/returnStatement.ts'
 export { buildSecurityMetadata, getOperationSecurity, resolveSecurityScheme } from './builders/security.ts'
 export type { Auth, SecurityDocument } from './builders/security.ts'

--- a/internals/client/src/types.ts
+++ b/internals/client/src/types.ts
@@ -3,9 +3,11 @@ import type { ast, Exclude, Group, Include, Output, OutputOptions, Override, Plu
 /**
  * Validator applied to request and response bodies using schemas from `@kubb/plugin-zod`.
  * - `false`: no validation.
- * - `'zod'`: validates success (2xx) response bodies only.
+ * - `'zod'`: validates the success (2xx) response body, and the error body when a non-2xx call does
+ *   not throw (`throwOnError: false`).
  * - `{ request?: 'zod'; response?: 'zod' }`: opt in per direction. `request` validates the request
- *   body and query parameters before the call; `response` validates the success response body.
+ *   body and query parameters before the call; `response` validates the success response body and,
+ *   on the non-throw path, the error body.
  */
 export type ParserOptions = false | 'zod' | { request?: 'zod'; response?: 'zod' }
 

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -13,6 +13,8 @@ export {
   getRequestGroups,
   getResponseType,
   getSuccessResponses,
+  isErrorStatusCode,
+  isSuccessStatusCode,
   operationFileEntry,
   resolveContentTypeVariants,
   resolveErrorNames,

--- a/packages/plugin-axios/src/generators/clientGenerator.tsx
+++ b/packages/plugin-axios/src/generators/clientGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { getOperationSecurity, Operation, resolveRequestParser, resolveResponseParser, type SecurityDocument } from '@internals/client'
+import { buildZodErrorParse, getOperationSecurity, Operation, resolveRequestParser, resolveResponseParser, type SecurityDocument } from '@internals/client'
 import { operationFileEntry } from '@internals/shared'
 import { ast, defineGenerator } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
@@ -36,6 +36,7 @@ export const clientGenerator = defineGenerator<PluginAxios>({
     const importedZodNames = zodResolver
       ? [
           resolveResponseParser(parser) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
+          resolveResponseParser(parser) === 'zod' ? (buildZodErrorParse(node, zodResolver)?.expression ?? null) : null,
           resolveRequestParser(parser) === 'zod' && hasRequestBody ? zodResolver.resolveDataName?.(node) : null,
         ].filter((name): name is string => Boolean(name))
       : []

--- a/packages/plugin-axios/templates/axios.test.ts
+++ b/packages/plugin-axios/templates/axios.test.ts
@@ -186,6 +186,23 @@ describe('createClientCore', () => {
     expect(response).not.toHaveBeenCalled()
   })
 
+  test('runs the error parser on a non-2xx body when throwOnError is false', async () => {
+    const { instance } = fakeAxios({ data: { message: 'invalid' }, status: 405 })
+    const client = createClientCore({ transport: instance })
+    const error = vi.fn(() => ({ parsed: true }))
+    const result = (await client({ method: 'POST', url: '/pet', throwOnError: false, parser: { error } })) as CallResult
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(result.error).toStrictEqual({ parsed: true })
+  })
+
+  test('skips the error parser on a success body', async () => {
+    const { instance } = fakeAxios({ data: { id: 1 }, status: 200 })
+    const client = createClientCore({ transport: instance })
+    const error = vi.fn((value: unknown) => value)
+    await client({ method: 'GET', url: '/pet/1', throwOnError: false, parser: { error } })
+    expect(error).not.toHaveBeenCalled()
+  })
+
   test('delegates interceptors to the native axios managers', () => {
     const { instance, requestUse, responseUse } = fakeAxios()
     const client = createClientCore({ transport: instance })

--- a/packages/plugin-axios/templates/axios.ts
+++ b/packages/plugin-axios/templates/axios.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/packages/plugin-fetch/src/generators/clientGenerator.tsx
+++ b/packages/plugin-fetch/src/generators/clientGenerator.tsx
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { getOperationSecurity, Operation, resolveRequestParser, resolveResponseParser, type SecurityDocument } from '@internals/client'
+import { buildZodErrorParse, getOperationSecurity, Operation, resolveRequestParser, resolveResponseParser, type SecurityDocument } from '@internals/client'
 import { operationFileEntry } from '@internals/shared'
 import { ast, defineGenerator } from '@kubb/core'
 import { pluginTsName } from '@kubb/plugin-ts'
@@ -36,6 +36,7 @@ export const clientGenerator = defineGenerator<PluginFetch>({
     const importedZodNames = zodResolver
       ? [
           resolveResponseParser(parser) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
+          resolveResponseParser(parser) === 'zod' ? (buildZodErrorParse(node, zodResolver)?.expression ?? null) : null,
           resolveRequestParser(parser) === 'zod' && hasRequestBody ? zodResolver.resolveDataName?.(node) : null,
         ].filter((name): name is string => Boolean(name))
       : []

--- a/packages/plugin-fetch/templates/fetch.test.ts
+++ b/packages/plugin-fetch/templates/fetch.test.ts
@@ -149,6 +149,21 @@ describe('createClientCore', () => {
     expect(response).not.toHaveBeenCalled()
   })
 
+  test('runs the error parser on a non-2xx body when throwOnError is false', async () => {
+    const { client } = createClient({ data: { message: 'invalid' }, status: 405 })
+    const error = vi.fn(() => ({ parsed: true }))
+    const result = (await client({ method: 'POST', url: '/pet', throwOnError: false, parser: { error } })) as CallResult<string, string>
+    expect(error).toHaveBeenCalledTimes(1)
+    expect(result).toStrictEqual({ status: 405, data: undefined, error: { parsed: true }, request: 'REQ', response: 'RES' })
+  })
+
+  test('skips the error parser on a success body', async () => {
+    const { client } = createClient({ data: { id: 1 }, status: 200 })
+    const error = vi.fn((value: unknown) => value)
+    await client({ method: 'GET', url: '/pet/1', throwOnError: false, parser: { error } })
+    expect(error).not.toHaveBeenCalled()
+  })
+
   test('runs request and response interceptors', async () => {
     const { client, calls } = createClient()
     client.interceptors.request.use((request) => ({ ...request, headers: { ...request.headers, 'X-Trace': '1' } }))

--- a/packages/plugin-fetch/templates/fetch.ts
+++ b/packages/plugin-fetch/templates/fetch.ts
@@ -84,7 +84,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => BodyInit |
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -133,7 +134,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   transport?: Transport<TRequest, TResponse>
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -486,11 +487,12 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     }
 
     const data = isSuccess ? await runParser(requestConfig.parser?.response, result.data) : undefined
+    const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, result.data)
 
     return {
       status: result.status,
       data,
-      error: isSuccess ? undefined : result.data,
+      error,
       request: result.request,
       response: result.response,
     }

--- a/packages/plugin-zod/src/generators/__snapshots__/addPetPOSTWithRequestBody/addPetSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/addPetPOSTWithRequestBody/addPetSchema.ts
@@ -11,4 +11,6 @@ export const addPetStatus405Schema = z.object({})
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchema = z.object({})

--- a/packages/plugin-zod/src/generators/__snapshots__/listPetsGETWithQueryParams/listPetsSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/listPetsGETWithQueryParams/listPetsSchema.ts
@@ -12,3 +12,5 @@ export const listPetsStatus200Schema = z.object({})
 export const listPetsStatusDefaultSchema = z.object({})
 
 export const listPetsResponseSchema = listPetsStatus200Schema
+
+export const listPetsErrorSchema = listPetsStatusDefaultSchema

--- a/packages/plugin-zod/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/placeOrderPatchSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/placeOrderPatchSchema.ts
@@ -13,4 +13,6 @@ export const placeOrderPatchStatus405Schema = z.object({})
 
 export const placeOrderPatchResponseSchema = placeOrderPatchStatus200Schema
 
+export const placeOrderPatchErrorSchema = placeOrderPatchStatus405Schema
+
 export const placeOrderPatchDataSchema = z.object({}).describe('Order payload')

--- a/packages/plugin-zod/src/generators/__snapshots__/showPetByIdGETWithPathParam/showPetByIdSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/showPetByIdGETWithPathParam/showPetByIdSchema.ts
@@ -12,3 +12,5 @@ export const showPetByIdStatus200Schema = z.object({})
 export const showPetByIdStatusDefaultSchema = z.object({})
 
 export const showPetByIdResponseSchema = showPetByIdStatus200Schema
+
+export const showPetByIdErrorSchema = showPetByIdStatusDefaultSchema

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -1,4 +1,4 @@
-import { caseParams, getSuccessResponses, resolveContentTypeVariants } from '@internals/shared'
+import { caseParams, getSuccessResponses, isSuccessStatusCode, resolveContentTypeVariants } from '@internals/shared'
 import type { Adapter } from '@kubb/core'
 import { ast, defineGenerator } from '@kubb/core'
 import type { AdapterOas } from '@kubb/adapter-oas'
@@ -298,6 +298,46 @@ export const zodGenerator = defineGenerator<PluginZod>({
           })()
         : null
 
+    // Validate error bodies on the non-throw path. Mirrors the success union but selects every
+    // non-2xx response (including the OpenAPI `default`) so it lines up with plugin-ts `ErrorOf` (#369).
+    const errorResponsesWithSchema = responsesWithSchema.filter((res) => !isSuccessStatusCode(res.statusCode))
+    const errorUnionSchema =
+      errorResponsesWithSchema.length > 0
+        ? (() => {
+            const errorUnionName = resolver.resolveErrorName(node)
+
+            const importedNames = new Set(
+              errorResponsesWithSchema.flatMap((res) =>
+                (res.content ?? []).flatMap((entry) =>
+                  entry.schema
+                    ? adapter
+                        .getImports(entry.schema, (schemaName) => ({
+                          name: resolver.resolveSchemaName(schemaName),
+                          path: '',
+                        }))
+                        .flatMap((imp) => (Array.isArray(imp.name) ? imp.name : [imp.name]))
+                    : [],
+                ),
+              ),
+            )
+
+            if (importedNames.has(errorUnionName)) {
+              return null
+            }
+
+            const members = errorResponsesWithSchema.map((res) =>
+              ast.factory.createSchema({ type: 'ref', name: resolver.resolveResponseStatusName(node, res.statusCode) }),
+            )
+
+            const unionNode = members.length === 1 ? members[0]! : ast.factory.createSchema({ type: 'union', members })
+
+            return renderSchemaEntry({
+              schema: unionNode,
+              name: errorUnionName,
+            })
+          })()
+        : null
+
     const requestBodyContent = node.requestBody?.content ?? []
     const requestSchema = (() => {
       if (requestBodyContent.length === 0) return null
@@ -334,6 +374,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
         {paramSchemas}
         {responseSchemas}
         {responseUnionSchema}
+        {errorUnionSchema}
         {requestSchema}
       </File>
     )

--- a/packages/plugin-zod/src/resolvers/resolverZod.ts
+++ b/packages/plugin-zod/src/resolvers/resolverZod.ts
@@ -58,6 +58,9 @@ export const resolverZod = defineResolver<PluginZod>(() => {
     resolveResponseName(node) {
       return this.resolveSchemaName(`${node.operationId} Response`)
     },
+    resolveErrorName(node) {
+      return this.resolveSchemaName(`${node.operationId} Error`)
+    },
     resolvePathParamsName(node, param) {
       return this.resolveParamName(node, param)
     },

--- a/packages/plugin-zod/src/types.ts
+++ b/packages/plugin-zod/src/types.ts
@@ -67,6 +67,14 @@ export type ResolverZod = Resolver &
      */
     resolveResponseName(this: ResolverZod, node: ast.OperationNode): string
     /**
+     * Resolves the name for the union of an operation's error (non-2xx) responses. Generated clients
+     * validate the error body against this on the non-throw path.
+     *
+     * @example Error union names
+     * `resolver.resolveErrorName(node) // → 'listPetsErrorSchema'`
+     */
+    resolveErrorName(this: ResolverZod, node: ast.OperationNode): string
+    /**
      * Resolves the name for an operation's grouped path parameters type.
      *
      * @example Path parameters names

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/client.ts
@@ -84,7 +84,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => BodyInit |
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -133,7 +134,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   transport?: Transport<TRequest, TResponse>
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -486,11 +487,12 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     }
 
     const data = isSuccess ? await runParser(requestConfig.parser?.response, result.data) : undefined
+    const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, result.data)
 
     return {
       status: result.status,
       data,
-      error: isSuccess ? undefined : result.data,
+      error,
       request: result.request,
       response: result.response,
     }

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/client.ts
@@ -84,7 +84,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => BodyInit |
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -133,7 +134,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   transport?: Transport<TRequest, TResponse>
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -486,11 +487,12 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     }
 
     const data = isSuccess ? await runParser(requestConfig.parser?.response, result.data) : undefined
+    const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, result.data)
 
     return {
       status: result.status,
       data,
-      error: isSuccess ? undefined : result.data,
+      error,
       request: result.request,
       response: result.response,
     }

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/client.ts
@@ -84,7 +84,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => BodyInit |
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -133,7 +134,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   transport?: Transport<TRequest, TResponse>
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -486,11 +487,12 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     }
 
     const data = isSuccess ? await runParser(requestConfig.parser?.response, result.data) : undefined
+    const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, result.data)
 
     return {
       status: result.status,
       data,
-      error: isSuccess ? undefined : result.data,
+      error,
       request: result.request,
       response: result.response,
     }

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/client.ts
@@ -84,7 +84,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => BodyInit |
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -133,7 +134,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   transport?: Transport<TRequest, TResponse>
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -486,11 +487,12 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     }
 
     const data = isSuccess ? await runParser(requestConfig.parser?.response, result.data) : undefined
+    const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, result.data)
 
     return {
       status: result.status,
       data,
-      error: isSuccess ? undefined : result.data,
+      error,
       request: result.request,
       response: result.response,
     }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/client.ts
@@ -86,7 +86,8 @@ export type BodySerializer = (body: unknown, contentType?: string) => unknown
 
 /**
  * Parses a value before it is sent or after it is received, returning the parsed (and optionally
- * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` hooks.
+ * transformed) value. Wires zod parsing through the per-call `parser.request` / `parser.response` /
+ * `parser.error` hooks (`error` runs on the error body when a non-2xx call does not throw).
  */
 export type Parser<T = unknown> = (value: T) => T | Promise<T>
 
@@ -136,7 +137,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   transport?: AxiosInstance
   querySerializer?: QuerySerializer
   bodySerializer?: BodySerializer
-  parser?: { request?: Parser; response?: Parser }
+  parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
   auth?: AuthResolver
 }
@@ -466,10 +467,11 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const response = await activeInstance.request<unknown, AxiosResponse>(axiosConfig)
       const isSuccess = response.status >= 200 && response.status < 300
       const data = isSuccess ? await runParser(requestConfig.parser?.response, response.data) : undefined
+      const error = isSuccess ? undefined : await runParser(requestConfig.parser?.error, response.data)
       return {
         status: response.status,
         data,
-        error: isSuccess ? undefined : response.data,
+        error,
         request: response.config as TRequest,
         response: response as TResponse,
       }

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.coerce.bigint().describe('Pet id to de
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderInputSchema.optional()
 
 export const placeOrderDataSchemaXml = orderInputSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/store/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/store/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/addPetSchema.ts
@@ -27,6 +27,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export type AddPetResponseSchemaType = z.infer<typeof addPetResponseSchema>
 
+export const addPetErrorSchema = addPetStatus405Schema
+
+export type AddPetErrorSchemaType = z.infer<typeof addPetErrorSchema>
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export type AddPetDataSchemaJsonType = z.infer<typeof addPetDataSchemaJson>

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/deletePetSchema.ts
@@ -20,3 +20,7 @@ export type DeletePetStatus400SchemaType = z.infer<typeof deletePetStatus400Sche
 export const deletePetResponseSchema = z.unknown()
 
 export type DeletePetResponseSchemaType = z.infer<typeof deletePetResponseSchema>
+
+export const deletePetErrorSchema = deletePetStatus400Schema
+
+export type DeletePetErrorSchemaType = z.infer<typeof deletePetErrorSchema>

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/findPetsByStatusSchema.ts
@@ -30,3 +30,7 @@ export type FindPetsByStatusStatus400SchemaType = z.infer<typeof findPetsByStatu
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
 
 export type FindPetsByStatusResponseSchemaType = z.infer<typeof findPetsByStatusResponseSchema>
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema
+
+export type FindPetsByStatusErrorSchemaType = z.infer<typeof findPetsByStatusErrorSchema>

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/getPetByIdSchema.ts
@@ -33,3 +33,7 @@ export type GetPetByIdStatus404SchemaType = z.infer<typeof getPetByIdStatus404Sc
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
 
 export type GetPetByIdResponseSchemaType = z.infer<typeof getPetByIdResponseSchema>
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])
+
+export type GetPetByIdErrorSchemaType = z.infer<typeof getPetByIdErrorSchema>

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/placeOrderSchema.ts
@@ -18,6 +18,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export type PlaceOrderResponseSchemaType = z.infer<typeof placeOrderResponseSchema>
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
+export type PlaceOrderErrorSchemaType = z.infer<typeof placeOrderErrorSchema>
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export type PlaceOrderDataSchemaJsonType = z.infer<typeof placeOrderDataSchemaJson>

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/addPetSchema.ts
@@ -17,6 +17,8 @@ export const addPetStatus405Schema = z.any()
 
 export const addPetResponseSchema = addPetStatus200Schema
 
+export const addPetErrorSchema = addPetStatus405Schema
+
 export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
 export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/deletePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/deletePetSchema.ts
@@ -12,3 +12,5 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 export const deletePetStatus400Schema = z.any()
 
 export const deletePetResponseSchema = z.unknown()
+
+export const deletePetErrorSchema = deletePetStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/findPetsByStatusSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/findPetsByStatusSchema.ts
@@ -18,3 +18,5 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 export const findPetsByStatusStatus400Schema = z.any()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
+
+export const findPetsByStatusErrorSchema = findPetsByStatusStatus400Schema

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/getPetByIdSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/getPetByIdSchema.ts
@@ -19,3 +19,5 @@ export const getPetByIdStatus400Schema = z.any()
 export const getPetByIdStatus404Schema = z.any()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
+
+export const getPetByIdErrorSchema = z.union([getPetByIdStatus400Schema, getPetByIdStatus404Schema])

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/placeOrderSchema.ts
@@ -12,6 +12,8 @@ export const placeOrderStatus405Schema = z.any()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
+export const placeOrderErrorSchema = placeOrderStatus405Schema
+
 export const placeOrderDataSchemaJson = orderSchema.optional()
 
 export const placeOrderDataSchemaXml = orderSchema.optional()


### PR DESCRIPTION
## Context

Follow-up to #369. That issue was fixed so `<operation>ResponseSchema` is success-only and only 2xx bodies are zod-parsed. The [follow-up comment](https://github.com/kubb-labs/plugins/issues/369#issuecomment-4789629729) points out the remaining gap: when a call resolves with a non-2xx status **and** `throwOnError: false`, the client assigns the **raw, unparsed** body to `error`, and the generated per-status error schemas are never used.

This PR parses the error body against a zod union of the error-status schemas on the non-throw path, so `result.error` has a known, validated shape — mirroring success parsing.

## What changed

- **plugin-zod**: emits a new error-only `<operation>ErrorSchema` (single error → that schema; multiple → `z.union([...])`) for every operation that documents a non-2xx response with a schema. Adds a `resolveErrorName` resolver. The success path is unchanged.
- **@internals/client**: the `parser: 'zod'` shorthand (and the object form's `response: 'zod'`) now also wires an `error` parser hook into the generated call config. Gated on the operation actually having a typed error response.
- **plugin-fetch / plugin-axios**: the runtime runs the error parser on the error body **only** when a non-2xx call does not throw. The default `throwOnError: true` path still throws a raw `ResponseError`.

## Before / after (the issue's `getStatus` example)

```ts
// schema file — AFTER adds the error union (success schema unchanged)
export const getStatusResponseSchema = getStatusStatus200Schema   // success-only
export const getStatusErrorSchema    = getStatusStatus422Schema   // NEW

// fetcher — AFTER wires an error hook alongside response
parser: {
  response: (data: unknown) => getStatusResponseSchema.parse(data),
  error:    (data: unknown) => getStatusErrorSchema.parse(data),
}

// consumer (throwOnError: false)
const { error } = await getStatus({ throwOnError: false })
// BEFORE: raw, unvalidated body   AFTER: parsed { detail: string }
```

## Behavioral note

Small behavioral change for existing `parser: 'zod'` users: error bodies on non-throw calls are now validated and can surface a `ZodError` if the server's error response does not match the spec. Hence the **minor** bump (changeset included).

## Tests

- `buildParserHooks` unit test covers the new error hook with the real zod resolver
- plugin-zod generator snapshot (`placeOrderPatch`) covers `<operation>ErrorSchema` emission
- new `fetch.ts` / `axios.ts` runtime tests assert the error parser runs on the non-throw path and is skipped on success
- full suite green: 972 tests, `pnpm typecheck` and `pnpm lint` clean

> Docs: the `parser` option description on the kubb.dev plugin pages (in `kubb-labs/docs`) should be updated to note error bodies are validated on the non-throw path — tracked separately from this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FgWdBxX3VwYJZL5WZb2EdX)_