### PR TITLE
feat(plugin-ts): render enum member descriptions as JSDoc

### DIFF
--- a/.changeset/enum-member-descriptions.md
+++ b/.changeset/enum-member-descriptions.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-ts': minor
+---
+
+Render enum member descriptions as per-member JSDoc.
+
+When the adapter supplies `namedEnumValues` with a `description` (sourced from the `x-enumDescriptions` / `x-enum-descriptions` vendor extensions), the generated `enum`, `const enum`, and `as const` declarations now attach that text as a JSDoc comment on each member, so per-value documentation from the spec carries through to the output.

--- a/.changeset/enum-member-descriptions.md
+++ b/.changeset/enum-member-descriptions.md
@@ -4,4 +4,4 @@
 
 Render enum member descriptions as per-member JSDoc.
 
-When the adapter supplies `namedEnumValues` with a `description` (sourced from the `x-enumDescriptions` / `x-enum-descriptions` vendor extensions), the generated `enum`, `const enum`, and `as const` declarations now attach that text as a JSDoc comment on each member, so per-value documentation from the spec carries through to the output.
+Enum schemas can document each value through the `x-enumDescriptions` / `x-enum-descriptions` vendor extensions. When `adapter-oas` supplies those labels on `namedEnumValues`, the generated `enum`, `const enum`, and `as const` declarations now carry each one as JSDoc on the matching member, so the per-value docs from the spec end up in the generated code. Members without a description are left untouched.

--- a/packages/plugin-ts/src/components/Enum.tsx
+++ b/packages/plugin-ts/src/components/Enum.tsx
@@ -10,6 +10,12 @@ import type { PluginTs, ResolverTs } from '../types.ts'
 
 type EnumOptions = PluginTs['resolvedOptions']['enum']
 
+/**
+ * A single `namedEnumValues` entry, widened with the optional per-member `description`
+ * sourced from the `x-enumDescriptions` / `x-enum-descriptions` vendor extension.
+ */
+type NamedEnumValue = NonNullable<ast.EnumSchemaNode['namedEnumValues']>[number] & { description?: string }
+
 type Props = {
   node: ast.EnumSchemaNode
   enum: EnumOptions
@@ -55,9 +61,9 @@ export function Enum({ node, enum: enumOptions, resolver }: Props): KubbReactNod
   const [nameNode, typeNode] = factory.createEnumDeclaration({
     name: enumName,
     typeName,
-    enums: (node.namedEnumValues?.map((v) => [trimQuotes(v.name.toString()), v.value]) ??
+    enums: ((node.namedEnumValues as Array<NamedEnumValue> | undefined)?.map((v) => [trimQuotes(v.name.toString()), v.value, v.description]) ??
       node.enumValues?.filter((v): v is NonNullable<typeof v> => v !== null && v !== undefined).map((v) => [trimQuotes(v.toString()), v]) ??
-      []) as Array<[string | number, string | number | boolean]>,
+      []) as Array<[string | number, string | number | boolean, string?]>,
     type: enumOptions.type,
     enumKeyCasing: enumOptions.keyCasing,
   })

--- a/packages/plugin-ts/src/components/Enum.tsx
+++ b/packages/plugin-ts/src/components/Enum.tsx
@@ -11,8 +11,9 @@ import type { PluginTs, ResolverTs } from '../types.ts'
 type EnumOptions = PluginTs['resolvedOptions']['enum']
 
 /**
- * A single `namedEnumValues` entry, widened with the optional per-member `description`
- * sourced from the `x-enumDescriptions` / `x-enum-descriptions` vendor extension.
+ * Widens a `namedEnumValues` entry with the optional per-member `description` that the
+ * `x-enumDescriptions` / `x-enum-descriptions` vendor extensions provide. The intersection
+ * keeps the field readable against published `@kubb/ast` versions that predate it.
  */
 type NamedEnumValue = NonNullable<ast.EnumSchemaNode['namedEnumValues']>[number] & { description?: string }
 

--- a/packages/plugin-ts/src/factory.test.ts
+++ b/packages/plugin-ts/src/factory.test.ts
@@ -473,6 +473,42 @@ describe('Code Generation', () => {
     expect(output).not.toMatch(/[\n{]\s*#0099ff:/)
     expect(output).not.toMatch(/[\n{]\s*#ccff9a:/)
   })
+
+  it('renders per-member descriptions as JSDoc on enum members', async () => {
+    const output = await formatTS(
+      createEnumDeclaration({
+        type: 'enum',
+        name: 'status',
+        typeName: 'Status',
+        enums: [
+          ['active', 'active', 'The resource is active'],
+          ['archived', 'archived', 'The resource is archived'],
+        ],
+      }),
+    )
+
+    expect(output).toContain('The resource is active')
+    expect(output).toContain('The resource is archived')
+    expect(output).toMatch(/\/\*\*[\s\S]*The resource is active[\s\S]*\*\/\s*active = 'active'/)
+  })
+
+  it('renders per-member descriptions as JSDoc on asConst members', async () => {
+    const output = await formatTS(
+      createEnumDeclaration({
+        type: 'asConst',
+        name: 'status',
+        typeName: 'StatusKey',
+        enums: [
+          ['active', 'active', 'The resource is active'],
+          ['archived', 'archived'],
+        ],
+      }),
+    )
+
+    expect(output).toMatch(/\/\*\*[\s\S]*The resource is active[\s\S]*\*\/\s*active: 'active'/)
+    // members without a description stay un-annotated
+    expect(output).not.toMatch(/\*\/\s*archived: 'archived'/)
+  })
 })
 
 describe('Import/Export Sorting Consistency', () => {

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -505,7 +505,7 @@ function applyEnumKeyCasing(key: string, casing: 'screamingSnakeCase' | 'snakeCa
  *   type: 'enum',
  *   name: 'petType',
  *   typeName: 'PetType',
- *   enums: [['cat', 'cat'], ['dog', 'dog']],
+ *   enums: [['cat', 'cat', 'A cat'], ['dog', 'dog']],
  * })
  * ```
  */
@@ -533,7 +533,7 @@ export function createEnumDeclaration({
    * Enum name in PascalCase.
    */
   typeName: string
-  enums: Array<[key: string | number, value: string | number | boolean]>
+  enums: Array<[key: string | number, value: string | number | boolean, description?: string]>
   /**
    * Choose the casing for enum key names.
    * @default 'none'
@@ -583,7 +583,7 @@ export function createEnumDeclaration({
         ),
         factory.createIdentifier(typeName),
         enums
-          .map(([key, value]) => {
+          .map(([key, value, description]) => {
             let initializer: ts.Expression = factory.createStringLiteral(value?.toString())
             const isExactNumber = Number.parseInt(value.toString(), 10) === value
 
@@ -601,12 +601,12 @@ export function createEnumDeclaration({
 
             if (isNumber(Number.parseInt(key.toString(), 10))) {
               const casingKey = applyEnumKeyCasing(`${typeName}_${key}`, enumKeyCasing)
-              return factory.createEnumMember(propertyName(casingKey), initializer)
+              return appendJSDocToNode({ node: factory.createEnumMember(propertyName(casingKey), initializer), comments: [description] })
             }
 
             if (key !== null && key !== undefined) {
               const casingKey = applyEnumKeyCasing(key.toString(), enumKeyCasing)
-              return factory.createEnumMember(propertyName(casingKey), initializer)
+              return appendJSDocToNode({ node: factory.createEnumMember(propertyName(casingKey), initializer), comments: [description] })
             }
 
             return undefined
@@ -648,7 +648,7 @@ export function createEnumDeclaration({
             factory.createAsExpression(
               factory.createObjectLiteralExpression(
                 enums
-                  .map(([key, value]) => {
+                  .map(([key, value, description]) => {
                     let initializer: ts.Expression = factory.createStringLiteral(value?.toString())
 
                     if (isNumber(value)) {
@@ -669,7 +669,7 @@ export function createEnumDeclaration({
 
                     if (key !== null && key !== undefined) {
                       const casingKey = applyEnumKeyCasing(key.toString(), enumKeyCasing)
-                      return factory.createPropertyAssignment(propertyName(casingKey), initializer)
+                      return appendJSDocToNode({ node: factory.createPropertyAssignment(propertyName(casingKey), initializer), comments: [description] })
                     }
 
                     return undefined


### PR DESCRIPTION
## Summary

`plugin-ts` rendered named enum members through `node.namedEnumValues` but never surfaced per-member documentation, so labels from the `x-enumDescriptions` / `x-enum-descriptions` vendor extensions were lost.

This attaches each member's `description` (now carried on `namedEnumValues` by `@kubb/adapter-oas` — see the companion PR in `kubb-labs/kubb`) as JSDoc on the generated declarations:

- `createEnumDeclaration` accepts an optional third tuple element (`[key, value, description?]`) and appends JSDoc to each member in the `enum`, `const enum`, and `as const` forms.
- The `Enum` component threads `v.description` through from `namedEnumValues`.

Members without a description stay un-annotated, so existing output is unchanged.

## Compatibility

The `description` access is widened locally (`NamedEnumValue`) so `plugin-ts` compiles against the currently published `@kubb/ast` as well as the version that adds the field — when `@kubb/ast` lacks it at runtime, `description` is simply `undefined` and no JSDoc is emitted.

## Verification

- Added `factory` tests asserting JSDoc on `enum` and `as const` members (and that undescribed members stay clean).
- Full `@kubb/plugin-ts` suite (241 tests), typecheck, and lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnzP2N7CzC1rKYRgAXknAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnzP2N7CzC1rKYRgAXknAk)_