### PR TITLE
feat(fetch,axios): accept declarative query serializer options

### DIFF
--- a/.changeset/declarative-query-serialization.md
+++ b/.changeset/declarative-query-serialization.md
@@ -1,0 +1,18 @@
+---
+"@kubb/plugin-fetch": minor
+"@kubb/plugin-axios": minor
+---
+
+`querySerializer` now accepts declarative options as well as a function. Pass a `QuerySerializerOptions` object to pick an array or object style with `explode`, or keep reserved characters with `allowReserved`, and the runtime builds the serializer for you:
+
+```ts
+client.setConfig({
+  querySerializer: {
+    array: { style: 'pipeDelimited', explode: false },
+    object: { style: 'deepObject', explode: true },
+  },
+})
+```
+
+A new `createQuerySerializer(options)` export builds the same function directly, and the exported `QuerySerializerOptions` type covers the `form`/`spaceDelimited`/`pipeDelimited` array styles, the `form`/`deepObject` object styles, and `allowReserved`. The default stays the same: arrays explode into repeated keys and nested objects use the `deepObject` style. A function still works for full control.
+</content>

--- a/packages/plugin-axios/templates/axios.test.ts
+++ b/packages/plugin-axios/templates/axios.test.ts
@@ -1,6 +1,6 @@
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 import { describe, expect, test, vi } from 'vitest'
-import { type CallResult, createClientCore, defaultBodySerializer, defaultQuerySerializer, ResponseError, resolveAuth } from './axios.ts'
+import { type CallResult, createClientCore, createQuerySerializer, defaultBodySerializer, defaultQuerySerializer, ResponseError, resolveAuth } from './axios.ts'
 
 type Programmed = { data?: unknown; status?: number; statusText?: string }
 
@@ -52,6 +52,51 @@ describe('defaultQuerySerializer', () => {
 
   test('skips undefined and null members', () => {
     expect(defaultQuerySerializer({ a: 1, b: undefined, c: null })).toBe('a=1')
+  })
+})
+
+describe('createQuerySerializer', () => {
+  test('with no options matches the default serializer', () => {
+    const serializer = createQuerySerializer()
+    expect(serializer({ tags: ['a', 'b'], filter: { name: 'odie' } })).toBe('tags=a&tags=b&filter%5Bname%5D=odie')
+  })
+
+  test('joins arrays with a comma for form style without explode', () => {
+    const serializer = createQuerySerializer({ array: { style: 'form', explode: false } })
+    expect(serializer({ tags: ['a', 'b'] })).toBe('tags=a,b')
+  })
+
+  test('joins arrays with %20 for spaceDelimited style', () => {
+    const serializer = createQuerySerializer({ array: { style: 'spaceDelimited', explode: false } })
+    expect(serializer({ tags: ['a', 'b'] })).toBe('tags=a%20b')
+  })
+
+  test('joins arrays with a pipe for pipeDelimited style', () => {
+    const serializer = createQuerySerializer({ array: { style: 'pipeDelimited', explode: false } })
+    expect(serializer({ tags: ['a', 'b'] })).toBe('tags=a|b')
+  })
+
+  test('explodes objects into top-level keys for form style', () => {
+    const serializer = createQuerySerializer({ object: { style: 'form', explode: true } })
+    expect(serializer({ filter: { name: 'odie', age: 3 } })).toBe('name=odie&age=3')
+  })
+
+  test('joins object entries for form style without explode', () => {
+    const serializer = createQuerySerializer({ object: { style: 'form', explode: false } })
+    expect(serializer({ filter: { name: 'odie', age: 3 } })).toBe('filter=name,odie,age,3')
+  })
+
+  test('leaves reserved characters unencoded when allowReserved is set', () => {
+    const serializer = createQuerySerializer({ allowReserved: true })
+    expect(serializer({ path: '/pets/1' })).toBe('path=/pets/1')
+  })
+
+  test('encodes reserved characters by default', () => {
+    expect(defaultQuerySerializer({ path: '/pets/1' })).toBe('path=%2Fpets%2F1')
+  })
+
+  test('skips empty arrays', () => {
+    expect(defaultQuerySerializer({ tags: [], a: 1 })).toBe('a=1')
   })
 })
 
@@ -302,6 +347,14 @@ describe('getUrl', () => {
     const { instance } = fakeAxios()
     const client = createClientCore({ transport: instance })
     expect(client.getUrl({ url: '/pet', query: { a: 1 }, querySerializer: () => 'custom=1' })).toBe('/pet?custom=1')
+  })
+
+  test('builds a serializer from a querySerializer options object', () => {
+    const { instance } = fakeAxios()
+    const client = createClientCore({ transport: instance })
+    expect(client.getUrl({ url: '/pet', query: { tags: ['a', 'b'] }, querySerializer: { array: { style: 'pipeDelimited', explode: false } } })).toBe(
+      '/pet?tags=a|b',
+    )
   })
 })
 

--- a/packages/plugin-axios/templates/axios.ts
+++ b/packages/plugin-axios/templates/axios.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/packages/plugin-fetch/templates/fetch.test.ts
+++ b/packages/plugin-fetch/templates/fetch.test.ts
@@ -3,6 +3,7 @@ import {
   type CallResult,
   createClientCore,
   createInterceptorStack,
+  createQuerySerializer,
   defaultBodySerializer,
   defaultQuerySerializer,
   type ResolvedRequest,
@@ -72,6 +73,51 @@ describe('defaultQuerySerializer', () => {
 
   test('skips undefined and null members', () => {
     expect(defaultQuerySerializer({ a: 1, b: undefined, c: null })).toBe('a=1')
+  })
+})
+
+describe('createQuerySerializer', () => {
+  test('with no options matches the default serializer', () => {
+    const serializer = createQuerySerializer()
+    expect(serializer({ tags: ['a', 'b'], filter: { name: 'odie' } })).toBe('tags=a&tags=b&filter%5Bname%5D=odie')
+  })
+
+  test('joins arrays with a comma for form style without explode', () => {
+    const serializer = createQuerySerializer({ array: { style: 'form', explode: false } })
+    expect(serializer({ tags: ['a', 'b'] })).toBe('tags=a,b')
+  })
+
+  test('joins arrays with %20 for spaceDelimited style', () => {
+    const serializer = createQuerySerializer({ array: { style: 'spaceDelimited', explode: false } })
+    expect(serializer({ tags: ['a', 'b'] })).toBe('tags=a%20b')
+  })
+
+  test('joins arrays with a pipe for pipeDelimited style', () => {
+    const serializer = createQuerySerializer({ array: { style: 'pipeDelimited', explode: false } })
+    expect(serializer({ tags: ['a', 'b'] })).toBe('tags=a|b')
+  })
+
+  test('explodes objects into top-level keys for form style', () => {
+    const serializer = createQuerySerializer({ object: { style: 'form', explode: true } })
+    expect(serializer({ filter: { name: 'odie', age: 3 } })).toBe('name=odie&age=3')
+  })
+
+  test('joins object entries for form style without explode', () => {
+    const serializer = createQuerySerializer({ object: { style: 'form', explode: false } })
+    expect(serializer({ filter: { name: 'odie', age: 3 } })).toBe('filter=name,odie,age,3')
+  })
+
+  test('leaves reserved characters unencoded when allowReserved is set', () => {
+    const serializer = createQuerySerializer({ allowReserved: true })
+    expect(serializer({ path: '/pets/1' })).toBe('path=/pets/1')
+  })
+
+  test('encodes reserved characters by default', () => {
+    expect(defaultQuerySerializer({ path: '/pets/1' })).toBe('path=%2Fpets%2F1')
+  })
+
+  test('skips empty arrays', () => {
+    expect(defaultQuerySerializer({ tags: [], a: 1 })).toBe('a=1')
   })
 })
 
@@ -265,6 +311,13 @@ describe('getUrl', () => {
   test('uses a per-call querySerializer override', () => {
     const { client } = createClient()
     expect(client.getUrl({ url: '/pet', query: { a: 1 }, querySerializer: () => 'custom=1' })).toBe('/pet?custom=1')
+  })
+
+  test('builds a serializer from a querySerializer options object', () => {
+    const { client } = createClient()
+    expect(client.getUrl({ url: '/pet', query: { tags: ['a', 'b'] }, querySerializer: { array: { style: 'pipeDelimited', explode: false } } })).toBe(
+      '/pet?tags=a|b',
+    )
   })
 })
 

--- a/packages/plugin-fetch/templates/fetch.ts
+++ b/packages/plugin-fetch/templates/fetch.ts
@@ -77,6 +77,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -132,7 +148,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   throwOnError?: boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -162,7 +178,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   credentials?: RequestCredentials
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -314,31 +330,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -453,7 +518,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const transport = requestConfig.transport ?? config.transport ?? defaultTransport
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -527,7 +592,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/client.ts
@@ -77,6 +77,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -132,7 +148,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   throwOnError?: boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -162,7 +178,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   credentials?: RequestCredentials
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -314,31 +330,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -453,7 +518,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const transport = requestConfig.transport ?? config.transport ?? defaultTransport
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -527,7 +592,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/client.ts
@@ -77,6 +77,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -132,7 +148,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   throwOnError?: boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -162,7 +178,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   credentials?: RequestCredentials
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -314,31 +330,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -453,7 +518,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const transport = requestConfig.transport ?? config.transport ?? defaultTransport
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -527,7 +592,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/client.ts
@@ -77,6 +77,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -132,7 +148,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   throwOnError?: boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -162,7 +178,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   credentials?: RequestCredentials
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -314,31 +330,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -453,7 +518,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const transport = requestConfig.transport ?? config.transport ?? defaultTransport
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -527,7 +592,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/client.ts
@@ -77,6 +77,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -132,7 +148,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   throwOnError?: boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -162,7 +178,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   credentials?: RequestCredentials
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -314,31 +330,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -453,7 +518,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const transport = requestConfig.transport ?? config.transport ?? defaultTransport
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -527,7 +592,7 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/client.ts
@@ -79,6 +79,22 @@ export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text'
 export type QuerySerializer = (params: Record<string, unknown>) => string
 
 /**
+ * Declarative query serialization knobs that mirror the OpenAPI 3.x `style` / `explode` /
+ * `allowReserved` model. Pass these to `createQuerySerializer`, or set them directly on a
+ * `querySerializer` config field instead of writing a `QuerySerializer` by hand.
+ *
+ * @example
+ * ```ts
+ * { array: { style: 'pipeDelimited', explode: false } }
+ * ```
+ */
+export type QuerySerializerOptions = {
+  array?: { style: 'form' | 'spaceDelimited' | 'pipeDelimited'; explode: boolean }
+  object?: { style: 'form' | 'deepObject'; explode: boolean }
+  allowReserved?: boolean
+}
+
+/**
  * Serializes the request body. JSON by default; `FormData`, `URLSearchParams`, `Blob`,
  * `ArrayBuffer`, and string bodies pass through untouched.
  */
@@ -135,7 +151,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   validateStatus?: (status: number) => boolean
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   parser?: { request?: Parser; response?: Parser; error?: Parser }
   security?: Array<Auth>
@@ -165,7 +181,7 @@ export type ClientConfig = {
   throwOnError?: boolean
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
-  querySerializer?: QuerySerializer
+  querySerializer?: QuerySerializer | QuerySerializerOptions
   bodySerializer?: BodySerializer
   auth?: AuthResolver
 }
@@ -285,31 +301,80 @@ export const defaultBodySerializer: BodySerializer = (body, contentType) => {
   return JSON.stringify(body)
 }
 
-function appendQueryValue(search: URLSearchParams, key: string, value: unknown): void {
+const arrayValueDelimiters = { form: ',', spaceDelimited: '%20', pipeDelimited: '|' } as const
+
+function encodeQueryPart(value: unknown, allowReserved: boolean | undefined): string {
+  return allowReserved ? String(value) : encodeURIComponent(String(value))
+}
+
+function appendQueryValue(parts: Array<string>, key: string, value: unknown, options: QuerySerializerOptions): void {
   if (value === undefined || value === null) return
+
   if (Array.isArray(value)) {
-    for (const item of value) appendQueryValue(search, key, item)
-    return
-  }
-  if (typeof value === 'object') {
-    for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
-      appendQueryValue(search, `${key}[${prop}]`, propValue)
+    if (value.length === 0) return
+    const { style, explode } = options.array ?? { style: 'form', explode: true }
+    if (explode) {
+      for (const item of value) appendQueryValue(parts, key, item, options)
+      return
     }
+    const joined = value.map((item) => encodeQueryPart(item, options.allowReserved)).join(arrayValueDelimiters[style])
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
     return
   }
-  search.append(key, String(value))
+
+  if (typeof value === 'object') {
+    const { style, explode } = options.object ?? { style: 'deepObject', explode: true }
+    if (style === 'deepObject') {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, `${key}[${prop}]`, propValue, options)
+      }
+      return
+    }
+    if (explode) {
+      for (const [prop, propValue] of Object.entries(value as Record<string, unknown>)) {
+        appendQueryValue(parts, prop, propValue, options)
+      }
+      return
+    }
+    const joined = Object.entries(value as Record<string, unknown>)
+      .flatMap(([prop, propValue]) => [prop, propValue])
+      .map((part) => encodeQueryPart(part, options.allowReserved))
+      .join(',')
+    parts.push(`${encodeQueryPart(key, options.allowReserved)}=${joined}`)
+    return
+  }
+
+  parts.push(`${encodeQueryPart(key, options.allowReserved)}=${encodeQueryPart(value, options.allowReserved)}`)
+}
+
+/**
+ * Builds a `QuerySerializer` from declarative options. Without options it reproduces the default:
+ * arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style
+ * (`key[prop]=value`). `style`, `explode`, and `allowReserved` adjust each kind from there.
+ */
+export function createQuerySerializer(options: QuerySerializerOptions = {}): QuerySerializer {
+  return (params) => {
+    const parts: Array<string> = []
+    for (const [key, value] of Object.entries(params)) {
+      appendQueryValue(parts, key, value, options)
+    }
+    return parts.join('&')
+  }
 }
 
 /**
  * Default query serializer: arrays explode into repeated keys and nested objects use the
  * `deepObject` style (`key[prop]=value`).
  */
-export const defaultQuerySerializer: QuerySerializer = (params) => {
-  const search = new URLSearchParams()
-  for (const [key, value] of Object.entries(params)) {
-    appendQueryValue(search, key, value)
-  }
-  return search.toString()
+export const defaultQuerySerializer: QuerySerializer = createQuerySerializer()
+
+/**
+ * Resolves a `querySerializer` config value to a function: a function passes through, declarative
+ * options become a serializer, and an unset value falls back to the default.
+ */
+function resolveQuerySerializer(serializer: QuerySerializer | QuerySerializerOptions | undefined): QuerySerializer {
+  if (!serializer) return defaultQuerySerializer
+  return typeof serializer === 'function' ? serializer : createQuerySerializer(serializer)
 }
 
 function serializeHeaders(headers: HeadersInit | undefined): Record<string, string> {
@@ -440,7 +505,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
 
   const client = (async <TBody = unknown>(requestConfig: RequestConfig<TBody, TRequest, TResponse>): Promise<CallResult<TRequest, TResponse>> => {
     const activeInstance = requestConfig.transport ?? config.transport ?? instance
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const bodySerializer = requestConfig.bodySerializer ?? config.bodySerializer ?? defaultBodySerializer
 
     const headers = mergeHeaders(config.headers, requestConfig.headers)
@@ -518,7 +583,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return config
   }
   client.getUrl = (requestConfig) => {
-    const querySerializer = requestConfig.querySerializer ?? config.querySerializer ?? defaultQuerySerializer
+    const querySerializer = resolveQuerySerializer(requestConfig.querySerializer ?? config.querySerializer)
     const query: Record<string, unknown> = { ...((requestConfig.query ?? requestConfig.params) as Record<string, unknown> | undefined) }
     return serializeUrl([config.baseURL, requestConfig.baseURL, requestConfig.url], requestConfig.path ?? {}, querySerializer(query))
   }


### PR DESCRIPTION
## Summary

`querySerializer` on the fetch and axios clients now accepts a declarative options object as well as a function. When an object is given, the runtime builds the serializer for you, so the common OpenAPI shapes no longer need a hand-written function.

```ts
client.setConfig({
  querySerializer: {
    array: { style: 'pipeDelimited', explode: false },
    object: { style: 'deepObject', explode: true },
    allowReserved: false,
  },
})
```

## What changed

- New `QuerySerializerOptions` type covering the `form` / `spaceDelimited` / `pipeDelimited` array styles, the `form` / `deepObject` object styles, and `allowReserved`.
- New `createQuerySerializer(options)` export that generalizes the existing query helper to honor `style`, `explode`, and `allowReserved`.
- `RequestConfig.querySerializer` and `ClientConfig.querySerializer` now take `QuerySerializer | QuerySerializerOptions`. Resolution happens once where the serializer is selected: a function passes through, an options object is built into one, and an unset value falls back to the default.
- The default is unchanged: arrays explode into repeated keys (`form`) and nested objects use the `deepObject` style.

Applied to both `@kubb/plugin-fetch` and `@kubb/plugin-axios` (which maps it onto axios's `paramsSerializer`).

## Tests

- Added unit tests for `createQuerySerializer` (each array and object style, `explode`, `allowReserved`, empty arrays) and for building a serializer from an options object through `getUrl`, in both template suites.
- Existing default-serializer tests stay green, confirming the default behavior is preserved.
- Regenerated the `.kubb/client.ts` file snapshots across the client-emitting plugins.
- `pnpm lint`, `pnpm typecheck` (tests/3.0.x), and the affected test suites pass.

A changeset is included (minor bump for both plugins). Docs for the new option are in companion PRs on `kubb-labs/docs` and `kubb-labs/platform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0163qz3YRYfQzam1a6GxA6U2)_