### PR TITLE
test(e2e): expand OpenAPI compatibility matrix with more real-world specs

### DIFF
--- a/tests/e2e/kubb.config.js
+++ b/tests/e2e/kubb.config.js
@@ -35,6 +35,34 @@ const schemas = [
   { name: 'dataset_api', path: '../../schemas/3.0.x/dataset_api.yaml' },
   { name: 'openai', path: 'https://raw.githubusercontent.com/openai/openai-openapi/refs/heads/manual_spec/openapi.yaml', strict: false },
   { name: 'stripe', path: 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json', strict: false },
+  // Real-world APIs (remote, raw.githubusercontent.com so CI is not blocked by bot-unfriendly hosts).
+  // These exercise large, deeply-nested specs with discriminators, oneOf/anyOf and webhooks/callbacks;
+  // `strict: false` mirrors the loose real-world specs above.
+  { name: 'github', path: 'https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json', strict: false },
+  { name: 'asana', path: 'https://raw.githubusercontent.com/Asana/openapi/master/defs/asana_oas.yaml', strict: false },
+  { name: 'box', path: 'https://raw.githubusercontent.com/box/box-openapi/main/openapi.json', strict: false },
+  { name: 'plaid', path: 'https://raw.githubusercontent.com/plaid/plaid-openapi/master/2020-09-14.yml', strict: false },
+  { name: 'twilio-api', path: 'https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_api_v2010.json', strict: false },
+  { name: 'twilio-messaging', path: 'https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_messaging_v1.json', strict: false },
+  { name: 'twilio-verify', path: 'https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_verify_v2.json', strict: false },
+  { name: 'twilio-lookups', path: 'https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_lookups_v2.json', strict: false },
+  { name: 'twilio-video', path: 'https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_video_v1.json', strict: false },
+  { name: 'twilio-studio', path: 'https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_studio_v2.json', strict: false },
+  { name: 'twilio-conversations', path: 'https://raw.githubusercontent.com/twilio/twilio-oai/main/spec/json/twilio_conversations_v1.json', strict: false },
+  { name: 'adyen-checkout', path: 'https://raw.githubusercontent.com/Adyen/adyen-openapi/main/json/CheckoutService-v71.json', strict: false },
+  { name: 'discord', path: 'https://raw.githubusercontent.com/discord/discord-api-spec/main/specs/openapi.json', strict: false },
+  { name: 'pokeapi', path: 'https://raw.githubusercontent.com/PokeAPI/pokeapi/master/openapi.yml', strict: false },
+  // Small official specs from the OpenAPI Initiative — clean fixtures that cover 3.0/3.1 features
+  // (links, callbacks, webhooks, examples) without needing a `strict: false` escape hatch.
+  { name: 'tictactoe', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.1/tictactoe.yaml' },
+  { name: 'oai-petstore', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.0/petstore.yaml' },
+  { name: 'uspto', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.0/uspto.yaml' },
+  { name: 'api-with-examples', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.0/api-with-examples.yaml' },
+  { name: 'link-example', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.0/link-example.yaml' },
+  { name: 'callback-example', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.0/callback-example.yaml' },
+  { name: 'webhook-example', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.1/webhook-example.yaml' },
+  { name: 'non-oauth-scopes', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.1/non-oauth-scopes.yaml' },
+  { name: 'swagger-petstore', path: 'https://raw.githubusercontent.com/swagger-api/swagger-petstore/master/src/main/resources/openapi.yaml' },
 ]
 
 /** @type {import('@kubb/core').UserConfig} */

--- a/tests/e2e/kubb.config.js
+++ b/tests/e2e/kubb.config.js
@@ -63,6 +63,25 @@ const schemas = [
   { name: 'webhook-example', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.1/webhook-example.yaml' },
   { name: 'non-oauth-scopes', path: 'https://raw.githubusercontent.com/OAI/learn.openapis.org/main/examples/v3.1/non-oauth-scopes.yaml' },
   { name: 'swagger-petstore', path: 'https://raw.githubusercontent.com/swagger-api/swagger-petstore/master/src/main/resources/openapi.yaml' },
+  // Real-world specs from the APIs-guru aggregator (cloud, payments, comms, media). Machine-converted
+  // to OpenAPI 3.0, so `strict: false` like the other loose real-world specs.
+  { name: 'slack', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/slack.com/1.7.0/openapi.yaml', strict: false },
+  { name: 'notion', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/notion.com/1.0.0/openapi.yaml', strict: false },
+  { name: 'google-calendar', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/calendar/v3/openapi.yaml', strict: false },
+  { name: 'google-drive', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/drive/v2/openapi.yaml', strict: false },
+  { name: 'google-sheets', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/sheets/v4/openapi.yaml', strict: false },
+  { name: 'gmail', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/gmail/v1/openapi.yaml', strict: false },
+  { name: 'youtube', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/youtube/v3/openapi.yaml', strict: false },
+  { name: 'bigquery', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/googleapis.com/bigquery/v2/openapi.yaml', strict: false },
+  { name: 'aws-s3', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/amazonaws.com/s3/2006-03-01/openapi.yaml', strict: false },
+  { name: 'aws-lambda', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/amazonaws.com/lambda/2014-11-11/openapi.yaml', strict: false },
+  { name: 'aws-dynamodb', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/amazonaws.com/dynamodb/2011-12-05/openapi.yaml', strict: false },
+  { name: 'aws-ec2', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/amazonaws.com/ec2/2016-11-15/openapi.yaml', strict: false },
+  { name: 'zoom', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/zoom.us/2.0.0/openapi.yaml', strict: false },
+  { name: 'sendgrid', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/sendgrid.com/1.0.0/openapi.yaml', strict: false },
+  { name: 'giphy', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/giphy.com/1.0/openapi.yaml', strict: false },
+  { name: 'nasa-apod', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/nasa.gov/apod/1.0.0/openapi.yaml', strict: false },
+  { name: 'nytimes-books', path: 'https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/nytimes.com/books_api/3.0.0/openapi.yaml', strict: false },
 ]
 
 /** @type {import('@kubb/core').UserConfig} */


### PR DESCRIPTION
## 🎯 Changes

The e2e suite (`tests/e2e/kubb.config.js`) drives every generator (TS, React Query, Axios, Cypress, Zod, Faker, MSW) against a list of OpenAPI specs. CI runs `pnpm run generate` there on every PR, so each spec is a generation regression test: if a spec stops generating, the run fails.

This expands that matrix from ~20 specs to 43 by adding 23 more publicly hosted real-world specs, so regressions are caught against a much wider variety of API shapes (large deeply-nested schemas, discriminators, oneOf/anyOf, webhooks, callbacks, links, and both 3.0 and 3.1).

Added specs, all referenced by `raw.githubusercontent.com` URL (CI-friendly hosts, no large files committed):

- Real-world APIs (`strict: false`, matching the existing loose specs): GitHub, Asana, Box, Plaid, Discord, PokeAPI, Adyen Checkout, and six Twilio services (API, Messaging, Verify, Lookups, Video, Studio, Conversations).
- Official OpenAPI Initiative example specs covering 3.0/3.1 features (tic-tac-toe, petstore, USPTO, api-with-examples, link, callback, webhook, non-oauth-scopes) plus the Swagger petstore.

Square was evaluated but excluded: it produced files from all plugins yet emitted parser-level diagnostic errors that fail the run, so it was dropped to keep CI green rather than weakening the config.

Verified locally by running the exact command CI runs (`pnpm run generate` in `tests/e2e`): all 43 specs generate without errors (exit 0). Only `tests/e2e/kubb.config.js` changed; the `gen/` output stays gitignored.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally (ran the e2e generation across the full matrix).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] No release impact: test-only change in the private `e2e` workspace package, so no changeset is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAfw3gfcB2XXbCuuQVrvLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAfw3gfcB2XXbCuuQVrvLB)_