### PR TITLE
fix(plugin-ts): honor resolveTypeName for type references

### DIFF
--- a/.changeset/curly-areas-sit.md
+++ b/.changeset/curly-areas-sit.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-ts": patch
+---
+
+Honor resolveTypeName when printing TypeScript schema references.

--- a/packages/plugin-ts/src/components/Enum.tsx
+++ b/packages/plugin-ts/src/components/Enum.tsx
@@ -38,7 +38,7 @@ export function getEnumNames({ node, enum: enumOptions, resolver }: { node: ast.
   enumName: string
   typeName: string
 } {
-  const resolved = resolver.default(node.name!, 'type')
+  const resolved = resolver.resolveTypeName(node.name!)
   const enumName = enumOptions.constCasing === 'pascalCase' ? resolved : camelCase(node.name!)
   const typeName = ENUM_TYPES_WITH_KEY_SUFFIX.has(enumOptions.type) ? resolver.resolveEnumKeyName(node, enumOptions.typeSuffix) : resolved
 

--- a/packages/plugin-ts/src/generators/typeGenerator.test.ts
+++ b/packages/plugin-ts/src/generators/typeGenerator.test.ts
@@ -5,7 +5,7 @@ import type { Config, Group } from '@kubb/core'
 import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation, renderGeneratorSchema } from '@kubb/core/mocks'
 import { describe, expect, test } from 'vitest'
-import { matchFiles } from '#mocks'
+import { matchFiles, rawSources } from '#mocks'
 import { resolverTs } from '../resolvers/resolverTs.ts'
 import type { PluginTs } from '../types.ts'
 import { typeGenerator } from './typeGenerator.tsx'
@@ -81,6 +81,72 @@ const operationWithSnakeCaseParams: ast.OperationNode = ast.factory.createOperat
     ],
   },
   responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'Success' })],
+})
+
+const apiResolver = {
+  ...resolverTs,
+  resolveTypeName(name: string) {
+    return `Api${resolverTs.default(name, 'type')}`
+  },
+}
+
+describe('typeGenerator — custom resolver', () => {
+  test('uses resolveTypeName consistently for imported schema refs', async () => {
+    const options: PluginTs['resolvedOptions'] = { ...defaultOptions }
+    const plugin = createMockedPlugin<PluginTs>({ name: 'plugin-ts', options, resolver: apiResolver })
+    const driver = createMockedPluginDriver({ name: 'custom resolver' })
+    const node = ast.factory.createOperation({
+      operationId: 'createPet',
+      method: 'POST',
+      path: '/pets',
+      tags: ['pets'],
+      requestBody: {
+        content: [
+          ast.factory.createContent({
+            contentType: 'application/json',
+            schema: ast.factory.createSchema({ type: 'ref', name: 'NewPet', ref: '#/components/schemas/NewPet' }),
+          }),
+        ],
+      },
+      responses: [
+        ast.factory.createResponse({
+          statusCode: '201',
+          schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }),
+          description: 'Created',
+        }),
+        ast.factory.createResponse({
+          statusCode: '400',
+          schema: ast.factory.createSchema({ type: 'ref', name: 'ErrorResponse', ref: '#/components/schemas/ErrorResponse' }),
+          description: 'Bad request',
+        }),
+      ],
+    })
+    const adapter = createMockedAdapter({
+      getImports: (_node, resolve) =>
+        ['Pet', 'ErrorResponse', 'NewPet'].map((name) => {
+          const imported = resolve(name)
+          return ast.factory.createImport({ name: [imported.name], path: imported.path })
+        }),
+    })
+
+    await renderGeneratorOperation(typeGenerator, node, {
+      config: testConfig,
+      adapter,
+      driver,
+      plugin,
+      options,
+      resolver: apiResolver,
+    })
+
+    const source = rawSources(driver.fileManager.files).join('\n')
+
+    expect(source).toContain('export type ApiCreatePetStatus201 = ApiPet')
+    expect(source).toContain('export type ApiCreatePetStatus400 = ApiErrorResponse')
+    expect(source).toContain('export type ApiCreatePetData = ApiNewPet')
+    expect(source).toContain("import type { ApiPet } from './Pet.ts'")
+    expect(source).toContain("import type { ApiErrorResponse } from './ErrorResponse.ts'")
+    expect(source).toContain("import type { ApiNewPet } from './NewPet.ts'")
+  })
 })
 
 describe('typeGenerator — Operation', () => {

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -171,7 +171,7 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         const name = isEnumRef
           ? this.options.resolver.resolveEnumKeyName({ name: refName }, this.options.enum.typeSuffix)
           : node.ref
-            ? this.options.resolver.default(refName, 'type')
+            ? this.options.resolver.resolveTypeName(refName)
             : refName
 
         return factory.createTypeReferenceNode(name, undefined)
@@ -193,7 +193,7 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         const resolvedName =
           ENUM_TYPES_WITH_KEY_SUFFIX.has(this.options.enum.type) && this.options.enum.typeSuffix
             ? this.options.resolver.resolveEnumKeyName(node, this.options.enum.typeSuffix)
-            : this.options.resolver.default(node.name, 'type')
+            : this.options.resolver.resolveTypeName(node.name)
 
         return factory.createTypeReferenceNode(resolvedName, undefined)
       },

--- a/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
@@ -1,5 +1,7 @@
 // Custom banner
 
+import type { CustomItem } from './Item.ts'
+
 /**
  * @description
  * Format: `int64`
@@ -11,7 +13,7 @@ export type CustomGetItemPathId = bigint;
  * @description A simple item
  * @type object
 */
-export type CustomGetItemStatus200 = Item;
+export type CustomGetItemStatus200 = CustomItem;
 
 /**
  * @type object


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Fixes `@kubb/plugin-ts` so custom `resolver.resolveTypeName` names are used consistently for generated TypeScript refs and enum types.

This prevents mismatches where imports use the custom name, like `CustomItem`, but generated type bodies still reference the default name, like `Item`.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
