### PR TITLE
fix(plugin-zod): emit z.literal/z.union for non-string const and enum

### DIFF
--- a/.changeset/zod-enum-non-string-literals.md
+++ b/.changeset/zod-enum-non-string-literals.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-zod": patch
+---
+
+Emit `z.literal`/`z.union` instead of `z.enum` for non-string `const`/enum values. `z.enum()` only accepts string members in Zod v4, so a numeric, boolean, or mixed set produced a type error (TS2769). All-string sets keep the compact `z.enum([…])`.

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -184,14 +184,24 @@ describe('printerZod', () => {
       expect(result).toMatchInlineSnapshot(`"z.enum(['a', 'b', 'c'])"`)
     })
 
-    test('number enum', () => {
+    test('number enum uses z.union of literals', () => {
       const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: [200, 400, 500] }))
-      expect(result).toBe('z.enum([200, 400, 500])')
+      expect(result).toBe('z.union([z.literal(200), z.literal(400), z.literal(500)])')
     })
 
-    test('boolean enum', () => {
+    test('single number enum uses z.literal', () => {
+      const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: [42] }))
+      expect(result).toBe('z.literal(42)')
+    })
+
+    test('boolean enum uses z.union of literals', () => {
       const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: [true, false] }))
-      expect(result).toBe('z.enum([true, false])')
+      expect(result).toBe('z.union([z.literal(true), z.literal(false)])')
+    })
+
+    test('mixed value enum uses z.union of literals', () => {
+      const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: ['active', 1, true] }))
+      expect(result).toBe("z.union([z.literal('active'), z.literal(1), z.literal(true)])")
     })
 
     test('number literals (namedEnumValues)', () => {

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -13,7 +13,17 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyModifiers, buildEnum, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, patternKeySchema, shouldCoerce } from '../utils.ts'
+import {
+  applyModifiers,
+  buildEnum,
+  containsCodec,
+  formatLiteral,
+  getCodec,
+  lengthConstraints,
+  numberConstraints,
+  patternKeySchema,
+  shouldCoerce,
+} from '../utils.ts'
 import type { AdapterOas } from '@kubb/adapter-oas'
 
 /**

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -13,7 +13,7 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyModifiers, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, patternKeySchema, shouldCoerce } from '../utils.ts'
+import { applyModifiers, buildEnum, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, patternKeySchema, shouldCoerce } from '../utils.ts'
 import type { AdapterOas } from '@kubb/adapter-oas'
 
 /**
@@ -216,8 +216,8 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
           return `z.union([${literals.join(', ')}])`
         }
 
-        // Regular enum: use z.enum([…])
-        return `z.enum([${nonNullValues.map(formatLiteral).join(', ')}])`
+        // Regular enum: z.enum for all-string sets, z.literal/z.union otherwise
+        return buildEnum(nonNullValues)
       },
       ref(node) {
         if (!node.name) return null

--- a/packages/plugin-zod/src/printers/printerZodMini.test.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.test.ts
@@ -135,14 +135,24 @@ describe('printerZodMini', () => {
       expect(result).toMatchInlineSnapshot(`"z.enum(['a', 'b', 'c'])"`)
     })
 
-    test('number enum', () => {
+    test('number enum uses z.union of literals', () => {
       const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: [200, 400, 500] }))
-      expect(result).toBe('z.enum([200, 400, 500])')
+      expect(result).toBe('z.union([z.literal(200), z.literal(400), z.literal(500)])')
     })
 
-    test('boolean enum', () => {
+    test('single number enum uses z.literal', () => {
+      const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: [42] }))
+      expect(result).toBe('z.literal(42)')
+    })
+
+    test('boolean enum uses z.union of literals', () => {
       const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: [true, false] }))
-      expect(result).toBe('z.enum([true, false])')
+      expect(result).toBe('z.union([z.literal(true), z.literal(false)])')
+    })
+
+    test('mixed value enum uses z.union of literals', () => {
+      const result = printer.print(ast.factory.createSchema({ type: 'enum', enumValues: ['active', 1, true] }))
+      expect(result).toBe("z.union([z.literal('active'), z.literal(1), z.literal(true)])")
     })
 
     test('number literals (namedEnumValues)', () => {

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -13,7 +13,7 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyMiniModifiers, formatLiteral, lengthChecksMini, numberChecksMini, patternKeySchemaMini } from '../utils.ts'
+import { applyMiniModifiers, buildEnum, formatLiteral, lengthChecksMini, numberChecksMini, patternKeySchemaMini } from '../utils.ts'
 
 /**
  * Partial map of node-type overrides for the Zod Mini printer.
@@ -173,8 +173,8 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
           return `z.union([${literals.join(', ')}])`
         }
 
-        // Regular enum: use z.enum([…])
-        return `z.enum([${nonNullValues.map(formatLiteral).join(', ')}])`
+        // Regular enum: z.enum for all-string sets, z.literal/z.union otherwise
+        return buildEnum(nonNullValues)
       },
 
       ref(node) {

--- a/packages/plugin-zod/src/utils.test.ts
+++ b/packages/plugin-zod/src/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest'
 import {
   applyMiniModifiers,
   applyModifiers,
+  buildEnum,
   buildGroupedParamsSchema,
   formatDefault,
   formatLiteral,
@@ -56,6 +57,28 @@ describe('formatLiteral', () => {
 
   test('boolean false is raw', () => {
     expect(formatLiteral(false)).toBe('false')
+  })
+})
+
+describe('buildEnum', () => {
+  test('all-string set uses z.enum', () => {
+    expect(buildEnum(['a', 'b', 'c'])).toBe("z.enum(['a', 'b', 'c'])")
+  })
+
+  test('single non-string value uses z.literal', () => {
+    expect(buildEnum([42])).toBe('z.literal(42)')
+  })
+
+  test('numeric set uses z.union of literals', () => {
+    expect(buildEnum([200, 400, 500])).toBe('z.union([z.literal(200), z.literal(400), z.literal(500)])')
+  })
+
+  test('boolean set uses z.union of literals', () => {
+    expect(buildEnum([true, false])).toBe('z.union([z.literal(true), z.literal(false)])')
+  })
+
+  test('mixed set uses z.union of literals', () => {
+    expect(buildEnum(['a', 1, true])).toBe("z.union([z.literal('a'), z.literal(1), z.literal(true)])")
   })
 })
 

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -138,6 +138,22 @@ export function formatLiteral(v: string | number | boolean): string {
 }
 
 /**
+ * Build the Zod schema for a set of literal enum values.
+ * `z.enum()` only accepts string members in Zod v4, so a numeric, boolean, or
+ * mixed set is emitted as a single `z.literal(…)` or a `z.union([z.literal(…), …])`.
+ * An all-string set keeps the more compact `z.enum([…])`.
+ */
+export function buildEnum(values: Array<string | number | boolean>): string {
+  const allStrings = values.every((v) => typeof v === 'string')
+  if (allStrings) return `z.enum([${values.map(formatLiteral).join(', ')}])`
+
+  const literals = values.map((v) => `z.literal(${formatLiteral(v)})`)
+  if (literals.length === 1) return literals[0]!
+
+  return `z.union([${literals.join(', ')}])`
+}
+
+/**
  * Numeric constraint limits for Zod schemas (min, max, and exclusive bounds).
  */
 export type NumericConstraints = {


### PR DESCRIPTION
## 🎯 Changes

Fixes **bug class 1** from #567.

`z.enum()` only accepts string members in Zod v4, so the zod printers emitting `z.enum([42])` for a numeric, boolean, or mixed `const`/enum produced a `No overload matches this call` type error (TS2769). This showed up in the generated output for the `constCases`, `discriminator`, `twitter`, and `digitalocean` fixtures.

- Added a shared `buildEnum()` helper in `packages/plugin-zod/src/utils.ts`:
  - all-string sets keep the compact `z.enum([…])`
  - a single non-string value becomes `z.literal(…)`
  - a multi-value set with any non-string member becomes `z.union([z.literal(…), …])`
- Wired the helper into the regular-enum branch of both `printerZod.ts` and `printerZodMini.ts` (the `asConst` / `namedEnumValues` branch already emitted literals).
- Updated the `number enum` / `boolean enum` printer tests to assert the corrected output and added single-value and mixed-value cases, plus unit tests for `buildEnum`.

The remaining bug classes (2 dangling cross-file imports, 3 missing `*Responses` export, 4 `.omit()` on a nullable wrapper) from #567 are out of scope for this PR.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxqS1AspskDgEY6QuT3d4H

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxqS1AspskDgEY6QuT3d4H)_