### PR TITLE
fix(plugin-ts): always emit a *Responses type for every operation

### DIFF
--- a/.changeset/plugin-ts-always-emit-responses.md
+++ b/.changeset/plugin-ts-always-emit-responses.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-ts": patch
+---
+
+Always emit a `*Responses` type for every operation, even when it declares no responses. The type now renders as an empty `object` instead of being skipped, so consumers that import it unconditionally (such as the axios SDK's `RequestResult<XResponses>`) keep resolving instead of failing strict typecheck with `TS2305: Module has no exported member 'XResponses'`. Reported in kubb-labs/plugins#567.

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -167,12 +167,23 @@ describe('buildResponses', () => {
       ],
     })
 
-    expect(printSchema(buildResponses(node, { resolver: resolverTs })!)).toMatchInlineSnapshot(`
+    expect(printSchema(buildResponses(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
       "{
           "200": ListPetsStatus200;
           default: ListPetsStatusDefault;
       }"
     `)
+  })
+
+  it('emits an empty object type for an operation with no responses', () => {
+    const node = ast.factory.createOperation({
+      operationId: 'noResponses',
+      method: 'GET',
+      path: '/pets',
+      responses: [],
+    })
+
+    expect(printSchema(buildResponses(node, { resolver: resolverTs }))).toBe('object')
   })
 })
 

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -140,11 +140,10 @@ export function buildData(node: ast.OperationNode, { resolver }: BuildOperationS
   })
 }
 
-export function buildResponses(node: ast.OperationNode, { resolver }: BuildOperationSchemaOptions): ast.SchemaNode | null {
-  if (node.responses.length === 0) {
-    return null
-  }
-
+export function buildResponses(node: ast.OperationNode, { resolver }: BuildOperationSchemaOptions): ast.SchemaNode {
+  // Always emit the keyed responses map, even when an operation declares no responses. An operation
+  // with no responses renders as an empty `object`, which keeps every consumer's import (for example
+  // the axios SDK's `RequestResult<XResponses>`) resolvable instead of pointing at a missing export.
   return ast.factory.createSchema({
     type: 'object',
     properties: node.responses.map((res) =>


### PR DESCRIPTION
## 🎯 Changes

Fixes bug class 3 from #567: `plugin-axios` SDK imports a `*Responses` type that `plugin-ts` never exports → TS2305.

For operations with no/empty responses, `buildResponses()` in `plugin-ts` returned `null`, so the type generator emitted nothing. The axios client generator imports `tsResolver.resolveResponsesName(node)` unconditionally, so the generated SDK failed strict typecheck with `Module '"../types/X.ts"' has no exported member 'XResponses'` (reproduced on `queryWithRefDefault` → `ProjectsGetResponses` and `optionalParameters` → `SomeNameResponses`).

`buildResponses()` now always returns the keyed responses map. An operation with no responses renders as an empty `object`, so every consumer's import stays resolvable. Existing fixtures all declare responses, so no snapshots changed.

A unit test covers the new empty-responses case.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hzj5cTnT44i7K661XwzFVj)_