### PR TITLE
fix(plugin-zod): unwrap nullable ref before .omit()

### DIFF
--- a/.changeset/zod-omit-unwrap-nullable-ref.md
+++ b/.changeset/zod-omit-unwrap-nullable-ref.md
@@ -1,0 +1,7 @@
+---
+"@kubb/plugin-zod": patch
+---
+
+Fix `.omit()` being called on a `ZodNullable`/`ZodOptional` wrapper for request schemas built from a `$ref` to a nullable (or optional) component (kubb-labs/plugins#567, bug 4).
+
+A `$ref` resolves to a named schema variable that already carries its own `.nullable()` / `.optional()` modifiers, but `.omit()` only exists on the inner `ZodObject`. When readonly keys were stripped from such a ref the printer emitted `mySchema.omit({ … })`, which fails strict typecheck with `Property 'omit' does not exist on type 'ZodNullable<…>'`. The printer now unwraps down to the object first and re-applies the modifier — `mySchema.unwrap().omit({ … }).nullable()` — mirroring plugin-ts emitting `Omit<NonNullable<T>, …>`. The same fix applies to the `zod/mini` printer.

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -772,6 +772,39 @@ describe('printerZod', () => {
       })
       expect(p.print(node)).toMatchInlineSnapshot(`"z.discriminatedUnion('petType', [Cat, Dog])"`)
     })
+
+    test('unwraps a nullable ref before omit so .omit() targets the ZodObject', () => {
+      // https://github.com/kubb-labs/plugins/issues/567 (bug 4): a $ref to a nullable schema
+      // resolves to a ZodNullable variable, and .omit() only exists on the inner ZodObject.
+      const p = printerZod({ keysToOmit: ['pending'] })
+      const node = ast.factory.createSchema({
+        type: 'ref',
+        name: 'maintenanceWindow',
+        ref: '#/components/schemas/maintenance_window',
+        nullable: true,
+        primitive: 'object',
+      })
+      expect(p.print(node)).toBe('maintenance_window.unwrap().omit({ "pending": true }).nullable()')
+    })
+
+    test('does not unwrap an inline nullable object before omit', () => {
+      const p = printerZod({ keysToOmit: ['pending'] })
+      const node = ast.factory.createSchema({
+        type: 'object',
+        primitive: 'object',
+        nullable: true,
+        properties: [
+          ast.factory.createProperty({ name: 'day', required: true, schema: ast.factory.createSchema({ type: 'string' }) }),
+          ast.factory.createProperty({ name: 'pending', required: false, schema: ast.factory.createSchema({ type: 'boolean' }) }),
+        ],
+      })
+      expect(p.print(node)).toMatchInlineSnapshot(`
+        "z.object({
+          day: z.string(),
+          pending: z.boolean().optional(),
+        }).omit({ "pending": true }).nullable()"
+      `)
+    })
   })
 
   describe('discriminator properties with external refs', () => {

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -13,7 +13,7 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyModifiers, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, patternKeySchema, shouldCoerce } from '../utils.ts'
+import { applyModifiers, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, omitUnwrapChain, patternKeySchema, shouldCoerce } from '../utils.ts'
 import type { AdapterOas } from '@kubb/adapter-oas'
 
 /**
@@ -367,14 +367,18 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
 
       const base = (() => {
         if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed
-        // Mirror printerTs `nonNullable: true`: when omitting keys, the resulting
-        // schema is a new non-nullable object type — skip optional/nullable/nullish.
         // Discriminated unions (z.discriminatedUnion) do not support .omit(), so skip them.
+
+        // A nullable/optional ref resolves to a ZodNullable/ZodOptional variable; .omit() lives on
+        // the inner ZodObject, so unwrap down to it first (mirrors printerTs `Omit<NonNullable<T>, …>`).
+        // applyModifiers re-applies the nullable/optional wrapper after the omit.
+        const unwrap = omitUnwrapChain(node)
+        const omit = `.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} })`
 
         // If this is a lazy reference, apply omit inside the lazy function
         const lazyMatch = transformed.match(/^z\.lazy\(\(\)\s*=>\s*(.+)\)$/)
-        if (lazyMatch) return `z.lazy(() => ${lazyMatch[1]}.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} }))`
-        return `${transformed}.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} })`
+        if (lazyMatch) return `z.lazy(() => ${lazyMatch[1]}${unwrap}${omit})`
+        return `${transformed}${unwrap}${omit}`
       })()
 
       return applyModifiers({

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -13,7 +13,17 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyModifiers, containsCodec, formatLiteral, getCodec, lengthConstraints, numberConstraints, omitUnwrapChain, patternKeySchema, shouldCoerce } from '../utils.ts'
+import {
+  applyModifiers,
+  containsCodec,
+  formatLiteral,
+  getCodec,
+  lengthConstraints,
+  numberConstraints,
+  omitUnwrapChain,
+  patternKeySchema,
+  shouldCoerce,
+} from '../utils.ts'
 import type { AdapterOas } from '@kubb/adapter-oas'
 
 /**

--- a/packages/plugin-zod/src/printers/printerZodMini.test.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.test.ts
@@ -667,6 +667,20 @@ describe('printerZodMini', () => {
       })
       expect(p.print(node)).toMatchInlineSnapshot(`"z.discriminatedUnion('petType', [Cat, Dog])"`)
     })
+
+    test('unwraps a nullable ref before omit so .omit() targets the inner object', () => {
+      // https://github.com/kubb-labs/plugins/issues/567 (bug 4): a $ref to a nullable schema
+      // resolves to a ZodMiniNullable variable, and .omit() only exists on the inner object.
+      const p = printerZodMini({ keysToOmit: ['pending'] })
+      const node = ast.factory.createSchema({
+        type: 'ref',
+        name: 'maintenanceWindow',
+        ref: '#/components/schemas/maintenance_window',
+        nullable: true,
+        primitive: 'object',
+      })
+      expect(p.print(node)).toBe('z.nullable(maintenance_window.unwrap().omit({ "pending": true }))')
+    })
   })
 
   describe('nodes override', () => {

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -13,7 +13,7 @@ import {
 import { ast } from '@kubb/core'
 import { containsCircularRef, syncSchemaRef } from '@kubb/ast/utils'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import { applyMiniModifiers, formatLiteral, lengthChecksMini, numberChecksMini, patternKeySchemaMini } from '../utils.ts'
+import { applyMiniModifiers, formatLiteral, lengthChecksMini, numberChecksMini, omitUnwrapChain, patternKeySchemaMini } from '../utils.ts'
 
 /**
  * Partial map of node-type overrides for the Zod Mini printer.
@@ -304,14 +304,18 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
 
       const base = (() => {
         if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed
-        // Mirror printerTs `nonNullable: true`: when omitting keys, the resulting
-        // schema is a new non-nullable object type — skip optional/nullable/nullish.
         // Discriminated unions (z.discriminatedUnion) do not support .omit(), so skip them.
+
+        // A nullable/optional ref resolves to a ZodMiniNullable/ZodMiniOptional variable; .omit() lives
+        // on the inner object, so unwrap down to it first (mirrors printerTs `Omit<NonNullable<T>, …>`).
+        // applyMiniModifiers re-applies the nullable/optional wrapper after the omit.
+        const unwrap = omitUnwrapChain(node)
+        const omit = `.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} })`
 
         // If this is a lazy reference, apply omit inside the lazy function
         const lazyMatch = transformed.match(/^z\.lazy\(\(\)\s*=>\s*(.+)\)$/)
-        if (lazyMatch) return `z.lazy(() => ${lazyMatch[1]}.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} }))`
-        return `${transformed}.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} })`
+        if (lazyMatch) return `z.lazy(() => ${lazyMatch[1]}${unwrap}${omit})`
+        return `${transformed}${unwrap}${omit}`
       })()
 
       return applyMiniModifiers({

--- a/packages/plugin-zod/src/utils.test.ts
+++ b/packages/plugin-zod/src/utils.test.ts
@@ -12,6 +12,7 @@ import {
   lengthConstraints,
   numberChecksMini,
   numberConstraints,
+  omitUnwrapChain,
   shouldCoerce,
 } from './utils.ts'
 
@@ -367,5 +368,43 @@ describe('codec', () => {
     expect(hasCodec(ast.factory.createSchema({ type: 'bigint' }))).toBe(false)
     expect(hasCodec(ast.factory.createSchema({ type: 'string' }))).toBe(false)
     expect(hasCodec(undefined)).toBe(false)
+  })
+})
+
+describe('omitUnwrapChain', () => {
+  test('non-ref schema needs no unwrap', () => {
+    expect(omitUnwrapChain(ast.factory.createSchema({ type: 'object', nullable: true }))).toBe('')
+  })
+
+  test('plain ref needs no unwrap', () => {
+    expect(omitUnwrapChain(ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }))).toBe('')
+  })
+
+  test('nullable ref unwraps once', () => {
+    expect(omitUnwrapChain(ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet', nullable: true }))).toBe('.unwrap()')
+  })
+
+  test('optional ref unwraps once', () => {
+    expect(omitUnwrapChain(ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet', optional: true }))).toBe('.unwrap()')
+  })
+
+  test('nullish ref unwraps twice', () => {
+    expect(omitUnwrapChain(ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet', nullish: true }))).toBe('.unwrap().unwrap()')
+  })
+
+  test('nullable ref with a default unwraps twice', () => {
+    expect(omitUnwrapChain(ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet', nullable: true, default: {} }))).toBe(
+      '.unwrap().unwrap()',
+    )
+  })
+
+  test('reads modifiers from the resolved ref target, not the usage site', () => {
+    const node = ast.factory.createSchema({
+      type: 'ref',
+      name: 'Pet',
+      ref: '#/components/schemas/Pet',
+      schema: ast.factory.createSchema({ type: 'object', nullable: true }),
+    })
+    expect(omitUnwrapChain(node)).toBe('.unwrap()')
   })
 })

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -271,6 +271,30 @@ export function applyModifiers({ value, nullable, optional, nullish, defaultValu
   return examples?.length ? `${withDescription}.meta({ examples: [${examples.map(formatDefault).join(', ')}] })` : withDescription
 }
 
+function modifierDepth(schema: ast.SchemaNode): number {
+  if (schema.nullish || (schema.nullable && schema.optional)) return 2
+  if (schema.nullable || schema.optional) return 1
+  return 0
+}
+
+/**
+ * Build the `.unwrap()` chain to insert before `.omit()` when the schema is a `$ref`.
+ *
+ * A `$ref` resolves to a named schema variable that already carries its own `.nullable()` /
+ * `.optional()` / `.nullish()` / `.default()` wrappers. `.omit()` lives on the inner `ZodObject`,
+ * not on those `ZodNullable` / `ZodOptional` / `ZodDefault` wrappers, so the omit has to unwrap
+ * down to the object first. This mirrors plugin-ts emitting `Omit<NonNullable<T>, …>`. Inline
+ * objects need no unwrap because the printer adds their modifiers after `.omit()`.
+ */
+export function omitUnwrapChain(node: ast.SchemaNode): string {
+  const ref = ast.narrowSchema(node, 'ref')
+  if (!ref) return ''
+
+  const target = ref.schema ?? ref
+  const depth = modifierDepth(target) + (target.default !== undefined ? 1 : 0)
+  return '.unwrap()'.repeat(depth)
+}
+
 /**
  * Apply nullable / optional / nullish modifiers using the functional `zod/mini` API
  * (`z.nullable()`, `z.optional()`, `z.nullish()`).


### PR DESCRIPTION
## 🎯 Changes

Fixes bug class 4 from #567: `plugin-zod` called `.omit()` on a `ZodNullable` wrapper, producing TS2339.

When a request body strips readonly keys from a `$ref` that points at a nullable (or optional) component, the ref resolves to a named schema variable that already carries its own `.nullable()` / `.optional()` modifiers. `.omit()` only exists on the inner `ZodObject`, so the generated `mySchema.omit({ … })` failed strict typecheck with `Property 'omit' does not exist on type 'ZodNullable<…>'`. The `digitalocean` fixture hit this on `databasesUpdateMaintenanceWindowSchema`.

The printer now unwraps down to the object before omitting and re-applies the modifier, so it emits `mySchema.unwrap().omit({ … }).nullable()`. This mirrors what `plugin-ts` already does for the same case (`Omit<NonNullable<T>, …> | null`). A new `omitUnwrapChain` helper computes the `.unwrap()` depth from the resolved ref target, and the same fix lands in both the chainable and `zod/mini` printers. Inline object schemas are unchanged, since their modifiers are added after `.omit()`.

Tests cover the nullable ref, the inline object (no unwrap), the `zod/mini` variant, and the helper's depth logic (nullable, optional, nullish, default, and reading from the resolved target).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015WAAhzBzZ4rXQ9D62N7AKX)_