### PR TITLE
fix(plugin-zod): emit default values that match the schema type

### DIFF
--- a/.changeset/zod-default-type-mismatch.md
+++ b/.changeset/zod-default-type-mismatch.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-zod": patch
+---
+
+Emit `.default(...)` values that match the generated schema's type. A `bigint` field (`format: int64`) carries a numeric default and some specs put `default: {}` on an array, both of which produced a Zod schema that did not typecheck. Numeric defaults on `bigint` schemas are now emitted as `BigInt(...)` literals, array defaults are emitted as array literals (a non-array default is dropped), and array defaults are no longer collapsed to `{}`.

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -276,6 +276,7 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
 
           const value = applyModifiers({
             value: wrappedOutput,
+            schema,
             nullable: meta.nullable,
             optional: schema.optional || property.required === false,
             nullish: schema.nullish,
@@ -394,6 +395,7 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
 
       return applyModifiers({
         value: base,
+        schema: node,
         nullable: meta.nullable,
         optional: meta.optional,
         nullish: meta.nullish,

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -210,6 +210,7 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
 
           const value = applyMiniModifiers({
             value: wrappedOutput,
+            schema,
             nullable: meta.nullable,
             optional: schema.optional || property.required === false,
             nullish: schema.nullish,
@@ -320,6 +321,7 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
 
       return applyMiniModifiers({
         value: base,
+        schema: node,
         nullable: meta.nullable,
         optional: meta.optional,
         nullish: meta.nullish,

--- a/packages/plugin-zod/src/utils.test.ts
+++ b/packages/plugin-zod/src/utils.test.ts
@@ -258,6 +258,21 @@ describe('applyModifiers', () => {
     expect(applyModifiers({ value: 'z.object({})', defaultValue: {} })).toBe('z.object({}).default({})')
   })
 
+  test('bigint schema coerces a numeric default to a BigInt literal', () => {
+    const schema = ast.factory.createSchema({ type: 'bigint' })
+    expect(applyModifiers({ value: 'z.bigint()', schema, defaultValue: 1 })).toBe('z.bigint().default(BigInt(1))')
+  })
+
+  test('array schema emits an array-literal default', () => {
+    const schema = ast.factory.createSchema({ type: 'array', items: [ast.factory.createSchema({ type: 'string' })] })
+    expect(applyModifiers({ value: 'z.array(z.string())', schema, defaultValue: ['a', 'b'] })).toBe('z.array(z.string()).default(["a","b"])')
+  })
+
+  test('array schema drops a non-array default', () => {
+    const schema = ast.factory.createSchema({ type: 'array', items: [ast.factory.createSchema({ type: 'string' })] })
+    expect(applyModifiers({ value: 'z.array(z.string())', schema, defaultValue: {} })).toBe('z.array(z.string())')
+  })
+
   test('description', () => {
     expect(applyModifiers({ value: 'z.string()', description: 'A name' })).toMatchInlineSnapshot(`"z.string().describe('A name')"`)
   })

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -128,6 +128,27 @@ export function formatDefault(value: unknown): string {
 }
 
 /**
+ * Format a default for `.default(...)` so the literal matches the generated schema's type.
+ *
+ * An OpenAPI `default` does not always agree with the schema it sits on: a `bigint` field
+ * (`format: int64`) carries a `number` default, and a spec may put `default: {}` on an `array`.
+ * Emitting those verbatim produces a Zod schema that does not typecheck, so coerce the bigint case
+ * to a `BigInt(...)` literal and emit an array literal for arrays (dropping a non-array default).
+ * Returns `null` when no `.default(...)` should be emitted. Keys off the schema node's type.
+ */
+export function defaultLiteral(node: ast.SchemaNode | undefined, value: unknown): string | null {
+  if (node && ast.narrowSchema(node, 'bigint')) {
+    if (typeof value === 'bigint') return `BigInt(${value})`
+    if (typeof value === 'number' && Number.isInteger(value)) return `BigInt(${value})`
+    return null
+  }
+  if (node && ast.narrowSchema(node, 'array')) {
+    return Array.isArray(value) ? JSON.stringify(value) : null
+  }
+  return formatDefault(value)
+}
+
+/**
  * Format a primitive enum/literal value.
  * Strings are quoted; numbers and booleans are emitted raw.
  */
@@ -213,6 +234,7 @@ function patternKeySource({ patterns, regexType }: { patterns: Array<string>; re
  */
 export type ModifierOptions = {
   value: string
+  schema?: ast.SchemaNode
   nullable?: boolean
   optional?: boolean
   nullish?: boolean
@@ -275,14 +297,15 @@ export function lengthChecksMini({ min, max, pattern, regexType }: LengthConstra
  * Apply nullable / optional / nullish modifiers, an optional `.describe()` call, and an
  * optional `.meta({ examples })` call to a schema value string using the chainable Zod v4 API.
  */
-export function applyModifiers({ value, nullable, optional, nullish, defaultValue, description, examples }: ModifierOptions): string {
+export function applyModifiers({ value, schema, nullable, optional, nullish, defaultValue, description, examples }: ModifierOptions): string {
   const withModifier = (() => {
     if (nullish || (nullable && optional)) return `${value}.nullish()`
     if (optional) return `${value}.optional()`
     if (nullable) return `${value}.nullable()`
     return value
   })()
-  const withDefault = defaultValue !== undefined ? `${withModifier}.default(${formatDefault(defaultValue)})` : withModifier
+  const literal = defaultValue !== undefined ? defaultLiteral(schema, defaultValue) : null
+  const withDefault = literal !== null ? `${withModifier}.default(${literal})` : withModifier
   const withDescription = description ? `${withDefault}.describe(${stringify(description)})` : withDefault
   return examples?.length ? `${withDescription}.meta({ examples: [${examples.map(formatDefault).join(', ')}] })` : withDescription
 }
@@ -315,13 +338,14 @@ export function omitUnwrapChain(node: ast.SchemaNode): string {
  * Apply nullable / optional / nullish modifiers using the functional `zod/mini` API
  * (`z.nullable()`, `z.optional()`, `z.nullish()`).
  */
-export function applyMiniModifiers({ value, nullable, optional, nullish, defaultValue }: Omit<ModifierOptions, 'description'>): string {
+export function applyMiniModifiers({ value, schema, nullable, optional, nullish, defaultValue }: Omit<ModifierOptions, 'description'>): string {
   const withModifier = (() => {
     if (nullish) return `z.nullish(${value})`
     const withNullable = nullable ? `z.nullable(${value})` : value
     return optional ? `z.optional(${withNullable})` : withNullable
   })()
-  return defaultValue !== undefined ? `z._default(${withModifier}, ${formatDefault(defaultValue)})` : withModifier
+  const literal = defaultValue !== undefined ? defaultLiteral(schema, defaultValue) : null
+  return literal !== null ? `z._default(${withModifier}, ${literal})` : withModifier
 }
 
 type BuildGroupedParamsSchemaOptions = {


### PR DESCRIPTION
## 🎯 Changes

An OpenAPI `default` does not always agree with the schema it sits on, and `plugin-zod` emitted it verbatim, producing a Zod schema that did not typecheck (`TS2769`):

- a `bigint` field (`format: int64`) carries a numeric default → `z.bigint().default(1)` (needs a `bigint`)
- some specs put `default: {}` on an array → `z.array(...).default({})`
- a real array default was additionally collapsed to `{}` by `formatDefault`

`.default(...)` is now type-aware, keyed off the schema AST node (`ast.narrowSchema`):

```ts
z.bigint().default(BigInt(1))            // numeric default coerced to a bigint literal
z.array(z.string()).default(["a","b"])   // array literal preserved (was `{}`)
z.array(z.string())                      // a non-array default is dropped
```

Surfaced by strict-typechecking the generated output of the repo's own `schemas/3.0.x` fixtures (tracked in #567). This clears the `TS2769` errors on `twitter` and the `bigint`/array-default cases on `digitalocean`. Added unit tests in `utils.test.ts`; the existing `plugin-zod` suite passes with no snapshot changes.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test` (plugin-zod suite passes; lint, typecheck, and format are clean).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (`@kubb/plugin-zod`: patch).
- [ ] This change is for the docs (no release).

Refs #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAfw3gfcB2XXbCuuQVrvLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAfw3gfcB2XXbCuuQVrvLB)_