### PR TITLE
Remove explicit any from source and generated examples

### DIFF
--- a/.changeset/faker-msw-no-any-output.md
+++ b/.changeset/faker-msw-no-any-output.md
@@ -1,0 +1,6 @@
+---
+"@kubb/plugin-faker": patch
+"@kubb/plugin-msw": patch
+---
+
+Drop `any` from generated output. Faker mocks type `arrayElement` element values from the schema (inferring literals for plain enums, the precise property type when nested) and emit a cyclic self-reference as `undefined as unknown as <Type>` instead of `undefined as any`. MSW handlers omit the response-body generic so it falls back to msw's `DefaultBodyType` instead of `any`. Runtime behavior is unchanged.

--- a/.changeset/redoc-template-options-unknown.md
+++ b/.changeset/redoc-template-options-unknown.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-redoc": patch
+---
+
+Type `templateOptions` on `getPageHTML` as `Record<string, unknown>` instead of `any`, so the runtime and plugin source stay free of explicit `any`. Generated output is unchanged: a schema typed `any` still emits `any`.

--- a/examples/advanced/configs/kubb.config.ts
+++ b/examples/advanced/configs/kubb.config.ts
@@ -17,12 +17,7 @@ export default defineConfig({
   input: {
     path: './petStore.yaml',
   },
-  adapter: adapterOas({
-    validate: true,
-    discriminator: 'preserve',
-    integerType: 'number',
-    enums: 'root',
-  }),
+  adapter: adapterOas({ unknownType: 'unknown', validate: true, discriminator: 'preserve', integerType: 'number', enums: 'root' }),
   output: {
     path: './src/gen',
     clean: true,

--- a/examples/advanced/src/gen/mocks/createAnimalFaker.ts
+++ b/examples/advanced/src/gen/mocks/createAnimalFaker.ts
@@ -6,7 +6,7 @@ import { fakerEN as faker } from '@faker-js/faker'
 
 export function createAnimalFaker<TData extends Partial<Animal> = object>(data?: TData) {
   const defaultFakeData = {
-    ...faker.helpers.arrayElement<any>([
+    ...faker.helpers.arrayElement([
       {
         ...createCatFaker(),
         ...{

--- a/examples/advanced/src/gen/mocks/createPetFaker.ts
+++ b/examples/advanced/src/gen/mocks/createPetFaker.ts
@@ -6,7 +6,7 @@ import { fakerEN as faker } from '@faker-js/faker'
 export function createPetFaker<TData extends Partial<Pet> = object>(data?: TData) {
   const defaultFakeData = {
     id: faker.number.int(),
-    parent: faker.helpers.multiple(() => undefined as any),
+    parent: faker.helpers.multiple(() => undefined as unknown as NonNullable<NonNullable<Pet>['parent']>[number]),
     signature: faker.helpers.fromRegExp('^data:image\/(png|jpeg|gif|webp);base64,([A-Za-z0-9+/]+={0,2})$'),
     name: faker.string.alpha(),
     url: faker.internet.url(),

--- a/examples/advanced/src/gen/mocks/pet/createAddFilesFaker.ts
+++ b/examples/advanced/src/gen/mocks/pet/createAddFilesFaker.ts
@@ -31,9 +31,9 @@ export function createAddFilesDataFakerFormData(data?: Partial<AddFilesFormData>
 }
 
 export function createAddFilesDataFaker(_data?: AddFilesData): AddFilesData {
-  return faker.helpers.arrayElement<any>([createAddFilesDataFakerJson(), createAddFilesDataFakerFormData()])
+  return faker.helpers.arrayElement([createAddFilesDataFakerJson(), createAddFilesDataFakerFormData()])
 }
 
 export function createAddFilesResponseFaker(_data?: AddFilesResponse): AddFilesResponse {
-  return faker.helpers.arrayElement<any>([createAddFilesStatus200Faker(), createAddFilesStatus405Faker()])
+  return faker.helpers.arrayElement([createAddFilesStatus200Faker(), createAddFilesStatus405Faker()])
 }

--- a/examples/advanced/src/gen/mocks/pet/createAddPetFaker.ts
+++ b/examples/advanced/src/gen/mocks/pet/createAddPetFaker.ts
@@ -45,7 +45,7 @@ export function createAddPetStatusDefaultFakerXml(data?: Partial<AddPetStatusDef
  * @description Successful operation
  */
 export function createAddPetStatusDefaultFaker(_data?: AddPetStatusDefault): AddPetStatusDefault {
-  return faker.helpers.arrayElement<any>([createAddPetStatusDefaultFakerJson(), createAddPetStatusDefaultFakerXml()])
+  return faker.helpers.arrayElement([createAddPetStatusDefaultFakerJson(), createAddPetStatusDefaultFakerXml()])
 }
 
 /**
@@ -73,9 +73,9 @@ export function createAddPetDataFakerFormUrlEncoded(data?: Partial<AddPetFormUrl
  * @description Create a new pet in the store
  */
 export function createAddPetDataFaker(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetDataFakerJson(), createAddPetDataFakerXml(), createAddPetDataFakerFormUrlEncoded()])
+  return faker.helpers.arrayElement([createAddPetDataFakerJson(), createAddPetDataFakerXml(), createAddPetDataFakerFormUrlEncoded()])
 }
 
 export function createAddPetResponseFaker(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus405Faker(), createAddPetStatusDefaultFaker()])
+  return faker.helpers.arrayElement([createAddPetStatus405Faker(), createAddPetStatusDefaultFaker()])
 }

--- a/examples/advanced/src/gen/mocks/pet/createFindPetsByStatusFaker.ts
+++ b/examples/advanced/src/gen/mocks/pet/createFindPetsByStatusFaker.ts
@@ -30,7 +30,7 @@ export function createFindPetsByStatusStatus200FakerXml(data?: FindPetsByStatusS
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200Faker(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200FakerJson(), createFindPetsByStatusStatus200FakerXml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200FakerJson(), createFindPetsByStatusStatus200FakerXml()])
 }
 
 /**
@@ -41,5 +41,5 @@ export function createFindPetsByStatusStatus400Faker() {
 }
 
 export function createFindPetsByStatusResponseFaker(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Faker(), createFindPetsByStatusStatus400Faker()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Faker(), createFindPetsByStatusStatus400Faker()])
 }

--- a/examples/advanced/src/gen/mocks/pet/createFindPetsByTagsFaker.ts
+++ b/examples/advanced/src/gen/mocks/pet/createFindPetsByTagsFaker.ts
@@ -45,7 +45,7 @@ export function createFindPetsByTagsStatus200FakerXml(data?: FindPetsByTagsStatu
  * @description successful operation
  */
 export function createFindPetsByTagsStatus200Faker(_data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByTagsStatus200FakerJson(), createFindPetsByTagsStatus200FakerXml()])
+  return faker.helpers.arrayElement([createFindPetsByTagsStatus200FakerJson(), createFindPetsByTagsStatus200FakerXml()])
 }
 
 /**
@@ -56,5 +56,5 @@ export function createFindPetsByTagsStatus400Faker() {
 }
 
 export function createFindPetsByTagsResponseFaker(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByTagsStatus200Faker(), createFindPetsByTagsStatus400Faker()])
+  return faker.helpers.arrayElement([createFindPetsByTagsStatus200Faker(), createFindPetsByTagsStatus400Faker()])
 }

--- a/examples/advanced/src/gen/mocks/pet/createGetPetByIdFaker.ts
+++ b/examples/advanced/src/gen/mocks/pet/createGetPetByIdFaker.ts
@@ -31,7 +31,7 @@ export function createGetPetByIdStatus200FakerXml(data?: Partial<GetPetByIdStatu
  * @description successful operation
  */
 export function createGetPetByIdStatus200Faker(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200FakerJson(), createGetPetByIdStatus200FakerXml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200FakerJson(), createGetPetByIdStatus200FakerXml()])
 }
 
 /**
@@ -49,5 +49,5 @@ export function createGetPetByIdStatus404Faker() {
 }
 
 export function createGetPetByIdResponseFaker(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Faker(), createGetPetByIdStatus400Faker(), createGetPetByIdStatus404Faker()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Faker(), createGetPetByIdStatus400Faker(), createGetPetByIdStatus404Faker()])
 }

--- a/examples/advanced/src/gen/mocks/pet/createUpdatePetFaker.ts
+++ b/examples/advanced/src/gen/mocks/pet/createUpdatePetFaker.ts
@@ -33,7 +33,7 @@ export function createUpdatePetStatus200FakerXml(data?: Partial<UpdatePetStatus2
  * @description Successful operation
  */
 export function createUpdatePetStatus200Faker(_data?: UpdatePetStatus200): UpdatePetStatus200 {
-  return faker.helpers.arrayElement<any>([createUpdatePetStatus200FakerJson(), createUpdatePetStatus200FakerXml()])
+  return faker.helpers.arrayElement([createUpdatePetStatus200FakerJson(), createUpdatePetStatus200FakerXml()])
 }
 
 /**
@@ -95,11 +95,11 @@ export function createUpdatePetDataFakerFormUrlEncoded(data?: Partial<UpdatePetF
  * @description Update an existent pet in the store
  */
 export function createUpdatePetDataFaker(_data?: UpdatePetData): UpdatePetData {
-  return faker.helpers.arrayElement<any>([createUpdatePetDataFakerJson(), createUpdatePetDataFakerXml(), createUpdatePetDataFakerFormUrlEncoded()])
+  return faker.helpers.arrayElement([createUpdatePetDataFakerJson(), createUpdatePetDataFakerXml(), createUpdatePetDataFakerFormUrlEncoded()])
 }
 
 export function createUpdatePetResponseFaker(_data?: UpdatePetResponse): UpdatePetResponse {
-  return faker.helpers.arrayElement<any>([
+  return faker.helpers.arrayElement([
     createUpdatePetStatus200Faker(),
     createUpdatePetStatus202Faker(),
     createUpdatePetStatus400Faker(),

--- a/examples/advanced/src/gen/mocks/pets/createCreatePetsFaker.ts
+++ b/examples/advanced/src/gen/mocks/pets/createCreatePetsFaker.ts
@@ -53,5 +53,5 @@ export function createCreatePetsDataFaker<TData extends Partial<CreatePetsData> 
 }
 
 export function createCreatePetsResponseFaker(_data?: CreatePetsResponse): CreatePetsResponse {
-  return faker.helpers.arrayElement<any>([createCreatePetsStatus201Faker(), createCreatePetsStatusDefaultFaker()])
+  return faker.helpers.arrayElement([createCreatePetsStatus201Faker(), createCreatePetsStatusDefaultFaker()])
 }

--- a/examples/advanced/src/gen/models/ts/pet/AddFiles.ts
+++ b/examples/advanced/src/gen/models/ts/pet/AddFiles.ts
@@ -6,9 +6,9 @@ import type { Pet } from '../Pet.ts'
 export type AddFilesStatus200 = Omit<NonNullable<Pet>, 'name'>
 
 /**
- * @type any
+ * @type unknown
  */
-export type AddFilesStatus405 = any
+export type AddFilesStatus405 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/pet/DeletePet.ts
+++ b/examples/advanced/src/gen/models/ts/pet/DeletePet.ts
@@ -12,9 +12,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = number
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/pet/FindPetsByStatus.ts
+++ b/examples/advanced/src/gen/models/ts/pet/FindPetsByStatus.ts
@@ -18,9 +18,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/pet/FindPetsByTags.ts
+++ b/examples/advanced/src/gen/models/ts/pet/FindPetsByTags.ts
@@ -37,9 +37,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/pet/GetPetById.ts
+++ b/examples/advanced/src/gen/models/ts/pet/GetPetById.ts
@@ -21,14 +21,14 @@ export type GetPetByIdStatus200Xml = Omit<NonNullable<Pet>, 'name'>
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/pet/UpdatePet.ts
+++ b/examples/advanced/src/gen/models/ts/pet/UpdatePet.ts
@@ -26,19 +26,19 @@ export type UpdatePetStatus202 = {
 }
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/advanced/src/gen/models/ts/pet/UpdatePetWithForm.ts
+++ b/examples/advanced/src/gen/models/ts/pet/UpdatePetWithForm.ts
@@ -19,9 +19,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/pets/CreatePets.ts
+++ b/examples/advanced/src/gen/models/ts/pets/CreatePets.ts
@@ -22,13 +22,13 @@ export type CreatePetsQueryOffset = number | undefined
 export type CreatePetsHeaderXEXAMPLE = CreatePetsXEXAMPLEKey
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreatePetsStatus201 = any
+export type CreatePetsStatus201 = unknown
 
 /**
  * @description Pet not found
- * @type any
+ * @type unknown
  */
 export type CreatePetsStatusDefault = PetNotFound
 

--- a/examples/advanced/src/gen/models/ts/store/DeleteOrder.ts
+++ b/examples/advanced/src/gen/models/ts/store/DeleteOrder.ts
@@ -7,14 +7,14 @@
 export type DeleteOrderPathOrderId = number
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/store/GetOrderById.ts
+++ b/examples/advanced/src/gen/models/ts/store/GetOrderById.ts
@@ -21,14 +21,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/advanced/src/gen/models/ts/store/PlaceOrder.ts
+++ b/examples/advanced/src/gen/models/ts/store/PlaceOrder.ts
@@ -6,9 +6,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/advanced/src/gen/models/ts/store/PlaceOrderPatch.ts
+++ b/examples/advanced/src/gen/models/ts/store/PlaceOrderPatch.ts
@@ -6,9 +6,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/advanced/src/gen/msw/pet/addFilesHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/addFilesHandler.ts
@@ -11,14 +11,17 @@ export function addFilesHandlerResponse200(data: AddFilesResponse) {
   })
 }
 
-export function addFilesHandlerResponse405(data?: AddFilesStatus405) {
+export function addFilesHandlerResponse405(data: AddFilesStatus405) {
   return new Response(JSON.stringify(data), {
     status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function addFilesHandler(data?: AddFilesResponse | HttpResponseResolver<Record<string, string>, AddFilesData, any>) {
-  return http.post<Record<string, string>, AddFilesData, any>(`/pet/files`, function handler(info) {
+export function addFilesHandler(data?: AddFilesResponse | HttpResponseResolver<Record<string, string>, AddFilesData>) {
+  return http.post<Record<string, string>, AddFilesData>(`/pet/files`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/advanced/src/gen/msw/pet/addPetHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/addPetHandler.ts
@@ -11,8 +11,8 @@ export function addPetHandlerResponse405(data: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
+export function addPetHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/advanced/src/gen/msw/pet/deletePetHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/deletePetHandler.ts
@@ -1,9 +1,12 @@
 import type { DeletePetStatus400 } from '../../models/ts/pet/DeletePet.ts'
 import { http } from 'msw'
 
-export function deletePetHandlerResponse400(data?: DeletePetStatus400) {
+export function deletePetHandlerResponse400(data: DeletePetStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/advanced/src/gen/msw/pet/findPetsByStatusHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/findPetsByStatusHandler.ts
@@ -10,9 +10,12 @@ export function findPetsByStatusHandlerResponse200(data: FindPetsByStatusRespons
   })
 }
 
-export function findPetsByStatusHandlerResponse400(data?: FindPetsByStatusStatus400) {
+export function findPetsByStatusHandlerResponse400(data: FindPetsByStatusStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/advanced/src/gen/msw/pet/findPetsByTagsHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/findPetsByTagsHandler.ts
@@ -10,9 +10,12 @@ export function findPetsByTagsHandlerResponse200(data: FindPetsByTagsResponse) {
   })
 }
 
-export function findPetsByTagsHandlerResponse400(data?: FindPetsByTagsStatus400) {
+export function findPetsByTagsHandlerResponse400(data: FindPetsByTagsStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/advanced/src/gen/msw/pet/getPetByIdHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/getPetByIdHandler.ts
@@ -10,15 +10,21 @@ export function getPetByIdHandlerResponse200(data: GetPetByIdResponse) {
   })
 }
 
-export function getPetByIdHandlerResponse400(data?: GetPetByIdStatus400) {
+export function getPetByIdHandlerResponse400(data: GetPetByIdStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function getPetByIdHandlerResponse404(data?: GetPetByIdStatus404) {
+export function getPetByIdHandlerResponse404(data: GetPetByIdStatus404) {
   return new Response(JSON.stringify(data), {
     status: 404,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/advanced/src/gen/msw/pet/updatePetHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/updatePetHandler.ts
@@ -20,26 +20,35 @@ export function updatePetHandlerResponse202(data: UpdatePetResponse) {
   })
 }
 
-export function updatePetHandlerResponse400(data?: UpdatePetStatus400) {
+export function updatePetHandlerResponse400(data: UpdatePetStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function updatePetHandlerResponse404(data?: UpdatePetStatus404) {
+export function updatePetHandlerResponse404(data: UpdatePetStatus404) {
   return new Response(JSON.stringify(data), {
     status: 404,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
+export function updatePetHandlerResponse405(data: UpdatePetStatus405) {
   return new Response(JSON.stringify(data), {
     status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
-  return http.put<Record<string, string>, UpdatePetData, any>(`/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData>) {
+  return http.put<Record<string, string>, UpdatePetData>(`/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/advanced/src/gen/msw/pet/updatePetWithFormHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/updatePetWithFormHandler.ts
@@ -1,9 +1,12 @@
 import type { UpdatePetWithFormStatus405 } from '../../models/ts/pet/UpdatePetWithForm.ts'
 import { http } from 'msw'
 
-export function updatePetWithFormHandlerResponse405(data?: UpdatePetWithFormStatus405) {
+export function updatePetWithFormHandlerResponse405(data: UpdatePetWithFormStatus405) {
   return new Response(JSON.stringify(data), {
     status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/advanced/src/gen/msw/pet/uploadFileHandler.ts
+++ b/examples/advanced/src/gen/msw/pet/uploadFileHandler.ts
@@ -11,8 +11,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/advanced/src/gen/msw/pets/createPetsHandler.ts
+++ b/examples/advanced/src/gen/msw/pets/createPetsHandler.ts
@@ -2,18 +2,24 @@ import type { CreatePetsResponse, CreatePetsData } from '../../models/ts/pets/Cr
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
-export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
+export function createPetsHandlerResponse201(data: CreatePetsResponse) {
   return new Response(JSON.stringify(data), {
     status: 201,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function createPetsHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreatePetsData, any>) {
-  return http.post<Record<string, string>, CreatePetsData, any>(`/pets/:uuid`, function handler(info) {
+export function createPetsHandler(data?: CreatePetsResponse | HttpResponseResolver<Record<string, string>, CreatePetsData>) {
+  return http.post<Record<string, string>, CreatePetsData>(`/pets/:uuid`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {
       status: 201,
+      headers: {
+        'Content-Type': 'application/json',
+      },
     })
   })
 }

--- a/examples/advanced/src/gen/zod/pet/addFilesSchema.ts
+++ b/examples/advanced/src/gen/zod/pet/addFilesSchema.ts
@@ -5,7 +5,7 @@ export const addFilesStatus200Schema = z.lazy(() => petSchema.omit({ name: true 
 
 export type AddFilesStatus200SchemaType = z.infer<typeof addFilesStatus200Schema>
 
-export const addFilesStatus405Schema = z.any()
+export const addFilesStatus405Schema = z.unknown()
 
 export type AddFilesStatus405SchemaType = z.infer<typeof addFilesStatus405Schema>
 

--- a/examples/advanced/src/gen/zod/pet/deletePetSchema.ts
+++ b/examples/advanced/src/gen/zod/pet/deletePetSchema.ts
@@ -8,7 +8,7 @@ export const deletePetPathPetIdSchema = z.int().describe('Pet id to delete')
 
 export type DeletePetPathPetIdSchemaType = z.infer<typeof deletePetPathPetIdSchema>
 
-export const deletePetStatus400Schema = z.any()
+export const deletePetStatus400Schema = z.unknown()
 
 export type DeletePetStatus400SchemaType = z.infer<typeof deletePetStatus400Schema>
 

--- a/examples/advanced/src/gen/zod/pet/findPetsByStatusSchema.ts
+++ b/examples/advanced/src/gen/zod/pet/findPetsByStatusSchema.ts
@@ -21,7 +21,7 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 
 export type FindPetsByStatusStatus200SchemaType = z.infer<typeof findPetsByStatusStatus200Schema>
 
-export const findPetsByStatusStatus400Schema = z.any()
+export const findPetsByStatusStatus400Schema = z.unknown()
 
 export type FindPetsByStatusStatus400SchemaType = z.infer<typeof findPetsByStatusStatus400Schema>
 

--- a/examples/advanced/src/gen/zod/pet/findPetsByTagsSchema.ts
+++ b/examples/advanced/src/gen/zod/pet/findPetsByTagsSchema.ts
@@ -30,7 +30,7 @@ export const findPetsByTagsStatus200Schema = z.union([findPetsByTagsStatus200Sch
 
 export type FindPetsByTagsStatus200SchemaType = z.infer<typeof findPetsByTagsStatus200Schema>
 
-export const findPetsByTagsStatus400Schema = z.any()
+export const findPetsByTagsStatus400Schema = z.unknown()
 
 export type FindPetsByTagsStatus400SchemaType = z.infer<typeof findPetsByTagsStatus400Schema>
 

--- a/examples/advanced/src/gen/zod/pet/getPetByIdSchema.ts
+++ b/examples/advanced/src/gen/zod/pet/getPetByIdSchema.ts
@@ -17,11 +17,11 @@ export const getPetByIdStatus200Schema = z.union([getPetByIdStatus200SchemaJson,
 
 export type GetPetByIdStatus200SchemaType = z.infer<typeof getPetByIdStatus200Schema>
 
-export const getPetByIdStatus400Schema = z.any()
+export const getPetByIdStatus400Schema = z.unknown()
 
 export type GetPetByIdStatus400SchemaType = z.infer<typeof getPetByIdStatus400Schema>
 
-export const getPetByIdStatus404Schema = z.any()
+export const getPetByIdStatus404Schema = z.unknown()
 
 export type GetPetByIdStatus404SchemaType = z.infer<typeof getPetByIdStatus404Schema>
 

--- a/examples/advanced/src/gen/zod/pet/updatePetSchema.ts
+++ b/examples/advanced/src/gen/zod/pet/updatePetSchema.ts
@@ -22,15 +22,15 @@ export const updatePetStatus202Schema = z.object({
 
 export type UpdatePetStatus202SchemaType = z.infer<typeof updatePetStatus202Schema>
 
-export const updatePetStatus400Schema = z.any()
+export const updatePetStatus400Schema = z.unknown()
 
 export type UpdatePetStatus400SchemaType = z.infer<typeof updatePetStatus400Schema>
 
-export const updatePetStatus404Schema = z.any()
+export const updatePetStatus404Schema = z.unknown()
 
 export type UpdatePetStatus404SchemaType = z.infer<typeof updatePetStatus404Schema>
 
-export const updatePetStatus405Schema = z.any()
+export const updatePetStatus405Schema = z.unknown()
 
 export type UpdatePetStatus405SchemaType = z.infer<typeof updatePetStatus405Schema>
 

--- a/examples/advanced/src/gen/zod/pet/updatePetWithFormSchema.ts
+++ b/examples/advanced/src/gen/zod/pet/updatePetWithFormSchema.ts
@@ -12,7 +12,7 @@ export const updatePetWithFormQueryStatusSchema = z.string().optional().describe
 
 export type UpdatePetWithFormQueryStatusSchemaType = z.infer<typeof updatePetWithFormQueryStatusSchema>
 
-export const updatePetWithFormStatus405Schema = z.any()
+export const updatePetWithFormStatus405Schema = z.unknown()
 
 export type UpdatePetWithFormStatus405SchemaType = z.infer<typeof updatePetWithFormStatus405Schema>
 

--- a/examples/advanced/src/gen/zod/pets/createPetsSchema.ts
+++ b/examples/advanced/src/gen/zod/pets/createPetsSchema.ts
@@ -19,7 +19,7 @@ export const createPetsHeaderXEXAMPLESchema = createPetsXEXAMPLESchema.describe(
 
 export type CreatePetsHeaderXEXAMPLESchemaType = z.infer<typeof createPetsHeaderXEXAMPLESchema>
 
-export const createPetsStatus201Schema = z.any()
+export const createPetsStatus201Schema = z.unknown()
 
 export type CreatePetsStatus201SchemaType = z.infer<typeof createPetsStatus201Schema>
 

--- a/examples/axios/kubb.config.ts
+++ b/examples/axios/kubb.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(() => {
       lint: false,
     },
     adapter: adapterOas({
+      unknownType: 'unknown',
       server: {
         index: 0,
       },

--- a/examples/axios/src/gen/models/pet/DeletePet.ts
+++ b/examples/axios/src/gen/models/pet/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/axios/src/gen/models/pet/FindPetsByStatus.ts
@@ -33,9 +33,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/axios/src/gen/models/pet/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/pet/GetPetById.ts
+++ b/examples/axios/src/gen/models/pet/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/pet/UpdatePet.ts
+++ b/examples/axios/src/gen/models/pet/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/axios/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/axios/src/gen/models/pet/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/store/DeleteOrder.ts
+++ b/examples/axios/src/gen/models/store/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/store/GetOrderById.ts
+++ b/examples/axios/src/gen/models/store/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/store/PlaceOrder.ts
+++ b/examples/axios/src/gen/models/store/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/axios/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/axios/src/gen/models/store/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/axios/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/axios/src/gen/models/user/CreateUsersWithListInput.ts
@@ -18,9 +18,9 @@ export type CreateUsersWithListInputStatus200Xml = User
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreateUsersWithListInputStatusDefault = any
+export type CreateUsersWithListInputStatusDefault = unknown
 
 /**
  * @type array | undefined

--- a/examples/axios/src/gen/models/user/DeleteUser.ts
+++ b/examples/axios/src/gen/models/user/DeleteUser.ts
@@ -10,14 +10,14 @@
 export type DeleteUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus400 = any
+export type DeleteUserStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus404 = any
+export type DeleteUserStatus404 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/user/GetUserByName.ts
+++ b/examples/axios/src/gen/models/user/GetUserByName.ts
@@ -24,14 +24,14 @@ export type GetUserByNameStatus200Xml = User
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus400 = any
+export type GetUserByNameStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus404 = any
+export type GetUserByNameStatus404 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/user/LoginUser.ts
+++ b/examples/axios/src/gen/models/user/LoginUser.ts
@@ -28,9 +28,9 @@ export type LoginUserStatus200Json = string
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
 /**
- * @type any
+ * @type unknown
  */
-export type LoginUserStatus400 = any
+export type LoginUserStatus400 = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/user/LogoutUser.ts
+++ b/examples/axios/src/gen/models/user/LogoutUser.ts
@@ -4,9 +4,9 @@
  */
 
 /**
- * @type any
+ * @type unknown
  */
-export type LogoutUserStatusDefault = any
+export type LogoutUserStatusDefault = unknown
 
 /**
  * @type object

--- a/examples/axios/src/gen/models/user/UpdateUser.ts
+++ b/examples/axios/src/gen/models/user/UpdateUser.ts
@@ -12,9 +12,9 @@ import type { User } from '../User.ts'
 export type UpdateUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdateUserStatusDefault = any
+export type UpdateUserStatusDefault = unknown
 
 /**
  * @description Update an existent user in the store

--- a/examples/cypress/kubb.config.js
+++ b/examples/cypress/kubb.config.js
@@ -1,3 +1,4 @@
+import { adapterOas } from '@kubb/adapter-oas'
 import { pluginCypress } from '@kubb/plugin-cypress'
 import { pluginTs } from '@kubb/plugin-ts'
 import { defineConfig } from 'kubb'
@@ -7,6 +8,7 @@ export default defineConfig([
   {
     root: '.',
     input,
+    adapter: adapterOas({ unknownType: 'unknown' }),
     output: {
       path: './src/gen',
       clean: true,
@@ -38,6 +40,7 @@ export default defineConfig([
   {
     root: '.',
     input,
+    adapter: adapterOas({ unknownType: 'unknown' }),
     output: { path: './src/gen-v4', clean: true },
     plugins: [
       pluginTs({

--- a/examples/cypress/package.json
+++ b/examples/cypress/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@kubb/adapter-oas": "catalog:",
     "@kubb/plugin-cypress": "workspace:*",
     "@kubb/plugin-ts": "workspace:*",
     "kubb": "catalog:",

--- a/examples/cypress/src/gen-v4/models.ts
+++ b/examples/cypress/src/gen-v4/models.ts
@@ -237,19 +237,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -422,9 +422,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -485,9 +485,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -540,14 +540,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -599,9 +599,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -650,9 +650,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -777,9 +777,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -827,9 +827,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -892,14 +892,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -939,14 +939,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/cypress/src/gen/models.ts
+++ b/examples/cypress/src/gen/models.ts
@@ -237,19 +237,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -422,9 +422,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -485,9 +485,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -540,14 +540,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -599,9 +599,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -650,9 +650,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -777,9 +777,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -827,9 +827,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -892,14 +892,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -939,14 +939,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/faker/kubb.config.cjs
+++ b/examples/faker/kubb.config.cjs
@@ -17,7 +17,7 @@ module.exports = defineConfig(() => {
         format: false,
         clean: true,
       },
-      adapter: adapterOas(),
+      adapter: adapterOas({ unknownType: 'unknown' }),
       hooks: {
         done: ['npm run typecheck'],
       },
@@ -52,7 +52,7 @@ module.exports = defineConfig(() => {
         lint: false,
         format: false,
       },
-      adapter: adapterOas(),
+      adapter: adapterOas({ unknownType: 'unknown' }),
       hooks: {
         done: ['npm run typecheck'],
       },

--- a/examples/faker/src/gen/faker/createUpdatePet.ts
+++ b/examples/faker/src/gen/faker/createUpdatePet.ts
@@ -37,7 +37,7 @@ export function createUpdatePetStatus200Xml(data?: Partial<UpdatePetStatus200Xml
  * @description Successful operation
  */
 export function createUpdatePetStatus200(_data?: UpdatePetStatus200): UpdatePetStatus200 {
-  return faker.helpers.arrayElement<any>([createUpdatePetStatus200Json(), createUpdatePetStatus200Xml()])
+  return faker.helpers.arrayElement([createUpdatePetStatus200Json(), createUpdatePetStatus200Xml()])
 }
 
 /**
@@ -86,9 +86,9 @@ export function createUpdatePetFormUrlEncodedData(data?: Partial<UpdatePetFormUr
  * @description Update an existent pet in the store
  */
 export function createUpdatePetData(_data?: UpdatePetData): UpdatePetData {
-  return faker.helpers.arrayElement<any>([createUpdatePetJsonData(), createUpdatePetXmlData(), createUpdatePetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createUpdatePetJsonData(), createUpdatePetXmlData(), createUpdatePetFormUrlEncodedData()])
 }
 
 export function createUpdatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
-  return faker.helpers.arrayElement<any>([createUpdatePetStatus200(), createUpdatePetStatus400(), createUpdatePetStatus404(), createUpdatePetStatus405()])
+  return faker.helpers.arrayElement([createUpdatePetStatus200(), createUpdatePetStatus400(), createUpdatePetStatus404(), createUpdatePetStatus405()])
 }

--- a/examples/faker/src/gen/models/AddPet.ts
+++ b/examples/faker/src/gen/models/AddPet.ts
@@ -18,9 +18,9 @@ export type AddPetStatus200Xml = Pet
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type AddPetStatus405 = any
+export type AddPetStatus405 = unknown
 
 /**
  * @description Create a new pet in the store

--- a/examples/faker/src/gen/models/DeleteOrder.ts
+++ b/examples/faker/src/gen/models/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/faker/src/gen/models/DeletePet.ts
+++ b/examples/faker/src/gen/models/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/faker/src/gen/models/FindPetsByStatus.ts
+++ b/examples/faker/src/gen/models/FindPetsByStatus.ts
@@ -33,9 +33,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/faker/src/gen/models/FindPetsByTags.ts
+++ b/examples/faker/src/gen/models/FindPetsByTags.ts
@@ -24,9 +24,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/faker/src/gen/models/GetOrderById.ts
+++ b/examples/faker/src/gen/models/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/faker/src/gen/models/GetPetById.ts
+++ b/examples/faker/src/gen/models/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/faker/src/gen/models/PlaceOrder.ts
+++ b/examples/faker/src/gen/models/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/faker/src/gen/models/UpdatePet.ts
+++ b/examples/faker/src/gen/models/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/faker/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/faker/src/gen/models/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/faker/src/gen/tag/createDeleteOrder.ts
+++ b/examples/faker/src/gen/tag/createDeleteOrder.ts
@@ -25,5 +25,5 @@ export function createDeleteOrderStatus404() {
 }
 
 export function createDeleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
-  return faker.helpers.arrayElement<any>([createDeleteOrderStatus400(), createDeleteOrderStatus404()])
+  return faker.helpers.arrayElement([createDeleteOrderStatus400(), createDeleteOrderStatus404()])
 }

--- a/examples/faker/src/gen/tag/createGetOrderById.ts
+++ b/examples/faker/src/gen/tag/createGetOrderById.ts
@@ -36,7 +36,7 @@ export function createGetOrderByIdStatus200Xml(data?: Partial<GetOrderByIdStatus
  * @description successful operation
  */
 export function createGetOrderByIdStatus200(_data?: GetOrderByIdStatus200): GetOrderByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetOrderByIdStatus200Json(), createGetOrderByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetOrderByIdStatus200Json(), createGetOrderByIdStatus200Xml()])
 }
 
 /**
@@ -54,5 +54,5 @@ export function createGetOrderByIdStatus404() {
 }
 
 export function createGetOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetOrderByIdStatus200(), createGetOrderByIdStatus400(), createGetOrderByIdStatus404()])
+  return faker.helpers.arrayElement([createGetOrderByIdStatus200(), createGetOrderByIdStatus400(), createGetOrderByIdStatus404()])
 }

--- a/examples/faker/src/gen/tag/createPlaceOrder.ts
+++ b/examples/faker/src/gen/tag/createPlaceOrder.ts
@@ -42,9 +42,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/examples/fetch/kubb.config.ts
+++ b/examples/fetch/kubb.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(() => {
       format: false,
       lint: false,
     },
-    adapter: adapterOas({ server: { index: 0 } }),
+    adapter: adapterOas({ unknownType: 'unknown', server: { index: 0 } }),
     plugins: [
       pluginTs({
         output: { path: 'models', barrel: { type: 'named' } },

--- a/examples/fetch/src/gen/models/pet/DeletePet.ts
+++ b/examples/fetch/src/gen/models/pet/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/fetch/src/gen/models/pet/FindPetsByStatus.ts
@@ -33,9 +33,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/fetch/src/gen/models/pet/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/pet/GetPetById.ts
+++ b/examples/fetch/src/gen/models/pet/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/pet/UpdatePet.ts
+++ b/examples/fetch/src/gen/models/pet/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/fetch/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/fetch/src/gen/models/pet/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/store/DeleteOrder.ts
+++ b/examples/fetch/src/gen/models/store/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/store/GetOrderById.ts
+++ b/examples/fetch/src/gen/models/store/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/store/PlaceOrder.ts
+++ b/examples/fetch/src/gen/models/store/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/fetch/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/fetch/src/gen/models/store/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/fetch/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/fetch/src/gen/models/user/CreateUsersWithListInput.ts
@@ -18,9 +18,9 @@ export type CreateUsersWithListInputStatus200Xml = User
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreateUsersWithListInputStatusDefault = any
+export type CreateUsersWithListInputStatusDefault = unknown
 
 /**
  * @type array | undefined

--- a/examples/fetch/src/gen/models/user/DeleteUser.ts
+++ b/examples/fetch/src/gen/models/user/DeleteUser.ts
@@ -10,14 +10,14 @@
 export type DeleteUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus400 = any
+export type DeleteUserStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus404 = any
+export type DeleteUserStatus404 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/user/GetUserByName.ts
+++ b/examples/fetch/src/gen/models/user/GetUserByName.ts
@@ -24,14 +24,14 @@ export type GetUserByNameStatus200Xml = User
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus400 = any
+export type GetUserByNameStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus404 = any
+export type GetUserByNameStatus404 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/user/LoginUser.ts
+++ b/examples/fetch/src/gen/models/user/LoginUser.ts
@@ -28,9 +28,9 @@ export type LoginUserStatus200Json = string
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
 /**
- * @type any
+ * @type unknown
  */
-export type LoginUserStatus400 = any
+export type LoginUserStatus400 = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/user/LogoutUser.ts
+++ b/examples/fetch/src/gen/models/user/LogoutUser.ts
@@ -4,9 +4,9 @@
  */
 
 /**
- * @type any
+ * @type unknown
  */
-export type LogoutUserStatusDefault = any
+export type LogoutUserStatusDefault = unknown
 
 /**
  * @type object

--- a/examples/fetch/src/gen/models/user/UpdateUser.ts
+++ b/examples/fetch/src/gen/models/user/UpdateUser.ts
@@ -12,9 +12,9 @@ import type { User } from '../User.ts'
 export type UpdateUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdateUserStatusDefault = any
+export type UpdateUserStatusDefault = unknown
 
 /**
  * @description Update an existent user in the store

--- a/examples/mcp/kubb.config.ts
+++ b/examples/mcp/kubb.config.ts
@@ -11,7 +11,7 @@ export default defineConfig(() => {
     input: {
       path: './petStore.yaml',
     },
-    adapter: adapterOas({ validate: false, integerType: 'number', enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, integerType: 'number', enums: 'root' }),
     hooks: {
       done: ['npm run typecheck', 'oxfmt ./', 'oxlint --fix ./src'],
     },

--- a/examples/mcp/src/gen/models/ts/AddFiles.ts
+++ b/examples/mcp/src/gen/models/ts/AddFiles.ts
@@ -11,9 +11,9 @@ import type { Pet } from './Pet.js'
 export type AddFilesStatus200 = Omit<NonNullable<Pet>, 'name'>
 
 /**
- * @type any
+ * @type unknown
  */
-export type AddFilesStatus405 = any
+export type AddFilesStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/mcp/src/gen/models/ts/CreatePets.ts
+++ b/examples/mcp/src/gen/models/ts/CreatePets.ts
@@ -24,13 +24,13 @@ export type CreatePetsQueryOffset = number | undefined
 export type CreatePetsHeaderXEXAMPLE = CreatePetsXEXAMPLEKey
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreatePetsStatus201 = any
+export type CreatePetsStatus201 = unknown
 
 /**
  * @description Pet not found
- * @type any
+ * @type unknown
  */
 export type CreatePetsStatusDefault = PetNotFound
 

--- a/examples/mcp/src/gen/models/ts/DeleteOrder.ts
+++ b/examples/mcp/src/gen/models/ts/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = number
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/mcp/src/gen/models/ts/DeletePet.ts
+++ b/examples/mcp/src/gen/models/ts/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = number
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/mcp/src/gen/models/ts/FindPetsByStatus.ts
+++ b/examples/mcp/src/gen/models/ts/FindPetsByStatus.ts
@@ -23,9 +23,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/mcp/src/gen/models/ts/FindPetsByTags.ts
+++ b/examples/mcp/src/gen/models/ts/FindPetsByTags.ts
@@ -42,9 +42,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/mcp/src/gen/models/ts/GetOrderById.ts
+++ b/examples/mcp/src/gen/models/ts/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/mcp/src/gen/models/ts/GetPetById.ts
+++ b/examples/mcp/src/gen/models/ts/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Omit<NonNullable<Pet>, 'name'>
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/mcp/src/gen/models/ts/PlaceOrder.ts
+++ b/examples/mcp/src/gen/models/ts/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.js'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/mcp/src/gen/models/ts/PlaceOrderPatch.ts
+++ b/examples/mcp/src/gen/models/ts/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.js'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/mcp/src/gen/models/ts/UpdatePet.ts
+++ b/examples/mcp/src/gen/models/ts/UpdatePet.ts
@@ -31,19 +31,19 @@ export type UpdatePetStatus202 = {
 }
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/mcp/src/gen/models/ts/UpdatePetWithForm.ts
+++ b/examples/mcp/src/gen/models/ts/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/mcp/src/gen/zod/addFilesSchema.ts
+++ b/examples/mcp/src/gen/zod/addFilesSchema.ts
@@ -8,7 +8,7 @@ import { petSchema } from './petSchema.js'
 
 export const addFilesStatus200Schema = petSchema.omit({ name: true })
 
-export const addFilesStatus405Schema = z.any()
+export const addFilesStatus405Schema = z.unknown()
 
 export const addFilesResponseSchema = addFilesStatus200Schema
 

--- a/examples/mcp/src/gen/zod/createPetsSchema.ts
+++ b/examples/mcp/src/gen/zod/createPetsSchema.ts
@@ -13,7 +13,7 @@ export const createPetsQueryOffsetSchema = z.int().optional().describe('Offset *
 
 export const createPetsHeaderXEXAMPLESchema = createPetsXEXAMPLESchema.describe('Header parameters')
 
-export const createPetsStatus201Schema = z.any()
+export const createPetsStatus201Schema = z.unknown()
 
 export const createPetsStatusDefaultSchema = petNotFoundSchema.describe('Pet not found')
 

--- a/examples/mcp/src/gen/zod/deleteOrderSchema.ts
+++ b/examples/mcp/src/gen/zod/deleteOrderSchema.ts
@@ -7,9 +7,9 @@ import * as z from 'zod'
 
 export const deleteOrderPathOrderIdSchema = z.int().describe('ID of the order that needs to be deleted')
 
-export const deleteOrderStatus400Schema = z.any()
+export const deleteOrderStatus400Schema = z.unknown()
 
-export const deleteOrderStatus404Schema = z.any()
+export const deleteOrderStatus404Schema = z.unknown()
 
 export const deleteOrderResponseSchema = z.unknown()
 

--- a/examples/mcp/src/gen/zod/deletePetSchema.ts
+++ b/examples/mcp/src/gen/zod/deletePetSchema.ts
@@ -9,7 +9,7 @@ export const deletePetHeaderApiKeySchema = z.string().optional()
 
 export const deletePetPathPetIdSchema = z.int().describe('Pet id to delete')
 
-export const deletePetStatus400Schema = z.any()
+export const deletePetStatus400Schema = z.unknown()
 
 export const deletePetResponseSchema = z.unknown()
 

--- a/examples/mcp/src/gen/zod/findPetsByStatusSchema.ts
+++ b/examples/mcp/src/gen/zod/findPetsByStatusSchema.ts
@@ -18,7 +18,7 @@ export const findPetsByStatusStatus200SchemaXml = z.array(petSchema)
 
 export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus200SchemaJson, findPetsByStatusStatus200SchemaXml])
 
-export const findPetsByStatusStatus400Schema = z.any()
+export const findPetsByStatusStatus400Schema = z.unknown()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
 

--- a/examples/mcp/src/gen/zod/findPetsByTagsSchema.ts
+++ b/examples/mcp/src/gen/zod/findPetsByTagsSchema.ts
@@ -21,7 +21,7 @@ export const findPetsByTagsStatus200SchemaXml = z.array(petSchema)
 
 export const findPetsByTagsStatus200Schema = z.union([findPetsByTagsStatus200SchemaJson, findPetsByTagsStatus200SchemaXml])
 
-export const findPetsByTagsStatus400Schema = z.any()
+export const findPetsByTagsStatus400Schema = z.unknown()
 
 export const findPetsByTagsResponseSchema = findPetsByTagsStatus200Schema
 

--- a/examples/mcp/src/gen/zod/getOrderByIdSchema.ts
+++ b/examples/mcp/src/gen/zod/getOrderByIdSchema.ts
@@ -14,9 +14,9 @@ export const getOrderByIdStatus200SchemaXml = orderSchema
 
 export const getOrderByIdStatus200Schema = z.union([getOrderByIdStatus200SchemaJson, getOrderByIdStatus200SchemaXml])
 
-export const getOrderByIdStatus400Schema = z.any()
+export const getOrderByIdStatus400Schema = z.unknown()
 
-export const getOrderByIdStatus404Schema = z.any()
+export const getOrderByIdStatus404Schema = z.unknown()
 
 export const getOrderByIdResponseSchema = getOrderByIdStatus200Schema
 

--- a/examples/mcp/src/gen/zod/getPetByIdSchema.ts
+++ b/examples/mcp/src/gen/zod/getPetByIdSchema.ts
@@ -14,9 +14,9 @@ export const getPetByIdStatus200SchemaXml = petSchema.omit({ name: true })
 
 export const getPetByIdStatus200Schema = z.union([getPetByIdStatus200SchemaJson, getPetByIdStatus200SchemaXml])
 
-export const getPetByIdStatus400Schema = z.any()
+export const getPetByIdStatus400Schema = z.unknown()
 
-export const getPetByIdStatus404Schema = z.any()
+export const getPetByIdStatus404Schema = z.unknown()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
 

--- a/examples/mcp/src/gen/zod/placeOrderPatchSchema.ts
+++ b/examples/mcp/src/gen/zod/placeOrderPatchSchema.ts
@@ -8,7 +8,7 @@ import { orderSchema } from './orderSchema.js'
 
 export const placeOrderPatchStatus200Schema = orderSchema
 
-export const placeOrderPatchStatus405Schema = z.any()
+export const placeOrderPatchStatus405Schema = z.unknown()
 
 export const placeOrderPatchResponseSchema = placeOrderPatchStatus200Schema
 

--- a/examples/mcp/src/gen/zod/placeOrderSchema.ts
+++ b/examples/mcp/src/gen/zod/placeOrderSchema.ts
@@ -8,7 +8,7 @@ import { orderSchema } from './orderSchema.js'
 
 export const placeOrderStatus200Schema = orderSchema
 
-export const placeOrderStatus405Schema = z.any()
+export const placeOrderStatus405Schema = z.unknown()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 

--- a/examples/mcp/src/gen/zod/updatePetSchema.ts
+++ b/examples/mcp/src/gen/zod/updatePetSchema.ts
@@ -19,11 +19,11 @@ export const updatePetStatus202Schema = z.object({
     .meta({ examples: [10] }),
 })
 
-export const updatePetStatus400Schema = z.any()
+export const updatePetStatus400Schema = z.unknown()
 
-export const updatePetStatus404Schema = z.any()
+export const updatePetStatus404Schema = z.unknown()
 
-export const updatePetStatus405Schema = z.any()
+export const updatePetStatus405Schema = z.unknown()
 
 export const updatePetResponseSchema = z.union([updatePetStatus200Schema, updatePetStatus202Schema])
 

--- a/examples/mcp/src/gen/zod/updatePetWithFormSchema.ts
+++ b/examples/mcp/src/gen/zod/updatePetWithFormSchema.ts
@@ -11,7 +11,7 @@ export const updatePetWithFormQueryNameSchema = z.string().optional().describe('
 
 export const updatePetWithFormQueryStatusSchema = z.string().optional().describe('Status of pet that needs to be updated')
 
-export const updatePetWithFormStatus405Schema = z.any()
+export const updatePetWithFormStatus405Schema = z.unknown()
 
 export const updatePetWithFormResponseSchema = z.unknown()
 

--- a/examples/msw/kubb.config.js
+++ b/examples/msw/kubb.config.js
@@ -19,7 +19,7 @@ export default defineConfig(() => {
     hooks: {
       done: ['npm run typecheck'],
     },
-    adapter: adapterOas({ collisionDetection: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', collisionDetection: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {

--- a/examples/msw/src/gen/mocks/pet/createAddPet.ts
+++ b/examples/msw/src/gen/mocks/pet/createAddPet.ts
@@ -42,7 +42,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -93,11 +93,11 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
 export function createAddPetData(_data?: AddPetData): AddPetData {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/examples/msw/src/gen/mocks/pet/createFindPetsByStatus.ts
+++ b/examples/msw/src/gen/mocks/pet/createFindPetsByStatus.ts
@@ -45,7 +45,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -60,5 +60,5 @@ export function createFindPetsByStatusStatus400() {
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/examples/msw/src/gen/mocks/pet/createFindPetsByTags.ts
+++ b/examples/msw/src/gen/mocks/pet/createFindPetsByTags.ts
@@ -56,7 +56,7 @@ export function createFindPetsByTagsStatus200Xml(data?: FindPetsByTagsStatus200X
 export function createFindPetsByTagsStatus200(_data?: FindPetsByTagsStatus200): FindPetsByTagsStatus200 {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createFindPetsByTagsStatus200Json(), createFindPetsByTagsStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByTagsStatus200Json(), createFindPetsByTagsStatus200Xml()])
 }
 
 /**
@@ -71,5 +71,5 @@ export function createFindPetsByTagsStatus400() {
 export function createFindPetsByTagsResponse(_data?: FindPetsByTagsResponse): FindPetsByTagsResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createFindPetsByTagsStatus200(), createFindPetsByTagsStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByTagsStatus200(), createFindPetsByTagsStatus400()])
 }

--- a/examples/msw/src/gen/mocks/pet/createGetPetById.ts
+++ b/examples/msw/src/gen/mocks/pet/createGetPetById.ts
@@ -44,7 +44,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -68,5 +68,5 @@ export function createGetPetByIdStatus404() {
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/examples/msw/src/gen/mocks/pet/createUpdatePet.ts
+++ b/examples/msw/src/gen/mocks/pet/createUpdatePet.ts
@@ -43,7 +43,7 @@ export function createUpdatePetStatus200Xml(data?: Partial<UpdatePetStatus200Xml
 export function createUpdatePetStatus200(_data?: UpdatePetStatus200): UpdatePetStatus200 {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createUpdatePetStatus200Json(), createUpdatePetStatus200Xml()])
+  return faker.helpers.arrayElement([createUpdatePetStatus200Json(), createUpdatePetStatus200Xml()])
 }
 
 /**
@@ -106,11 +106,11 @@ export function createUpdatePetFormUrlEncodedData(data?: Partial<UpdatePetFormUr
 export function createUpdatePetData(_data?: UpdatePetData): UpdatePetData {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createUpdatePetJsonData(), createUpdatePetXmlData(), createUpdatePetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createUpdatePetJsonData(), createUpdatePetXmlData(), createUpdatePetFormUrlEncodedData()])
 }
 
 export function createUpdatePetResponse(_data?: UpdatePetResponse): UpdatePetResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createUpdatePetStatus200(), createUpdatePetStatus400(), createUpdatePetStatus404(), createUpdatePetStatus405()])
+  return faker.helpers.arrayElement([createUpdatePetStatus200(), createUpdatePetStatus400(), createUpdatePetStatus404(), createUpdatePetStatus405()])
 }

--- a/examples/msw/src/gen/mocks/store/createDeleteOrder.ts
+++ b/examples/msw/src/gen/mocks/store/createDeleteOrder.ts
@@ -33,5 +33,5 @@ export function createDeleteOrderStatus404() {
 export function createDeleteOrderResponse(_data?: DeleteOrderResponse): DeleteOrderResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createDeleteOrderStatus400(), createDeleteOrderStatus404()])
+  return faker.helpers.arrayElement([createDeleteOrderStatus400(), createDeleteOrderStatus404()])
 }

--- a/examples/msw/src/gen/mocks/store/createGetOrderById.ts
+++ b/examples/msw/src/gen/mocks/store/createGetOrderById.ts
@@ -44,7 +44,7 @@ export function createGetOrderByIdStatus200Xml(data?: Partial<GetOrderByIdStatus
 export function createGetOrderByIdStatus200(_data?: GetOrderByIdStatus200): GetOrderByIdStatus200 {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createGetOrderByIdStatus200Json(), createGetOrderByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetOrderByIdStatus200Json(), createGetOrderByIdStatus200Xml()])
 }
 
 /**
@@ -68,5 +68,5 @@ export function createGetOrderByIdStatus404() {
 export function createGetOrderByIdResponse(_data?: GetOrderByIdResponse): GetOrderByIdResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createGetOrderByIdStatus200(), createGetOrderByIdStatus400(), createGetOrderByIdStatus404()])
+  return faker.helpers.arrayElement([createGetOrderByIdStatus200(), createGetOrderByIdStatus400(), createGetOrderByIdStatus404()])
 }

--- a/examples/msw/src/gen/mocks/store/createPlaceOrder.ts
+++ b/examples/msw/src/gen/mocks/store/createPlaceOrder.ts
@@ -54,11 +54,11 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/examples/msw/src/gen/mocks/store/createPlaceOrderPatch.ts
+++ b/examples/msw/src/gen/mocks/store/createPlaceOrderPatch.ts
@@ -54,11 +54,11 @@ export function createPlaceOrderPatchFormUrlEncodedData(data?: Partial<PlaceOrde
 export function createPlaceOrderPatchData(_data?: PlaceOrderPatchData): PlaceOrderPatchData {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createPlaceOrderPatchJsonData(), createPlaceOrderPatchXmlData(), createPlaceOrderPatchFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderPatchJsonData(), createPlaceOrderPatchXmlData(), createPlaceOrderPatchFormUrlEncodedData()])
 }
 
 export function createPlaceOrderPatchResponse(_data?: PlaceOrderPatchResponse): PlaceOrderPatchResponse {
   faker.seed([220])
 
-  return faker.helpers.arrayElement<any>([createPlaceOrderPatchStatus200(), createPlaceOrderPatchStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderPatchStatus200(), createPlaceOrderPatchStatus405()])
 }

--- a/examples/msw/src/gen/models/DeleteOrder.ts
+++ b/examples/msw/src/gen/models/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/msw/src/gen/models/DeletePet.ts
+++ b/examples/msw/src/gen/models/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/msw/src/gen/models/FindPetsByStatus.ts
+++ b/examples/msw/src/gen/models/FindPetsByStatus.ts
@@ -25,9 +25,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/msw/src/gen/models/FindPetsByTags.ts
+++ b/examples/msw/src/gen/models/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/msw/src/gen/models/GetOrderById.ts
+++ b/examples/msw/src/gen/models/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/msw/src/gen/models/GetPetById.ts
+++ b/examples/msw/src/gen/models/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/msw/src/gen/models/PlaceOrder.ts
+++ b/examples/msw/src/gen/models/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/msw/src/gen/models/PlaceOrderPatch.ts
+++ b/examples/msw/src/gen/models/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/msw/src/gen/models/UpdatePet.ts
+++ b/examples/msw/src/gen/models/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/msw/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/msw/src/gen/models/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/msw/src/gen/msw/pet/Handlers/addPetHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/addPetHandler.ts
@@ -25,8 +25,8 @@ export function addPetHandlerResponse405(data: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>(`http://localhost:3000/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>(`http://localhost:3000/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/pet/Handlers/deletePetHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/deletePetHandler.ts
@@ -6,9 +6,12 @@
 import type { DeletePetStatus400 } from '../../../models/DeletePet.ts'
 import { http } from 'msw'
 
-export function deletePetHandlerResponse400(data?: DeletePetStatus400) {
+export function deletePetHandlerResponse400(data: DeletePetStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/msw/src/gen/msw/pet/Handlers/findPetsByStatusHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/findPetsByStatusHandler.ts
@@ -15,9 +15,12 @@ export function findPetsByStatusHandlerResponse200(data: FindPetsByStatusRespons
   })
 }
 
-export function findPetsByStatusHandlerResponse400(data?: FindPetsByStatusStatus400) {
+export function findPetsByStatusHandlerResponse400(data: FindPetsByStatusStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/msw/src/gen/msw/pet/Handlers/findPetsByTagsHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/findPetsByTagsHandler.ts
@@ -15,9 +15,12 @@ export function findPetsByTagsHandlerResponse200(data: FindPetsByTagsResponse) {
   })
 }
 
-export function findPetsByTagsHandlerResponse400(data?: FindPetsByTagsStatus400) {
+export function findPetsByTagsHandlerResponse400(data: FindPetsByTagsStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/msw/src/gen/msw/pet/Handlers/getPetByIdHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/getPetByIdHandler.ts
@@ -15,15 +15,21 @@ export function getPetByIdHandlerResponse200(data: GetPetByIdResponse) {
   })
 }
 
-export function getPetByIdHandlerResponse400(data?: GetPetByIdStatus400) {
+export function getPetByIdHandlerResponse400(data: GetPetByIdStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function getPetByIdHandlerResponse404(data?: GetPetByIdStatus404) {
+export function getPetByIdHandlerResponse404(data: GetPetByIdStatus404) {
   return new Response(JSON.stringify(data), {
     status: 404,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/msw/src/gen/msw/pet/Handlers/updatePetHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/updatePetHandler.ts
@@ -16,26 +16,35 @@ export function updatePetHandlerResponse200(data: UpdatePetResponse) {
   })
 }
 
-export function updatePetHandlerResponse400(data?: UpdatePetStatus400) {
+export function updatePetHandlerResponse400(data: UpdatePetStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function updatePetHandlerResponse404(data?: UpdatePetStatus404) {
+export function updatePetHandlerResponse404(data: UpdatePetStatus404) {
   return new Response(JSON.stringify(data), {
     status: 404,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function updatePetHandlerResponse405(data?: UpdatePetStatus405) {
+export function updatePetHandlerResponse405(data: UpdatePetStatus405) {
   return new Response(JSON.stringify(data), {
     status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData, any>) {
-  return http.put<Record<string, string>, UpdatePetData, any>(`http://localhost:3000/pet`, function handler(info) {
+export function updatePetHandler(data?: UpdatePetResponse | HttpResponseResolver<Record<string, string>, UpdatePetData>) {
+  return http.put<Record<string, string>, UpdatePetData>(`http://localhost:3000/pet`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/pet/Handlers/updatePetWithFormHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/updatePetWithFormHandler.ts
@@ -6,9 +6,12 @@
 import type { UpdatePetWithFormStatus405 } from '../../../models/UpdatePetWithForm.ts'
 import { http } from 'msw'
 
-export function updatePetWithFormHandlerResponse405(data?: UpdatePetWithFormStatus405) {
+export function updatePetWithFormHandlerResponse405(data: UpdatePetWithFormStatus405) {
   return new Response(JSON.stringify(data), {
     status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/msw/src/gen/msw/pet/Handlers/uploadFileHandler.ts
+++ b/examples/msw/src/gen/msw/pet/Handlers/uploadFileHandler.ts
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/store/Handlers/deleteOrderHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/deleteOrderHandler.ts
@@ -6,15 +6,21 @@
 import type { DeleteOrderStatus400, DeleteOrderStatus404 } from '../../../models/DeleteOrder.ts'
 import { http } from 'msw'
 
-export function deleteOrderHandlerResponse400(data?: DeleteOrderStatus400) {
+export function deleteOrderHandlerResponse400(data: DeleteOrderStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function deleteOrderHandlerResponse404(data?: DeleteOrderStatus404) {
+export function deleteOrderHandlerResponse404(data: DeleteOrderStatus404) {
   return new Response(JSON.stringify(data), {
     status: 404,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/msw/src/gen/msw/store/Handlers/getOrderByIdHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/getOrderByIdHandler.ts
@@ -15,15 +15,21 @@ export function getOrderByIdHandlerResponse200(data: GetOrderByIdResponse) {
   })
 }
 
-export function getOrderByIdHandlerResponse400(data?: GetOrderByIdStatus400) {
+export function getOrderByIdHandlerResponse400(data: GetOrderByIdStatus400) {
   return new Response(JSON.stringify(data), {
     status: 400,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function getOrderByIdHandlerResponse404(data?: GetOrderByIdStatus404) {
+export function getOrderByIdHandlerResponse404(data: GetOrderByIdStatus404) {
   return new Response(JSON.stringify(data), {
     status: 404,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 

--- a/examples/msw/src/gen/msw/store/Handlers/placeOrderHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/placeOrderHandler.ts
@@ -16,14 +16,17 @@ export function placeOrderHandlerResponse200(data: PlaceOrderResponse) {
   })
 }
 
-export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
+export function placeOrderHandlerResponse405(data: PlaceOrderStatus405) {
   return new Response(JSON.stringify(data), {
     status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
-  return http.post<Record<string, string>, PlaceOrderData, any>(`http://localhost:3000/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
+  return http.post<Record<string, string>, PlaceOrderData>(`http://localhost:3000/store/order`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/msw/src/gen/msw/store/Handlers/placeOrderPatchHandler.ts
+++ b/examples/msw/src/gen/msw/store/Handlers/placeOrderPatchHandler.ts
@@ -16,14 +16,17 @@ export function placeOrderPatchHandlerResponse200(data: PlaceOrderPatchResponse)
   })
 }
 
-export function placeOrderPatchHandlerResponse405(data?: PlaceOrderPatchStatus405) {
+export function placeOrderPatchHandlerResponse405(data: PlaceOrderPatchStatus405) {
   return new Response(JSON.stringify(data), {
     status: 405,
+    headers: {
+      'Content-Type': 'application/json',
+    },
   })
 }
 
-export function placeOrderPatchHandler(data?: PlaceOrderPatchResponse | HttpResponseResolver<Record<string, string>, PlaceOrderPatchData, any>) {
-  return http.patch<Record<string, string>, PlaceOrderPatchData, any>(`http://localhost:3000/store/order`, function handler(info) {
+export function placeOrderPatchHandler(data?: PlaceOrderPatchResponse | HttpResponseResolver<Record<string, string>, PlaceOrderPatchData>) {
+  return http.patch<Record<string, string>, PlaceOrderPatchData>(`http://localhost:3000/store/order`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/examples/react-query/kubb.config.ts
+++ b/examples/react-query/kubb.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(() => {
       format: false,
       lint: false,
     },
-    adapter: adapterOas({ serverIndex: 0 }),
+    adapter: adapterOas({ unknownType: 'unknown', serverIndex: 0 }),
     plugins: [
       pluginTs({
         output: { path: 'models', barrel: { type: 'named' } },

--- a/examples/react-query/src/gen/models/pet/DeletePet.ts
+++ b/examples/react-query/src/gen/models/pet/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/react-query/src/gen/models/pet/FindPetsByStatus.ts
@@ -33,9 +33,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/react-query/src/gen/models/pet/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/pet/GetPetById.ts
+++ b/examples/react-query/src/gen/models/pet/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/pet/UpdatePet.ts
+++ b/examples/react-query/src/gen/models/pet/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/react-query/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/react-query/src/gen/models/pet/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/store/DeleteOrder.ts
+++ b/examples/react-query/src/gen/models/store/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/store/GetOrderById.ts
+++ b/examples/react-query/src/gen/models/store/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/store/PlaceOrder.ts
+++ b/examples/react-query/src/gen/models/store/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/react-query/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/react-query/src/gen/models/store/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/react-query/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/react-query/src/gen/models/user/CreateUsersWithListInput.ts
@@ -18,9 +18,9 @@ export type CreateUsersWithListInputStatus200Xml = User
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreateUsersWithListInputStatusDefault = any
+export type CreateUsersWithListInputStatusDefault = unknown
 
 /**
  * @type array | undefined

--- a/examples/react-query/src/gen/models/user/DeleteUser.ts
+++ b/examples/react-query/src/gen/models/user/DeleteUser.ts
@@ -10,14 +10,14 @@
 export type DeleteUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus400 = any
+export type DeleteUserStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus404 = any
+export type DeleteUserStatus404 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/user/GetUserByName.ts
+++ b/examples/react-query/src/gen/models/user/GetUserByName.ts
@@ -24,14 +24,14 @@ export type GetUserByNameStatus200Xml = User
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus400 = any
+export type GetUserByNameStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus404 = any
+export type GetUserByNameStatus404 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/user/LoginUser.ts
+++ b/examples/react-query/src/gen/models/user/LoginUser.ts
@@ -28,9 +28,9 @@ export type LoginUserStatus200Json = string
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
 /**
- * @type any
+ * @type unknown
  */
-export type LoginUserStatus400 = any
+export type LoginUserStatus400 = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/user/LogoutUser.ts
+++ b/examples/react-query/src/gen/models/user/LogoutUser.ts
@@ -4,9 +4,9 @@
  */
 
 /**
- * @type any
+ * @type unknown
  */
-export type LogoutUserStatusDefault = any
+export type LogoutUserStatusDefault = unknown
 
 /**
  * @type object

--- a/examples/react-query/src/gen/models/user/UpdateUser.ts
+++ b/examples/react-query/src/gen/models/user/UpdateUser.ts
@@ -12,9 +12,9 @@ import type { User } from '../User.ts'
 export type UpdateUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdateUserStatusDefault = any
+export type UpdateUserStatusDefault = unknown
 
 /**
  * @description Update an existent user in the store

--- a/examples/sdk/kubb.config.ts
+++ b/examples/sdk/kubb.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
     format: false,
     lint: false,
   },
-  adapter: adapterOas({ enums: 'root' }),
+  adapter: adapterOas({ unknownType: 'unknown', enums: 'root' }),
   plugins: [
     pluginTs({
       output: { path: 'models' },

--- a/examples/sdk/src/gen/models/pet/DeletePet.ts
+++ b/examples/sdk/src/gen/models/pet/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/sdk/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/sdk/src/gen/models/pet/FindPetsByStatus.ts
@@ -25,9 +25,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/sdk/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/sdk/src/gen/models/pet/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/sdk/src/gen/models/pet/GetPetById.ts
+++ b/examples/sdk/src/gen/models/pet/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/sdk/src/gen/models/pet/UpdatePet.ts
+++ b/examples/sdk/src/gen/models/pet/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/sdk/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/sdk/src/gen/models/pet/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/sdk/src/gen/models/store/DeleteOrder.ts
+++ b/examples/sdk/src/gen/models/store/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/sdk/src/gen/models/store/GetOrderById.ts
+++ b/examples/sdk/src/gen/models/store/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/sdk/src/gen/models/store/PlaceOrder.ts
+++ b/examples/sdk/src/gen/models/store/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/sdk/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/sdk/src/gen/models/store/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/simple-single/kubb.config.js
+++ b/examples/simple-single/kubb.config.js
@@ -26,7 +26,7 @@ export default defineConfig([
     hooks: {
       done: ['npm run typecheck'],
     },
-    adapter: adapterOas({ collisionDetection: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', collisionDetection: false, enums: 'root' }),
     plugins: [
       pluginRedoc({
         output: {

--- a/examples/simple-single/src/gen/models.ts
+++ b/examples/simple-single/src/gen/models.ts
@@ -251,19 +251,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -400,9 +400,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -463,9 +463,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -518,14 +518,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -577,9 +577,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -628,9 +628,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -755,9 +755,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -805,9 +805,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -870,14 +870,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -917,14 +917,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/simple-single/src/gen/zod.ts
+++ b/examples/simple-single/src/gen/zod.ts
@@ -110,11 +110,11 @@ export const updatePetStatus200SchemaXml = petSchema
 
 export const updatePetStatus200Schema = z.union([updatePetStatus200SchemaJson, updatePetStatus200SchemaXml])
 
-export const updatePetStatus400Schema = z.any()
+export const updatePetStatus400Schema = z.unknown()
 
-export const updatePetStatus404Schema = z.any()
+export const updatePetStatus404Schema = z.unknown()
 
-export const updatePetStatus405Schema = z.any()
+export const updatePetStatus405Schema = z.unknown()
 
 export const updatePetResponseSchema = updatePetStatus200Schema
 
@@ -162,7 +162,7 @@ export const findPetsByStatusStatus200SchemaXml = z.array(petSchema)
 
 export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus200SchemaJson, findPetsByStatusStatus200SchemaXml])
 
-export const findPetsByStatusStatus400Schema = z.any()
+export const findPetsByStatusStatus400Schema = z.unknown()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
 
@@ -180,7 +180,7 @@ export const findPetsByTagsStatus200SchemaXml = z.array(petSchema)
 
 export const findPetsByTagsStatus200Schema = z.union([findPetsByTagsStatus200SchemaJson, findPetsByTagsStatus200SchemaXml])
 
-export const findPetsByTagsStatus400Schema = z.any()
+export const findPetsByTagsStatus400Schema = z.unknown()
 
 export const findPetsByTagsResponseSchema = findPetsByTagsStatus200Schema
 
@@ -194,9 +194,9 @@ export const getPetByIdStatus200SchemaXml = petSchema
 
 export const getPetByIdStatus200Schema = z.union([getPetByIdStatus200SchemaJson, getPetByIdStatus200SchemaXml])
 
-export const getPetByIdStatus400Schema = z.any()
+export const getPetByIdStatus400Schema = z.unknown()
 
-export const getPetByIdStatus404Schema = z.any()
+export const getPetByIdStatus404Schema = z.unknown()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
 
@@ -208,7 +208,7 @@ export const updatePetWithFormQueryNameSchema = z.string().optional().describe('
 
 export const updatePetWithFormQueryStatusSchema = z.string().optional().describe('Status of pet that needs to be updated')
 
-export const updatePetWithFormStatus405Schema = z.any()
+export const updatePetWithFormStatus405Schema = z.unknown()
 
 export const updatePetWithFormResponseSchema = z.unknown()
 
@@ -218,7 +218,7 @@ export const deletePetHeaderApiKeySchema = z.string().optional()
 
 export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 
-export const deletePetStatus400Schema = z.any()
+export const deletePetStatus400Schema = z.unknown()
 
 export const deletePetResponseSchema = z.unknown()
 
@@ -240,7 +240,7 @@ export const getInventoryResponseSchema = getInventoryStatus200Schema
 
 export const placeOrderStatus200Schema = orderSchema
 
-export const placeOrderStatus405Schema = z.any()
+export const placeOrderStatus405Schema = z.unknown()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 
@@ -256,7 +256,7 @@ export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrde
 
 export const placeOrderPatchStatus200Schema = orderSchema
 
-export const placeOrderPatchStatus405Schema = z.any()
+export const placeOrderPatchStatus405Schema = z.unknown()
 
 export const placeOrderPatchResponseSchema = placeOrderPatchStatus200Schema
 
@@ -278,9 +278,9 @@ export const getOrderByIdStatus200SchemaXml = orderSchema
 
 export const getOrderByIdStatus200Schema = z.union([getOrderByIdStatus200SchemaJson, getOrderByIdStatus200SchemaXml])
 
-export const getOrderByIdStatus400Schema = z.any()
+export const getOrderByIdStatus400Schema = z.unknown()
 
-export const getOrderByIdStatus404Schema = z.any()
+export const getOrderByIdStatus404Schema = z.unknown()
 
 export const getOrderByIdResponseSchema = getOrderByIdStatus200Schema
 
@@ -288,9 +288,9 @@ export const getOrderByIdErrorSchema = z.union([getOrderByIdStatus400Schema, get
 
 export const deleteOrderPathOrderIdSchema = z.bigint().describe('ID of the order that needs to be deleted')
 
-export const deleteOrderStatus400Schema = z.any()
+export const deleteOrderStatus400Schema = z.unknown()
 
-export const deleteOrderStatus404Schema = z.any()
+export const deleteOrderStatus404Schema = z.unknown()
 
 export const deleteOrderResponseSchema = z.unknown()
 

--- a/examples/swr/kubb.config.ts
+++ b/examples/swr/kubb.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(() => {
       format: false,
       lint: false,
     },
-    adapter: adapterOas({ serverIndex: 0 }),
+    adapter: adapterOas({ unknownType: 'unknown', serverIndex: 0 }),
     plugins: [
       pluginTs({
         output: { path: 'models', barrel: { type: 'named' } },

--- a/examples/swr/src/gen/models/pet/DeletePet.ts
+++ b/examples/swr/src/gen/models/pet/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/swr/src/gen/models/pet/FindPetsByStatus.ts
@@ -33,9 +33,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/swr/src/gen/models/pet/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/pet/GetPetById.ts
+++ b/examples/swr/src/gen/models/pet/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/pet/UpdatePet.ts
+++ b/examples/swr/src/gen/models/pet/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/swr/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/swr/src/gen/models/pet/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/store/DeleteOrder.ts
+++ b/examples/swr/src/gen/models/store/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/store/GetOrderById.ts
+++ b/examples/swr/src/gen/models/store/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/store/PlaceOrder.ts
+++ b/examples/swr/src/gen/models/store/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/swr/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/swr/src/gen/models/store/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/swr/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/swr/src/gen/models/user/CreateUsersWithListInput.ts
@@ -18,9 +18,9 @@ export type CreateUsersWithListInputStatus200Xml = User
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreateUsersWithListInputStatusDefault = any
+export type CreateUsersWithListInputStatusDefault = unknown
 
 /**
  * @type array | undefined

--- a/examples/swr/src/gen/models/user/DeleteUser.ts
+++ b/examples/swr/src/gen/models/user/DeleteUser.ts
@@ -10,14 +10,14 @@
 export type DeleteUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus400 = any
+export type DeleteUserStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus404 = any
+export type DeleteUserStatus404 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/user/GetUserByName.ts
+++ b/examples/swr/src/gen/models/user/GetUserByName.ts
@@ -24,14 +24,14 @@ export type GetUserByNameStatus200Xml = User
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus400 = any
+export type GetUserByNameStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus404 = any
+export type GetUserByNameStatus404 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/user/LoginUser.ts
+++ b/examples/swr/src/gen/models/user/LoginUser.ts
@@ -28,9 +28,9 @@ export type LoginUserStatus200Json = string
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
 /**
- * @type any
+ * @type unknown
  */
-export type LoginUserStatus400 = any
+export type LoginUserStatus400 = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/user/LogoutUser.ts
+++ b/examples/swr/src/gen/models/user/LogoutUser.ts
@@ -4,9 +4,9 @@
  */
 
 /**
- * @type any
+ * @type unknown
  */
-export type LogoutUserStatusDefault = any
+export type LogoutUserStatusDefault = unknown
 
 /**
  * @type object

--- a/examples/swr/src/gen/models/user/UpdateUser.ts
+++ b/examples/swr/src/gen/models/user/UpdateUser.ts
@@ -12,9 +12,9 @@ import type { User } from '../User.ts'
 export type UpdateUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdateUserStatusDefault = any
+export type UpdateUserStatusDefault = unknown
 
 /**
  * @description Update an existent user in the store

--- a/examples/typescript/kubb.config.ts
+++ b/examples/typescript/kubb.config.ts
@@ -14,10 +14,7 @@ export default defineConfig([
       format: false,
       lint: false,
     },
-    adapter: adapterOas({
-      validate: false,
-      enums: 'root',
-    }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {
@@ -47,10 +44,7 @@ export default defineConfig([
       format: false,
       lint: false,
     },
-    adapter: adapterOas({
-      validate: false,
-      enums: 'root',
-    }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {
@@ -68,10 +62,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen2', clean: true, format: false, lint: false },
-    adapter: adapterOas({
-      validate: false,
-      enums: 'root',
-    }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {
@@ -87,10 +78,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen3', clean: true, format: false, lint: false },
-    adapter: adapterOas({
-      validate: false,
-      enums: 'root',
-    }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {
@@ -106,10 +94,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen4', clean: true, format: false, lint: false },
-    adapter: adapterOas({
-      validate: false,
-      enums: 'root',
-    }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {
@@ -125,10 +110,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen5', clean: true, format: false, lint: false },
-    adapter: adapterOas({
-      validate: false,
-      enums: 'root',
-    }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {
@@ -147,10 +129,7 @@ export default defineConfig([
     hooks: {
       done: ['npm run typecheck'],
     },
-    adapter: adapterOas({
-      validate: false,
-      enums: 'root',
-    }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: {
@@ -163,7 +142,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen7', clean: true, format: false, lint: false },
-    adapter: adapterOas({ validate: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: { path: 'modelsInlineLiteral.ts', mode: 'file', barrel: false },
@@ -175,7 +154,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen8', clean: true, format: false, lint: false },
-    adapter: adapterOas({ validate: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: { path: 'modelsOptionalUndefined.ts', mode: 'file', barrel: false },
@@ -188,7 +167,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen9', clean: true, format: false, lint: false },
-    adapter: adapterOas({ validate: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: { path: 'modelsOptionalBoth.ts', mode: 'file', barrel: false },
@@ -201,7 +180,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen10', clean: true, format: false, lint: false },
-    adapter: adapterOas({ validate: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: { path: 'models' },
@@ -214,7 +193,7 @@ export default defineConfig([
     root: '.',
     input,
     output: { path: './src/gen11', clean: true, format: false, lint: false },
-    adapter: adapterOas({ validate: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: { path: 'modelsPascalCaseKeys.ts', mode: 'file', barrel: false },
@@ -229,7 +208,7 @@ export default defineConfig([
     hooks: {
       done: ['npm run typecheck'],
     },
-    adapter: adapterOas({ validate: false, enums: 'root' }),
+    adapter: adapterOas({ unknownType: 'unknown', validate: false, enums: 'root' }),
     plugins: [
       pluginTs({
         output: { path: 'modelsCamelCaseKeys.ts', mode: 'file', barrel: false },

--- a/examples/typescript/src/gen/models.ts
+++ b/examples/typescript/src/gen/models.ts
@@ -411,19 +411,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -549,9 +549,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -612,9 +612,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -661,14 +661,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -720,9 +720,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -776,9 +776,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -906,9 +906,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -957,9 +957,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1022,14 +1022,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1069,14 +1069,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/pet/DeletePet.ts
+++ b/examples/typescript/src/gen10/models/pet/DeletePet.ts
@@ -24,9 +24,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/pet/FindPetsByStatus.ts
+++ b/examples/typescript/src/gen10/models/pet/FindPetsByStatus.ts
@@ -25,9 +25,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/pet/FindPetsByTags.ts
+++ b/examples/typescript/src/gen10/models/pet/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/pet/GetPetById.ts
+++ b/examples/typescript/src/gen10/models/pet/GetPetById.ts
@@ -20,14 +20,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/pet/UpdatePet.ts
+++ b/examples/typescript/src/gen10/models/pet/UpdatePet.ts
@@ -12,19 +12,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/typescript/src/gen10/models/pet/UpdatePetWithForm.ts
+++ b/examples/typescript/src/gen10/models/pet/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/store/DeleteOrder.ts
+++ b/examples/typescript/src/gen10/models/store/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/store/GetOrderById.ts
+++ b/examples/typescript/src/gen10/models/store/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen10/models/store/PlaceOrder.ts
+++ b/examples/typescript/src/gen10/models/store/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description

--- a/examples/typescript/src/gen10/models/store/PlaceOrderPatch.ts
+++ b/examples/typescript/src/gen10/models/store/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
+++ b/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
@@ -411,19 +411,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -549,9 +549,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -612,9 +612,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -661,14 +661,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -720,9 +720,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -776,9 +776,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -906,9 +906,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -957,9 +957,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1022,14 +1022,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1069,14 +1069,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
+++ b/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
@@ -411,19 +411,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -549,9 +549,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -612,9 +612,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -661,14 +661,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -720,9 +720,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -776,9 +776,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -906,9 +906,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -957,9 +957,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1022,14 +1022,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1069,14 +1069,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen2/modelsConst.ts
+++ b/examples/typescript/src/gen2/modelsConst.ts
@@ -411,19 +411,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -549,9 +549,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -612,9 +612,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -661,14 +661,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -720,9 +720,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -776,9 +776,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumenumType>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -906,9 +906,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -957,9 +957,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1022,14 +1022,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1069,14 +1069,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen3/modelsPascalConst.ts
+++ b/examples/typescript/src/gen3/modelsPascalConst.ts
@@ -411,19 +411,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -549,9 +549,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -612,9 +612,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -661,14 +661,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -720,9 +720,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -776,9 +776,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -906,9 +906,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -957,9 +957,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1022,14 +1022,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1069,14 +1069,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen4/modelsConstEnum.ts
+++ b/examples/typescript/src/gen4/modelsConstEnum.ts
@@ -393,19 +393,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -531,9 +531,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -594,9 +594,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -643,14 +643,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -702,9 +702,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -758,9 +758,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -888,9 +888,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -939,9 +939,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1004,14 +1004,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1051,14 +1051,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen5/modelsLiteral.ts
+++ b/examples/typescript/src/gen5/modelsLiteral.ts
@@ -359,19 +359,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -497,9 +497,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -560,9 +560,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -609,14 +609,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -668,9 +668,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -724,9 +724,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -854,9 +854,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -905,9 +905,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -970,14 +970,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1017,14 +1017,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/DeleteOrder.ts
+++ b/examples/typescript/src/gen6/ts/models/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/DeletePet.ts
+++ b/examples/typescript/src/gen6/ts/models/DeletePet.ts
@@ -24,9 +24,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/FindPetsByStatus.ts
+++ b/examples/typescript/src/gen6/ts/models/FindPetsByStatus.ts
@@ -25,9 +25,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/FindPetsByTags.ts
+++ b/examples/typescript/src/gen6/ts/models/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/GetOrderById.ts
+++ b/examples/typescript/src/gen6/ts/models/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/GetPetById.ts
+++ b/examples/typescript/src/gen6/ts/models/GetPetById.ts
@@ -20,14 +20,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen6/ts/models/PlaceOrder.ts
+++ b/examples/typescript/src/gen6/ts/models/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description

--- a/examples/typescript/src/gen6/ts/models/PlaceOrderPatch.ts
+++ b/examples/typescript/src/gen6/ts/models/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/typescript/src/gen6/ts/models/UpdatePet.ts
+++ b/examples/typescript/src/gen6/ts/models/UpdatePet.ts
@@ -12,19 +12,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/typescript/src/gen6/ts/models/UpdatePetWithForm.ts
+++ b/examples/typescript/src/gen6/ts/models/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen7/modelsInlineLiteral.ts
+++ b/examples/typescript/src/gen7/modelsInlineLiteral.ts
@@ -396,19 +396,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -534,9 +534,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -597,9 +597,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -646,14 +646,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -705,9 +705,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -761,9 +761,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -891,9 +891,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -942,9 +942,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1007,14 +1007,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1054,14 +1054,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen8/modelsOptionalUndefined.ts
+++ b/examples/typescript/src/gen8/modelsOptionalUndefined.ts
@@ -400,19 +400,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -538,9 +538,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -603,9 +603,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -654,14 +654,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -713,9 +713,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -771,9 +771,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -905,9 +905,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -956,9 +956,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1021,14 +1021,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1068,14 +1068,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/gen9/modelsOptionalBoth.ts
+++ b/examples/typescript/src/gen9/modelsOptionalBoth.ts
@@ -400,19 +400,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -538,9 +538,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -603,9 +603,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -654,14 +654,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -713,9 +713,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -771,9 +771,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -905,9 +905,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -956,9 +956,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1021,14 +1021,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1068,14 +1068,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/typescript/src/legacy/models.ts
+++ b/examples/typescript/src/legacy/models.ts
@@ -393,19 +393,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store
@@ -531,9 +531,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object
@@ -594,9 +594,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object
@@ -643,14 +643,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object
@@ -702,9 +702,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object
@@ -758,9 +758,9 @@ export type DeletePetPathPetId = bigint
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object
@@ -888,9 +888,9 @@ export type GetInventoryResponse = GetInventoryStatus200
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @description Order description
@@ -939,9 +939,9 @@ export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined
@@ -1004,14 +1004,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object
@@ -1051,14 +1051,14 @@ export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/kubb.config.ts
+++ b/examples/vue-query/kubb.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(() => {
       format: false,
       lint: false,
     },
-    adapter: adapterOas({ serverIndex: 0 }),
+    adapter: adapterOas({ unknownType: 'unknown', serverIndex: 0 }),
     plugins: [
       pluginTs({
         output: { path: 'models', barrel: { type: 'named' } },

--- a/examples/vue-query/src/gen/models/pet/DeletePet.ts
+++ b/examples/vue-query/src/gen/models/pet/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/vue-query/src/gen/models/pet/FindPetsByStatus.ts
@@ -33,9 +33,9 @@ export type FindPetsByStatusStatus200Xml = Pet[]
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/vue-query/src/gen/models/pet/FindPetsByTags.ts
@@ -36,9 +36,9 @@ export type FindPetsByTagsStatus200Xml = Pet[]
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/pet/GetPetById.ts
+++ b/examples/vue-query/src/gen/models/pet/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/pet/UpdatePet.ts
+++ b/examples/vue-query/src/gen/models/pet/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/vue-query/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/vue-query/src/gen/models/pet/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/store/DeleteOrder.ts
+++ b/examples/vue-query/src/gen/models/store/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/store/GetOrderById.ts
+++ b/examples/vue-query/src/gen/models/store/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/store/PlaceOrder.ts
+++ b/examples/vue-query/src/gen/models/store/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/vue-query/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/vue-query/src/gen/models/store/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from '../Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/vue-query/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/vue-query/src/gen/models/user/CreateUsersWithListInput.ts
@@ -18,9 +18,9 @@ export type CreateUsersWithListInputStatus200Xml = User
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreateUsersWithListInputStatusDefault = any
+export type CreateUsersWithListInputStatusDefault = unknown
 
 /**
  * @type array | undefined

--- a/examples/vue-query/src/gen/models/user/DeleteUser.ts
+++ b/examples/vue-query/src/gen/models/user/DeleteUser.ts
@@ -10,14 +10,14 @@
 export type DeleteUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus400 = any
+export type DeleteUserStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteUserStatus404 = any
+export type DeleteUserStatus404 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/user/GetUserByName.ts
+++ b/examples/vue-query/src/gen/models/user/GetUserByName.ts
@@ -24,14 +24,14 @@ export type GetUserByNameStatus200Xml = User
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus400 = any
+export type GetUserByNameStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetUserByNameStatus404 = any
+export type GetUserByNameStatus404 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/user/LoginUser.ts
+++ b/examples/vue-query/src/gen/models/user/LoginUser.ts
@@ -28,9 +28,9 @@ export type LoginUserStatus200Json = string
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
 /**
- * @type any
+ * @type unknown
  */
-export type LoginUserStatus400 = any
+export type LoginUserStatus400 = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/user/LogoutUser.ts
+++ b/examples/vue-query/src/gen/models/user/LogoutUser.ts
@@ -4,9 +4,9 @@
  */
 
 /**
- * @type any
+ * @type unknown
  */
-export type LogoutUserStatusDefault = any
+export type LogoutUserStatusDefault = unknown
 
 /**
  * @type object

--- a/examples/vue-query/src/gen/models/user/UpdateUser.ts
+++ b/examples/vue-query/src/gen/models/user/UpdateUser.ts
@@ -12,9 +12,9 @@ import type { User } from '../User.ts'
 export type UpdateUserPathUsername = string
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdateUserStatusDefault = any
+export type UpdateUserStatusDefault = unknown
 
 /**
  * @description Update an existent user in the store

--- a/examples/zod/kubb.config.js
+++ b/examples/zod/kubb.config.js
@@ -1,3 +1,4 @@
+import { adapterOas } from '@kubb/adapter-oas'
 import { pluginTs } from '@kubb/plugin-ts'
 import { pluginZod } from '@kubb/plugin-zod'
 import { defineConfig } from 'kubb'
@@ -10,6 +11,7 @@ export default defineConfig([
     input: {
       path: './petStore.yaml',
     },
+    adapter: adapterOas({ unknownType: 'unknown' }),
     output: {
       path: './src/zod',
       clean: true,
@@ -37,6 +39,7 @@ export default defineConfig([
     input: {
       path: './petStore.yaml',
     },
+    adapter: adapterOas({ unknownType: 'unknown' }),
     output: {
       path: './src/mini',
       clean: true,
@@ -56,6 +59,7 @@ export default defineConfig([
     input: {
       path: './unionWithReadOnly.yaml',
     },
+    adapter: adapterOas({ unknownType: 'unknown' }),
     output: {
       path: './src/gen3',
       clean: true,

--- a/examples/zod/package.json
+++ b/examples/zod/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@kubb/adapter-oas": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
     "axios": "^1.18.1",

--- a/examples/zod/src/mini/zod/createPetsSchema.ts
+++ b/examples/zod/src/mini/zod/createPetsSchema.ts
@@ -12,7 +12,7 @@ export const createPetsQueryOffsetSchema = z.optional(z.int())
 
 export const createPetsHeaderXEXAMPLESchema = z.enum(['ONE', 'TWO', 'THREE'])
 
-export const createPetsStatus201Schema = z.any()
+export const createPetsStatus201Schema = z.unknown()
 
 export const createPetsStatusDefaultSchema = petNotFoundSchema
 

--- a/examples/zod/src/mini/zod/deleteOrderSchema.ts
+++ b/examples/zod/src/mini/zod/deleteOrderSchema.ts
@@ -7,9 +7,9 @@ import * as z from 'zod/mini'
 
 export const deleteOrderPathOrderIdSchema = z.bigint()
 
-export const deleteOrderStatus400Schema = z.any()
+export const deleteOrderStatus400Schema = z.unknown()
 
-export const deleteOrderStatus404Schema = z.any()
+export const deleteOrderStatus404Schema = z.unknown()
 
 export const deleteOrderResponseSchema = z.unknown()
 

--- a/examples/zod/src/mini/zod/deletePetSchema.ts
+++ b/examples/zod/src/mini/zod/deletePetSchema.ts
@@ -9,7 +9,7 @@ export const deletePetHeaderApiKeySchema = z.optional(z.string())
 
 export const deletePetPathPetIdSchema = z.bigint()
 
-export const deletePetStatus400Schema = z.any()
+export const deletePetStatus400Schema = z.unknown()
 
 export const deletePetResponseSchema = z.unknown()
 

--- a/examples/zod/src/mini/zod/findPetsByStatusSchema.ts
+++ b/examples/zod/src/mini/zod/findPetsByStatusSchema.ts
@@ -14,7 +14,7 @@ export const findPetsByStatusStatus200SchemaXml = z.array(z.lazy(() => petSchema
 
 export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus200SchemaJson, findPetsByStatusStatus200SchemaXml])
 
-export const findPetsByStatusStatus400Schema = z.any()
+export const findPetsByStatusStatus400Schema = z.unknown()
 
 export const findPetsByStatusResponseSchema = findPetsByStatusStatus200Schema
 

--- a/examples/zod/src/mini/zod/findPetsByTagsSchema.ts
+++ b/examples/zod/src/mini/zod/findPetsByTagsSchema.ts
@@ -20,7 +20,7 @@ export const findPetsByTagsStatus200SchemaXml = z.array(z.lazy(() => petSchema))
 
 export const findPetsByTagsStatus200Schema = z.union([findPetsByTagsStatus200SchemaJson, findPetsByTagsStatus200SchemaXml])
 
-export const findPetsByTagsStatus400Schema = z.any()
+export const findPetsByTagsStatus400Schema = z.unknown()
 
 export const findPetsByTagsResponseSchema = findPetsByTagsStatus200Schema
 

--- a/examples/zod/src/mini/zod/getOrderByIdSchema.ts
+++ b/examples/zod/src/mini/zod/getOrderByIdSchema.ts
@@ -14,9 +14,9 @@ export const getOrderByIdStatus200SchemaXml = orderSchema
 
 export const getOrderByIdStatus200Schema = z.union([getOrderByIdStatus200SchemaJson, getOrderByIdStatus200SchemaXml])
 
-export const getOrderByIdStatus400Schema = z.any()
+export const getOrderByIdStatus400Schema = z.unknown()
 
-export const getOrderByIdStatus404Schema = z.any()
+export const getOrderByIdStatus404Schema = z.unknown()
 
 export const getOrderByIdResponseSchema = getOrderByIdStatus200Schema
 

--- a/examples/zod/src/mini/zod/getPetByIdSchema.ts
+++ b/examples/zod/src/mini/zod/getPetByIdSchema.ts
@@ -14,9 +14,9 @@ export const getPetByIdStatus200SchemaXml = z.lazy(() => petSchema)
 
 export const getPetByIdStatus200Schema = z.union([getPetByIdStatus200SchemaJson, getPetByIdStatus200SchemaXml])
 
-export const getPetByIdStatus400Schema = z.any()
+export const getPetByIdStatus400Schema = z.unknown()
 
-export const getPetByIdStatus404Schema = z.any()
+export const getPetByIdStatus404Schema = z.unknown()
 
 export const getPetByIdResponseSchema = getPetByIdStatus200Schema
 

--- a/examples/zod/src/mini/zod/getThingsSchema.ts
+++ b/examples/zod/src/mini/zod/getThingsSchema.ts
@@ -10,7 +10,7 @@ export const getThingsQueryLimitSchema = z._default(z.optional(z.int().check(z.m
 
 export const getThingsQuerySkipSchema = z._default(z.optional(z.int().check(z.minimum(0))), 0)
 
-export const getThingsStatus201Schema = z.any()
+export const getThingsStatus201Schema = z.unknown()
 
 export const getThingsStatusDefaultSchema = petNotFoundSchema
 

--- a/examples/zod/src/mini/zod/placeOrderPatchSchema.ts
+++ b/examples/zod/src/mini/zod/placeOrderPatchSchema.ts
@@ -8,7 +8,7 @@ import { orderSchema } from './orderSchema.ts'
 
 export const placeOrderPatchStatus200Schema = orderSchema
 
-export const placeOrderPatchStatus405Schema = z.any()
+export const placeOrderPatchStatus405Schema = z.unknown()
 
 export const placeOrderPatchResponseSchema = placeOrderPatchStatus200Schema
 

--- a/examples/zod/src/mini/zod/placeOrderSchema.ts
+++ b/examples/zod/src/mini/zod/placeOrderSchema.ts
@@ -8,7 +8,7 @@ import { orderSchema } from './orderSchema.ts'
 
 export const placeOrderStatus200Schema = orderSchema
 
-export const placeOrderStatus405Schema = z.any()
+export const placeOrderStatus405Schema = z.unknown()
 
 export const placeOrderResponseSchema = placeOrderStatus200Schema
 

--- a/examples/zod/src/mini/zod/updatePetSchema.ts
+++ b/examples/zod/src/mini/zod/updatePetSchema.ts
@@ -12,11 +12,11 @@ export const updatePetStatus200SchemaXml = z.lazy(() => petSchema)
 
 export const updatePetStatus200Schema = z.union([updatePetStatus200SchemaJson, updatePetStatus200SchemaXml])
 
-export const updatePetStatus400Schema = z.any()
+export const updatePetStatus400Schema = z.unknown()
 
-export const updatePetStatus404Schema = z.any()
+export const updatePetStatus404Schema = z.unknown()
 
-export const updatePetStatus405Schema = z.any()
+export const updatePetStatus405Schema = z.unknown()
 
 export const updatePetResponseSchema = updatePetStatus200Schema
 

--- a/examples/zod/src/mini/zod/updatePetWithFormSchema.ts
+++ b/examples/zod/src/mini/zod/updatePetWithFormSchema.ts
@@ -11,7 +11,7 @@ export const updatePetWithFormQueryNameSchema = z.optional(z.string())
 
 export const updatePetWithFormQueryStatusSchema = z.optional(z.string())
 
-export const updatePetWithFormStatus405Schema = z.any()
+export const updatePetWithFormStatus405Schema = z.unknown()
 
 export const updatePetWithFormResponseSchema = z.unknown()
 

--- a/examples/zod/src/zod/ts/CreatePets.ts
+++ b/examples/zod/src/zod/ts/CreatePets.ts
@@ -32,13 +32,13 @@ export type CreatePetsXEXAMPLEKey = (typeof createPetsXEXAMPLE)[keyof typeof cre
 export type CreatePetsHeaderXEXAMPLE = CreatePetsXEXAMPLEKey
 
 /**
- * @type any
+ * @type unknown
  */
-export type CreatePetsStatus201 = any
+export type CreatePetsStatus201 = unknown
 
 /**
  * @description Pet not found
- * @type any
+ * @type unknown
  */
 export type CreatePetsStatusDefault = PetNotFound
 

--- a/examples/zod/src/zod/ts/DeleteOrder.ts
+++ b/examples/zod/src/zod/ts/DeleteOrder.ts
@@ -12,14 +12,14 @@
 export type DeleteOrderPathOrderId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus400 = any
+export type DeleteOrderStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeleteOrderStatus404 = any
+export type DeleteOrderStatus404 = unknown
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/DeletePet.ts
+++ b/examples/zod/src/zod/ts/DeletePet.ts
@@ -17,9 +17,9 @@ export type DeletePetHeaderApiKey = string | undefined
 export type DeletePetPathPetId = bigint
 
 /**
- * @type any
+ * @type unknown
  */
-export type DeletePetStatus400 = any
+export type DeletePetStatus400 = unknown
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/FindPetsByStatus.ts
+++ b/examples/zod/src/zod/ts/FindPetsByStatus.ts
@@ -33,9 +33,9 @@ export type FindPetsByStatusStatus200Xml = Array<Pet>
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByStatusStatus400 = any
+export type FindPetsByStatusStatus400 = unknown
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/FindPetsByTags.ts
+++ b/examples/zod/src/zod/ts/FindPetsByTags.ts
@@ -50,9 +50,9 @@ export type FindPetsByTagsStatus200Xml = Array<Pet>
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type FindPetsByTagsStatus400 = any
+export type FindPetsByTagsStatus400 = unknown
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/GetOrderById.ts
+++ b/examples/zod/src/zod/ts/GetOrderById.ts
@@ -26,14 +26,14 @@ export type GetOrderByIdStatus200Xml = Order
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus400 = any
+export type GetOrderByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetOrderByIdStatus404 = any
+export type GetOrderByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/GetPetById.ts
+++ b/examples/zod/src/zod/ts/GetPetById.ts
@@ -26,14 +26,14 @@ export type GetPetByIdStatus200Xml = Pet
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus400 = any
+export type GetPetByIdStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetPetByIdStatus404 = any
+export type GetPetByIdStatus404 = unknown
 
 /**
  * @type object

--- a/examples/zod/src/zod/ts/GetThings.ts
+++ b/examples/zod/src/zod/ts/GetThings.ts
@@ -23,13 +23,13 @@ export type GetThingsQueryLimit = number | undefined
 export type GetThingsQuerySkip = number | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type GetThingsStatus201 = any
+export type GetThingsStatus201 = unknown
 
 /**
  * @description Pet not found
- * @type any
+ * @type unknown
  */
 export type GetThingsStatusDefault = PetNotFound
 

--- a/examples/zod/src/zod/ts/PlaceOrder.ts
+++ b/examples/zod/src/zod/ts/PlaceOrder.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.ts'
 export type PlaceOrderStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderStatus405 = any
+export type PlaceOrderStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/zod/src/zod/ts/PlaceOrderPatch.ts
+++ b/examples/zod/src/zod/ts/PlaceOrderPatch.ts
@@ -11,9 +11,9 @@ import type { Order } from './Order.ts'
 export type PlaceOrderPatchStatus200 = Order
 
 /**
- * @type any
+ * @type unknown
  */
-export type PlaceOrderPatchStatus405 = any
+export type PlaceOrderPatchStatus405 = unknown
 
 /**
  * @type object | undefined

--- a/examples/zod/src/zod/ts/UpdatePet.ts
+++ b/examples/zod/src/zod/ts/UpdatePet.ts
@@ -18,19 +18,19 @@ export type UpdatePetStatus200Xml = Pet
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus400 = any
+export type UpdatePetStatus400 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus404 = any
+export type UpdatePetStatus404 = unknown
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetStatus405 = any
+export type UpdatePetStatus405 = unknown
 
 /**
  * @description Update an existent pet in the store

--- a/examples/zod/src/zod/ts/UpdatePetWithForm.ts
+++ b/examples/zod/src/zod/ts/UpdatePetWithForm.ts
@@ -24,9 +24,9 @@ export type UpdatePetWithFormQueryName = string | undefined
 export type UpdatePetWithFormQueryStatus = string | undefined
 
 /**
- * @type any
+ * @type unknown
  */
-export type UpdatePetWithFormStatus405 = any
+export type UpdatePetWithFormStatus405 = unknown
 
 /**
  * @type object

--- a/examples/zod/src/zod/zod/createPetsSchema.ts
+++ b/examples/zod/src/zod/zod/createPetsSchema.ts
@@ -18,7 +18,7 @@ export const createPetsHeaderXEXAMPLESchema = z.enum(['ONE', 'TWO', 'THREE']).de
 
 export type CreatePetsHeaderXEXAMPLESchemaType = z.infer<typeof createPetsHeaderXEXAMPLESchema>
 
-export const createPetsStatus201Schema = z.any()
+export const createPetsStatus201Schema = z.unknown()
 
 export type CreatePetsStatus201SchemaType = z.infer<typeof createPetsStatus201Schema>
 

--- a/examples/zod/src/zod/zod/deleteOrderSchema.ts
+++ b/examples/zod/src/zod/zod/deleteOrderSchema.ts
@@ -9,11 +9,11 @@ export const deleteOrderPathOrderIdSchema = z.bigint().describe('ID of the order
 
 export type DeleteOrderPathOrderIdSchemaType = z.infer<typeof deleteOrderPathOrderIdSchema>
 
-export const deleteOrderStatus400Schema = z.any()
+export const deleteOrderStatus400Schema = z.unknown()
 
 export type DeleteOrderStatus400SchemaType = z.infer<typeof deleteOrderStatus400Schema>
 
-export const deleteOrderStatus404Schema = z.any()
+export const deleteOrderStatus404Schema = z.unknown()
 
 export type DeleteOrderStatus404SchemaType = z.infer<typeof deleteOrderStatus404Schema>
 

--- a/examples/zod/src/zod/zod/deletePetSchema.ts
+++ b/examples/zod/src/zod/zod/deletePetSchema.ts
@@ -13,7 +13,7 @@ export const deletePetPathPetIdSchema = z.bigint().describe('Pet id to delete')
 
 export type DeletePetPathPetIdSchemaType = z.infer<typeof deletePetPathPetIdSchema>
 
-export const deletePetStatus400Schema = z.any()
+export const deletePetStatus400Schema = z.unknown()
 
 export type DeletePetStatus400SchemaType = z.infer<typeof deletePetStatus400Schema>
 

--- a/examples/zod/src/zod/zod/findPetsByStatusSchema.ts
+++ b/examples/zod/src/zod/zod/findPetsByStatusSchema.ts
@@ -26,7 +26,7 @@ export const findPetsByStatusStatus200Schema = z.union([findPetsByStatusStatus20
 
 export type FindPetsByStatusStatus200SchemaType = z.infer<typeof findPetsByStatusStatus200Schema>
 
-export const findPetsByStatusStatus400Schema = z.any()
+export const findPetsByStatusStatus400Schema = z.unknown()
 
 export type FindPetsByStatusStatus400SchemaType = z.infer<typeof findPetsByStatusStatus400Schema>
 

--- a/examples/zod/src/zod/zod/findPetsByTagsSchema.ts
+++ b/examples/zod/src/zod/zod/findPetsByTagsSchema.ts
@@ -34,7 +34,7 @@ export const findPetsByTagsStatus200Schema = z.union([findPetsByTagsStatus200Sch
 
 export type FindPetsByTagsStatus200SchemaType = z.infer<typeof findPetsByTagsStatus200Schema>
 
-export const findPetsByTagsStatus400Schema = z.any()
+export const findPetsByTagsStatus400Schema = z.unknown()
 
 export type FindPetsByTagsStatus400SchemaType = z.infer<typeof findPetsByTagsStatus400Schema>
 

--- a/examples/zod/src/zod/zod/getOrderByIdSchema.ts
+++ b/examples/zod/src/zod/zod/getOrderByIdSchema.ts
@@ -22,11 +22,11 @@ export const getOrderByIdStatus200Schema = z.union([getOrderByIdStatus200SchemaJ
 
 export type GetOrderByIdStatus200SchemaType = z.infer<typeof getOrderByIdStatus200Schema>
 
-export const getOrderByIdStatus400Schema = z.any()
+export const getOrderByIdStatus400Schema = z.unknown()
 
 export type GetOrderByIdStatus400SchemaType = z.infer<typeof getOrderByIdStatus400Schema>
 
-export const getOrderByIdStatus404Schema = z.any()
+export const getOrderByIdStatus404Schema = z.unknown()
 
 export type GetOrderByIdStatus404SchemaType = z.infer<typeof getOrderByIdStatus404Schema>
 

--- a/examples/zod/src/zod/zod/getPetByIdSchema.ts
+++ b/examples/zod/src/zod/zod/getPetByIdSchema.ts
@@ -22,11 +22,11 @@ export const getPetByIdStatus200Schema = z.union([getPetByIdStatus200SchemaJson,
 
 export type GetPetByIdStatus200SchemaType = z.infer<typeof getPetByIdStatus200Schema>
 
-export const getPetByIdStatus400Schema = z.any()
+export const getPetByIdStatus400Schema = z.unknown()
 
 export type GetPetByIdStatus400SchemaType = z.infer<typeof getPetByIdStatus400Schema>
 
-export const getPetByIdStatus404Schema = z.any()
+export const getPetByIdStatus404Schema = z.unknown()
 
 export type GetPetByIdStatus404SchemaType = z.infer<typeof getPetByIdStatus404Schema>
 

--- a/examples/zod/src/zod/zod/getThingsSchema.ts
+++ b/examples/zod/src/zod/zod/getThingsSchema.ts
@@ -14,7 +14,7 @@ export const getThingsQuerySkipSchema = z.int().min(0).optional().default(0).des
 
 export type GetThingsQuerySkipSchemaType = z.infer<typeof getThingsQuerySkipSchema>
 
-export const getThingsStatus201Schema = z.any()
+export const getThingsStatus201Schema = z.unknown()
 
 export type GetThingsStatus201SchemaType = z.infer<typeof getThingsStatus201Schema>
 

--- a/examples/zod/src/zod/zod/placeOrderPatchSchema.ts
+++ b/examples/zod/src/zod/zod/placeOrderPatchSchema.ts
@@ -10,7 +10,7 @@ export const placeOrderPatchStatus200Schema = orderSchema
 
 export type PlaceOrderPatchStatus200SchemaType = z.infer<typeof placeOrderPatchStatus200Schema>
 
-export const placeOrderPatchStatus405Schema = z.any()
+export const placeOrderPatchStatus405Schema = z.unknown()
 
 export type PlaceOrderPatchStatus405SchemaType = z.infer<typeof placeOrderPatchStatus405Schema>
 

--- a/examples/zod/src/zod/zod/placeOrderSchema.ts
+++ b/examples/zod/src/zod/zod/placeOrderSchema.ts
@@ -10,7 +10,7 @@ export const placeOrderStatus200Schema = orderSchema
 
 export type PlaceOrderStatus200SchemaType = z.infer<typeof placeOrderStatus200Schema>
 
-export const placeOrderStatus405Schema = z.any()
+export const placeOrderStatus405Schema = z.unknown()
 
 export type PlaceOrderStatus405SchemaType = z.infer<typeof placeOrderStatus405Schema>
 

--- a/examples/zod/src/zod/zod/updatePetSchema.ts
+++ b/examples/zod/src/zod/zod/updatePetSchema.ts
@@ -18,15 +18,15 @@ export const updatePetStatus200Schema = z.union([updatePetStatus200SchemaJson, u
 
 export type UpdatePetStatus200SchemaType = z.infer<typeof updatePetStatus200Schema>
 
-export const updatePetStatus400Schema = z.any()
+export const updatePetStatus400Schema = z.unknown()
 
 export type UpdatePetStatus400SchemaType = z.infer<typeof updatePetStatus400Schema>
 
-export const updatePetStatus404Schema = z.any()
+export const updatePetStatus404Schema = z.unknown()
 
 export type UpdatePetStatus404SchemaType = z.infer<typeof updatePetStatus404Schema>
 
-export const updatePetStatus405Schema = z.any()
+export const updatePetStatus405Schema = z.unknown()
 
 export type UpdatePetStatus405SchemaType = z.infer<typeof updatePetStatus405Schema>
 

--- a/examples/zod/src/zod/zod/updatePetWithFormSchema.ts
+++ b/examples/zod/src/zod/zod/updatePetWithFormSchema.ts
@@ -17,7 +17,7 @@ export const updatePetWithFormQueryStatusSchema = z.string().optional().describe
 
 export type UpdatePetWithFormQueryStatusSchemaType = z.infer<typeof updatePetWithFormQueryStatusSchema>
 
-export const updatePetWithFormStatus405Schema = z.any()
+export const updatePetWithFormStatus405Schema = z.unknown()
 
 export type UpdatePetWithFormStatus405SchemaType = z.infer<typeof updatePetWithFormStatus405Schema>
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -44,12 +44,5 @@ export default defineConfig({
         'no-unused-vars': 'off',
       },
     },
-    {
-      // Generated output mirrors the OpenAPI document, so a schema typed `any` stays `any`.
-      files: ['examples/**'],
-      rules: {
-        'typescript/no-explicit-any': 'off',
-      },
-    },
   ],
 })

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     'prefer-exponentiation-operator': 'error',
     'typescript/array-type': ['error', { default: 'generic' }],
     'typescript/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
+    'typescript/no-explicit-any': 'error',
     'typescript/no-inferrable-types': 'error',
     'typescript/prefer-function-type': 'error',
     'react/self-closing-comp': 'error',
@@ -41,6 +42,13 @@ export default defineConfig({
       rules: {
         'typescript/array-type': 'off',
         'no-unused-vars': 'off',
+      },
+    },
+    {
+      // Generated output mirrors the OpenAPI document, so a schema typed `any` stays `any`.
+      files: ['examples/**'],
+      rules: {
+        'typescript/no-explicit-any': 'off',
       },
     },
   ],

--- a/packages/plugin-faker/src/generators/__snapshots__/catCycle/createCat.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/catCycle/createCat.ts
@@ -10,7 +10,7 @@ export function createCat<TData extends Partial<Cat> = object>(data?: TData) {
   const defaultFakeData = {
     id: faker.number.int(),
     get archEnemy() {
-      const _value = faker.helpers.arrayElement<any>([null, createPet()])
+      const _value = faker.helpers.arrayElement([null, createPet()])
       Object.defineProperty(this, 'archEnemy', { value: _value, configurable: true, writable: true, enumerable: true })
       return _value
     },

--- a/packages/plugin-faker/src/generators/__snapshots__/showPetById/createShowPetById.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/showPetById/createShowPetById.ts
@@ -25,5 +25,5 @@ export function createShowPetByIdStatusDefault(data?: Partial<ShowPetByIdStatusD
 }
 
 export function createShowPetByIdResponse(_data?: ShowPetByIdResponse): ShowPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createShowPetByIdStatus200(), createShowPetByIdStatusDefault()])
+  return faker.helpers.arrayElement([createShowPetByIdStatus200(), createShowPetByIdStatusDefault()])
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/treeNode/createTreeNode.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/treeNode/createTreeNode.ts
@@ -9,8 +9,8 @@ import { faker } from '@faker-js/faker'
 export function createTreeNode<TData extends Partial<TreeNode> = object>(data?: TData) {
   const defaultFakeData = {
     value: faker.string.alpha(),
-    left: undefined as any,
-    right: undefined as any,
+    left: undefined as unknown as NonNullable<TreeNode>['left'],
+    right: undefined as unknown as NonNullable<TreeNode>['right'],
   }
   return {
     ...defaultFakeData,

--- a/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
@@ -199,7 +199,10 @@ describe('fakerGenerator — schema', () => {
   test('named string schema omits unused type import', async () => {
     const resolvedOptions: PluginFaker['resolvedOptions'] = { ...defaultOptions }
     const plugin = createMockedPlugin<PluginFaker>({ name: 'plugin-faker', options: resolvedOptions, resolver: resolverFaker })
-    const driver = createMockedPluginDriver({ name: 'emoji', plugin: defaultTsPlugin as any })
+    const driver = createMockedPluginDriver({
+      name: 'emoji',
+      plugin: defaultTsPlugin as unknown as NonNullable<Parameters<typeof createMockedPluginDriver>[0]>['plugin'],
+    })
 
     await renderGeneratorSchema(fakerGenerator, emojiSchema, {
       config: testConfig,

--- a/packages/plugin-faker/src/printers/printerFaker.test.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.test.ts
@@ -109,7 +109,9 @@ describe('printerFaker', () => {
         resolver: resolverFaker,
         typeName: `NonNullable<Address>["identifier"]`,
       }).print(node),
-    ).toMatchInlineSnapshot(`"[faker.number.int(), faker.string.alpha(), faker.helpers.arrayElement<NonNullable<NonNullable<Address>["identifier"]>[2]>(['NW', 'NE', 'SW', 'SE'])]"`)
+    ).toMatchInlineSnapshot(
+      `"[faker.number.int(), faker.string.alpha(), faker.helpers.arrayElement<NonNullable<NonNullable<Address>["identifier"]>[2]>(['NW', 'NE', 'SW', 'SE'])]"`,
+    )
   })
 
   test('narrows discriminated oneOf variants to their own branch', () => {

--- a/packages/plugin-faker/src/printers/printerFaker.test.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.test.ts
@@ -58,7 +58,7 @@ describe('printerFaker', () => {
   test('guards self refs', () => {
     const node = ast.factory.createSchema({ type: 'ref', name: 'TreeNode', ref: '#/components/schemas/TreeNode' })
 
-    expect(printerFaker({ resolver: resolverFaker, schemaName: 'TreeNode' }).print(node)).toMatchInlineSnapshot(`"undefined as any"`)
+    expect(printerFaker({ resolver: resolverFaker, schemaName: 'TreeNode' }).print(node)).toMatchInlineSnapshot(`"undefined as unknown"`)
   })
 
   test('does not re-resolve internal helper refs', () => {
@@ -109,9 +109,7 @@ describe('printerFaker', () => {
         resolver: resolverFaker,
         typeName: `NonNullable<Address>["identifier"]`,
       }).print(node),
-    ).toMatchInlineSnapshot(
-      `"[faker.number.int(), faker.string.alpha(), faker.helpers.arrayElement<NonNullable<NonNullable<Address>["identifier"]>[2]>(['NW', 'NE', 'SW', 'SE'])]"`,
-    )
+    ).toMatchInlineSnapshot(`"[faker.number.int(), faker.string.alpha(), faker.helpers.arrayElement<NonNullable<NonNullable<Address>["identifier"]>[2]>(['NW', 'NE', 'SW', 'SE'])]"`)
   })
 
   test('narrows discriminated oneOf variants to their own branch', () => {
@@ -166,7 +164,7 @@ describe('printerFaker', () => {
 
     expect(printerFaker({ resolver: resolverFaker, typeName: 'Filter', schemaName: 'Filter' }).print(node)).toMatchInlineSnapshot(
       `
-      "faker.helpers.arrayElement<any>([{}, {
+      "faker.helpers.arrayElement([{}, {
         '+order': faker.helpers.arrayElement<(NonNullable<Filter> & Record<"+order", unknown>)["+order"]>(['asc', 'desc']),
       }])"
     `,

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -132,8 +132,9 @@ const fakerKeywordMapper = {
     return `faker.helpers.multiple(() => (${item}))`
   },
   tuple: (items: Array<string> = []) => `[${items.join(', ')}]`,
-  enum: (items: Array<string | number | boolean | undefined> = [], type = 'any') => `faker.helpers.arrayElement<${type}>([${items.join(', ')}])`,
-  union: (items: Array<string> = []) => `faker.helpers.arrayElement<any>([${items.join(', ')}])`,
+  enum: (items: Array<string | number | boolean | undefined> = [], type?: string) =>
+    `faker.helpers.arrayElement${type ? `<${type}>` : ''}([${items.join(', ')}])`,
+  union: (items: Array<string> = []) => `faker.helpers.arrayElement([${items.join(', ')}])`,
   datetime: () => 'faker.date.anytime().toISOString()',
   date: (representation: 'date' | 'string' = 'string', parser: PluginFaker['resolvedOptions']['dateParser'] = 'faker') => {
     if (representation === 'string') {
@@ -292,7 +293,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         }
 
         if (this.options.schemaName && refName === this.options.schemaName) {
-          return 'undefined as any'
+          return this.options.typeName ? `undefined as unknown as ${this.options.typeName}` : 'undefined as unknown'
         }
 
         // Internal helper refs (for generated response/data helpers) are already

--- a/packages/plugin-mcp/src/generators/serverGenerator.test.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.test.tsx
@@ -70,15 +70,15 @@ describe('serverGenerator — Operations', () => {
     })
     // Also register zod plugin — serverGenerator needs it for zod schema imports
     const originalGetPlugin = driver.getPlugin.bind(driver)
-    driver.getPlugin = (pluginName: string) => {
-      if (pluginName === 'plugin-zod') return mockedZodPlugin as any
+    driver.getPlugin = ((pluginName: string) => {
+      if (pluginName === 'plugin-zod') return mockedZodPlugin
       return originalGetPlugin(pluginName)
-    }
+    }) as typeof driver.getPlugin
 
-    driver.getResolver = (pluginName: string) => {
-      if (pluginName === 'plugin-zod') return mockedZodPlugin.resolver as any
-      return mockedTsPlugin.resolver as any
-    }
+    driver.getResolver = ((pluginName: string) => {
+      if (pluginName === 'plugin-zod') return mockedZodPlugin.resolver
+      return mockedTsPlugin.resolver
+    }) as typeof driver.getResolver
 
     await renderGeneratorOperations(serverGenerator, nodes, {
       config: testConfig,

--- a/packages/plugin-msw/src/components/Mock.tsx
+++ b/packages/plugin-msw/src/components/Mock.tsx
@@ -28,7 +28,7 @@ export function Mock({ baseURL = '', name, typeName, requestTypeName, node }: Pr
   const dataType = responseHasSchema ? typeName : 'string | number | boolean | null | object'
 
   const callbackType = requestTypeName
-    ? `HttpResponseResolver<Record<string, string>, ${requestTypeName}, any>`
+    ? `HttpResponseResolver<Record<string, string>, ${requestTypeName}>`
     : `((info: Parameters<Parameters<typeof http.${method}>[1]>[0]) => Response | Promise<Response>)`
 
   const params = declarationPrinter.print(
@@ -43,7 +43,7 @@ export function Mock({ baseURL = '', name, typeName, requestTypeName, node }: Pr
     }),
   )
 
-  const httpCall = requestTypeName ? `http.${method}<Record<string, string>, ${requestTypeName}, any>` : `http.${method}`
+  const httpCall = requestTypeName ? `http.${method}<Record<string, string>, ${requestTypeName}>` : `http.${method}`
 
   return (
     <File.Source name={name} isIndexable isExportable>

--- a/packages/plugin-msw/src/components/MockWithFaker.tsx
+++ b/packages/plugin-msw/src/components/MockWithFaker.tsx
@@ -27,7 +27,7 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, request
   const headers = [contentType ? `'Content-Type': '${contentType}'` : null].filter(Boolean)
 
   const callbackType = requestTypeName
-    ? `HttpResponseResolver<Record<string, string>, ${requestTypeName}, any>`
+    ? `HttpResponseResolver<Record<string, string>, ${requestTypeName}>`
     : `((info: Parameters<Parameters<typeof http.${method}>[1]>[0]) => Response | Promise<Response>)`
 
   const params = declarationPrinter.print(
@@ -42,7 +42,7 @@ export function MockWithFaker({ baseURL = '', name, fakerName, typeName, request
     }),
   )
 
-  const httpCall = requestTypeName ? `http.${method}<Record<string, string>, ${requestTypeName}, any>` : `http.${method}`
+  const httpCall = requestTypeName ? `http.${method}<Record<string, string>, ${requestTypeName}>` : `http.${method}`
 
   return (
     <File.Source name={name} isIndexable isExportable>

--- a/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
@@ -13,8 +13,8 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
   })
 }
 
-export function createPetsHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreatePetsData, any>) {
-  return http.post<Record<string, string>, CreatePetsData, any>(`/pets`, function handler(info) {
+export function createPetsHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreatePetsData>) {
+  return http.post<Record<string, string>, CreatePetsData>(`/pets`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
@@ -14,8 +14,8 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
   })
 }
 
-export function createPetsHandler(data?: CreatePetsResponse | HttpResponseResolver<Record<string, string>, CreatePetsData, any>) {
-  return http.post<Record<string, string>, CreatePetsData, any>('/pets', function handler(info) {
+export function createPetsHandler(data?: CreatePetsResponse | HttpResponseResolver<Record<string, string>, CreatePetsData>) {
+  return http.post<Record<string, string>, CreatePetsData>('/pets', function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data || createCreatePetsResponse(data)), {

--- a/packages/plugin-msw/src/generators/mswGenerator.test.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.test.tsx
@@ -2,6 +2,7 @@
 import type { Config } from '@kubb/core'
 import { ast, memoryStorage } from '@kubb/core'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation } from '@kubb/core/mocks'
+import type { PluginFaker } from '@kubb/plugin-faker'
 import { pluginFakerName, resolverFaker } from '@kubb/plugin-faker'
 import type { PluginTs } from '@kubb/plugin-ts'
 import { resolverTs } from '@kubb/plugin-ts'
@@ -40,9 +41,9 @@ const mockedTsPlugin = createMockedPlugin<PluginTs>({
   resolver: resolverTs,
 })
 
-const mockedFakerPlugin = createMockedPlugin<any>({
+const mockedFakerPlugin = createMockedPlugin<PluginFaker>({
   name: pluginFakerName,
-  options: { output: { path: '.' }, group: null },
+  options: { output: { path: '.' }, group: null } as PluginFaker['resolvedOptions'],
   resolver: resolverFaker,
 })
 
@@ -137,17 +138,17 @@ describe('mswGenerator operation', () => {
     const plugin = createMockedPlugin<PluginMsw>({ name: 'plugin-msw', options, resolver: resolverMsw })
     const driver = createMockedPluginDriver({ name: props.name })
 
-    driver.getPlugin = (pluginName: string) => {
-      if (pluginName === 'plugin-ts') return mockedTsPlugin as any
+    driver.getPlugin = ((pluginName: string) => {
+      if (pluginName === 'plugin-ts') return mockedTsPlugin
       if (pluginName === pluginFakerName) return mockedFakerPlugin
       return undefined
-    }
+    }) as typeof driver.getPlugin
 
-    driver.getResolver = (pluginName: string) => {
-      if (pluginName === 'plugin-ts') return mockedTsPlugin.resolver as any
+    driver.getResolver = ((pluginName: string) => {
+      if (pluginName === 'plugin-ts') return mockedTsPlugin.resolver
       if (pluginName === pluginFakerName) return mockedFakerPlugin.resolver
       return undefined
-    }
+    }) as typeof driver.getResolver
 
     await renderGeneratorOperation(mswGenerator, props.node, {
       config: testConfig,

--- a/packages/plugin-redoc/src/redoc.tsx
+++ b/packages/plugin-redoc/src/redoc.tsx
@@ -3,7 +3,7 @@ import type { AdapterOas } from '@kubb/adapter-oas'
 type BuildDocsOptions = {
   title?: string
   disableGoogleFont?: boolean
-  templateOptions?: any
+  templateOptions?: Record<string, unknown>
 }
 
 const htmlEscapes: Record<string, string> = {

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -1,5 +1,6 @@
 import { ast } from '@kubb/core'
 import { describe, expect, test } from 'vitest'
+import type { ResolverZod } from '../types.ts'
 import { printerZod } from './printerZod.ts'
 
 describe('printerZod', () => {
@@ -363,7 +364,7 @@ describe('printerZod', () => {
     })
 
     test('cross-file ref with resolver returns resolved bare name', () => {
-      const p = printerZod({ resolver: { default: (name: string) => `${name.charAt(0).toLowerCase()}${name.slice(1)}Schema` } as any })
+      const p = printerZod({ resolver: { default: (name: string) => `${name.charAt(0).toLowerCase()}${name.slice(1)}Schema` } as unknown as ResolverZod })
       const node = ast.factory.createSchema({ type: 'ref', name: 'UnsupportedAuthenticationProblem', ref: '#/components/schemas/Problem' })
 
       expect(p.print(node)).toBe('problemSchema')

--- a/packages/plugin-zod/src/printers/printerZodMini.test.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.test.ts
@@ -1,5 +1,6 @@
 import { ast } from '@kubb/core'
 import { describe, expect, test } from 'vitest'
+import type { ResolverZod } from '../types.ts'
 import { printerZodMini } from './printerZodMini.ts'
 
 describe('printerZodMini', () => {
@@ -311,7 +312,7 @@ describe('printerZodMini', () => {
     })
 
     test('cross-file ref with resolver returns resolved bare name', () => {
-      const p = printerZodMini({ resolver: { default: (name: string) => `${name.charAt(0).toLowerCase()}${name.slice(1)}Schema` } as any })
+      const p = printerZodMini({ resolver: { default: (name: string) => `${name.charAt(0).toLowerCase()}${name.slice(1)}Schema` } as unknown as ResolverZod })
       const node = ast.factory.createSchema({ type: 'ref', name: 'UnsupportedAuthenticationProblem', ref: '#/components/schemas/Problem' })
 
       expect(p.print(node)).toBe('problemSchema')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,9 @@ importers:
 
   examples/cypress:
     dependencies:
+      '@kubb/adapter-oas':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.74(@kubb/renderer-jsx@5.0.0-beta.74)(openapi-types@12.1.3)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:../../packages/plugin-cypress
@@ -542,6 +545,9 @@ importers:
 
   examples/zod:
     dependencies:
+      '@kubb/adapter-oas':
+        specifier: 'catalog:'
+        version: 5.0.0-beta.74(@kubb/renderer-jsx@5.0.0-beta.74)(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/store/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/store/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/mapper/faker/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createAddPet.ts
@@ -32,7 +32,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -77,11 +77,11 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
 export function createAddPetData(_data?: AddPetData): AddPetData {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createFindPetsByStatus.ts
@@ -44,7 +44,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -59,5 +59,5 @@ export function createFindPetsByStatusStatus400() {
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createGetPetById.ts
@@ -37,7 +37,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -61,5 +61,5 @@ export function createGetPetByIdStatus404() {
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createPlaceOrder.ts
@@ -46,11 +46,11 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
   faker.seed([42])
 
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/addPetHandler.ts
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>(`http://localhost:3000/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>(`http://localhost:3000/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/placeOrderHandler.ts
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
-  return http.post<Record<string, string>, PlaceOrderData, any>(`http://localhost:3000/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
+  return http.post<Record<string, string>, PlaceOrderData>(`http://localhost:3000/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/uploadFileHandler.ts
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/placeOrderHandler.ts
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
-  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
+  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/uploadFileHandler.ts
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/addPetHandler.ts
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/uploadFileHandler.ts
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/store/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/store/placeOrderHandler.ts
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
-  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
+  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/addPetHandler.ts
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/placeOrderHandler.ts
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
-  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
+  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/uploadFileHandler.ts
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/addPetHandler.ts
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/uploadFileHandler.ts
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createAddPet.ts
@@ -26,7 +26,7 @@ export function createAddPetStatus200Xml(data?: Partial<AddPetStatus200Xml>): Ad
  * @description Successful operation
  */
 export function createAddPetStatus200(_data?: AddPetStatus200): AddPetStatus200 {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200Json(), createAddPetStatus200Xml()])
+  return faker.helpers.arrayElement([createAddPetStatus200Json(), createAddPetStatus200Xml()])
 }
 
 /**
@@ -61,9 +61,9 @@ export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncod
  * @description Create a new pet in the store
  */
 export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement<any>([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {
-  return faker.helpers.arrayElement<any>([createAddPetStatus200(), createAddPetStatus405()])
+  return faker.helpers.arrayElement([createAddPetStatus200(), createAddPetStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createFindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createFindPetsByStatus.ts
@@ -36,7 +36,7 @@ export function createFindPetsByStatusStatus200Xml(data?: FindPetsByStatusStatus
  * @description successful operation
  */
 export function createFindPetsByStatusStatus200(_data?: FindPetsByStatusStatus200): FindPetsByStatusStatus200 {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200Json(), createFindPetsByStatusStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createFindPetsByStatusStatus400() {
 }
 
 export function createFindPetsByStatusResponse(_data?: FindPetsByStatusResponse): FindPetsByStatusResponse {
-  return faker.helpers.arrayElement<any>([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
+  return faker.helpers.arrayElement([createFindPetsByStatusStatus200(), createFindPetsByStatusStatus400()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createGetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createGetPetById.ts
@@ -29,7 +29,7 @@ export function createGetPetByIdStatus200Xml(data?: Partial<GetPetByIdStatus200X
  * @description successful operation
  */
 export function createGetPetByIdStatus200(_data?: GetPetByIdStatus200): GetPetByIdStatus200 {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200Json(), createGetPetByIdStatus200Xml()])
 }
 
 /**
@@ -47,5 +47,5 @@ export function createGetPetByIdStatus404() {
 }
 
 export function createGetPetByIdResponse(_data?: GetPetByIdResponse): GetPetByIdResponse {
-  return faker.helpers.arrayElement<any>([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
+  return faker.helpers.arrayElement([createGetPetByIdStatus200(), createGetPetByIdStatus400(), createGetPetByIdStatus404()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createPlaceOrder.ts
@@ -34,9 +34,9 @@ export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderForm
 }
 
 export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement<any>([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {
-  return faker.helpers.arrayElement<any>([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
+  return faker.helpers.arrayElement([createPlaceOrderStatus200(), createPlaceOrderStatus405()])
 }

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
@@ -24,8 +24,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>('/pet', function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>('/pet', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || createAddPetResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
@@ -24,8 +24,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
-  return http.post<Record<string, string>, PlaceOrderData, any>('/store/order', function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
+  return http.post<Record<string, string>, PlaceOrderData>('/store/order', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || createPlaceOrderResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
@@ -17,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>('/pet/:petId/uploadImage', function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>('/pet/:petId/uploadImage', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || createUploadFileResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/addPetHandler.ts
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData, any>) {
-  return http.post<Record<string, string>, AddPetData, any>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
+  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/placeOrderHandler.ts
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData, any>) {
-  return http.post<Record<string, string>, PlaceOrderData, any>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
+  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/uploadFileHandler.ts
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData, any>) {
-  return http.post<Record<string, string>, UploadFileData, any>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
+  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {


### PR DESCRIPTION
## 🎯 Changes

Removes explicit `any` from hand-written code **and** from the generated examples, and turns on `typescript/no-explicit-any` to keep it out.

### Source + enforcement
- Enable `typescript/no-explicit-any: error` in `oxlint.config.ts`.
- `@kubb/plugin-redoc`: type the unused `templateOptions` on `getPageHTML` as `Record<string, unknown>`.
- Tests (`plugin-faker`, `plugin-mcp`, `plugin-msw`, `plugin-zod`): drop `as any` casts for defined types — mocked driver methods cast to their own method type, a mocked resolver to its concrete `ResolverZod` type.

### Generated examples
The printers stay faithful — an explicit `any` schema node still renders `any`. The `any`-vs-`unknown` choice for free-form/empty schemas is driven by the adapter instead:
- Example configs pass `adapterOas({ unknownType: 'unknown' })`, so unmapped schemas generate `unknown` (e.g. `export type UpdatePetStatus400 = unknown`) across the TS, Zod, and Cypress outputs. `@kubb/adapter-oas` is added as a dependency to the `cypress` and `zod` examples, which previously relied on the default adapter.
- `@kubb/plugin-faker`: `arrayElement` element values are typed from the schema (inferred literals for plain enums, the precise property type when nested), and a cyclic self-reference emits `undefined as unknown as <Type>` instead of `undefined as any`.
- `@kubb/plugin-msw`: handlers omit the response-body generic, falling back to msw's `DefaultBodyType` rather than `any`.
- Remove the temporary `examples/**` exemption so the rule now covers generated example output too, and regenerate every example.

The only remaining `any` is the `advanced` example's custom `status` faker mapper, which deliberately overrides the differently-typed `status` fields across schemas (`Pet`, `Order`); no single concrete type fits, and the output lands in the lint-ignored `src/gen`.

Generators/printers were left faithful per review feedback: the `any → any` node mapping is preserved and the behavior is steered through the adapter's `unknownType`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)