### PR TITLE
feat(client)!: merge body serializers/deserializers into codecs, rename serialization to styles

### DIFF
--- a/.changeset/client-codecs-styles.md
+++ b/.changeset/client-codecs-styles.md
@@ -1,0 +1,33 @@
+---
+"@kubb/plugin-fetch": minor
+"@kubb/plugin-axios": minor
+---
+
+Rename two client config options so they no longer collide with each other.
+
+The per-content-type `bodySerializers` and `deserializers` maps merge into one `codecs` map, keyed by content type, where each entry holds a `serialize` and a `deserialize` function. This removes the overlap with the single `serializer.body` function and pairs request encoding with response decoding per media type.
+
+```ts
+// before
+client.setConfig({
+  bodySerializers: { 'application/xml': (body) => build(body) },
+  deserializers: { 'application/xml': (raw) => parse(raw) },
+})
+
+// after
+client.setConfig({
+  codecs: {
+    'application/xml': { serialize: (body) => build(body), deserialize: (raw) => parse(raw) },
+  },
+})
+```
+
+The per-parameter `serialization` metadata (the OpenAPI `style` / `explode` config a generated operation carries, and the per-call override) is renamed to `styles`, so it no longer reads like the `serializer` functions. The generated operations now emit a `styles:` entry instead of `serialization:`.
+
+```ts
+// before
+await listPets({ query: { tags }, serialization: { query: { tags: { style: 'pipeDelimited', explode: false } } } })
+
+// after
+await listPets({ query: { tags }, styles: { query: { tags: { style: 'pipeDelimited', explode: false } } } })
+```

--- a/examples/advanced/src/gen/.kubb/client.ts
+++ b/examples/advanced/src/gen/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/advanced/src/gen/.kubb/serializers.ts
+++ b/examples/advanced/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/advanced/src/gen/clients/axios/petService/findPetsByTags.ts
+++ b/examples/advanced/src/gen/clients/axios/petService/findPetsByTags.ts
@@ -17,7 +17,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     validator: { response: findPetsByTagsResponseSchema, error: findPetsByTagsErrorSchema },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>

--- a/examples/axios/src/gen/.kubb/client.ts
+++ b/examples/axios/src/gen/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/axios/src/gen/.kubb/serializers.ts
+++ b/examples/axios/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/axios/src/gen/clients/pet/findPetsByStatus.ts
+++ b/examples/axios/src/gen/clients/pet/findPetsByStatus.ts
@@ -21,7 +21,7 @@ export function findPetsByStatus<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByStatus',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { status: { explode: true } } },
+    styles: { query: { status: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/examples/axios/src/gen/clients/pet/findPetsByTags.ts
+++ b/examples/axios/src/gen/clients/pet/findPetsByTags.ts
@@ -21,7 +21,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>
 }

--- a/examples/fetch/src/gen/.kubb/client.ts
+++ b/examples/fetch/src/gen/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/fetch/src/gen/.kubb/serializers.ts
+++ b/examples/fetch/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/fetch/src/gen/clients/pet/findPetsByStatus.ts
+++ b/examples/fetch/src/gen/clients/pet/findPetsByStatus.ts
@@ -21,7 +21,7 @@ export function findPetsByStatus<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByStatus',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { status: { explode: true } } },
+    styles: { query: { status: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/examples/fetch/src/gen/clients/pet/findPetsByTags.ts
+++ b/examples/fetch/src/gen/clients/pet/findPetsByTags.ts
@@ -21,7 +21,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>
 }

--- a/examples/mcp/src/gen/.kubb/client.ts
+++ b/examples/mcp/src/gen/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/mcp/src/gen/.kubb/serializers.ts
+++ b/examples/mcp/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/mcp/src/gen/clients/findPetsByTags.ts
+++ b/examples/mcp/src/gen/clients/findPetsByTags.ts
@@ -21,7 +21,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>
 }

--- a/examples/react-query/src/gen/.kubb/client.ts
+++ b/examples/react-query/src/gen/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/react-query/src/gen/.kubb/serializers.ts
+++ b/examples/react-query/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/react-query/src/gen/clients/pet/findPetsByStatus.ts
+++ b/examples/react-query/src/gen/clients/pet/findPetsByStatus.ts
@@ -21,7 +21,7 @@ export function findPetsByStatus<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByStatus',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { status: { explode: true } } },
+    styles: { query: { status: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/examples/react-query/src/gen/clients/pet/findPetsByTags.ts
+++ b/examples/react-query/src/gen/clients/pet/findPetsByTags.ts
@@ -21,7 +21,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>
 }

--- a/examples/sdk/src/gen/.kubb/client.ts
+++ b/examples/sdk/src/gen/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/sdk/src/gen/.kubb/serializers.ts
+++ b/examples/sdk/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/simple-single/src/gen/.kubb/client.ts
+++ b/examples/simple-single/src/gen/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/simple-single/src/gen/.kubb/serializers.ts
+++ b/examples/simple-single/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/simple-single/src/gen/clients/findPetsByStatus.ts
+++ b/examples/simple-single/src/gen/clients/findPetsByStatus.ts
@@ -21,7 +21,7 @@ export function findPetsByStatus<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByStatus',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { status: { explode: true } } },
+    styles: { query: { status: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/examples/simple-single/src/gen/clients/findPetsByTags.ts
+++ b/examples/simple-single/src/gen/clients/findPetsByTags.ts
@@ -21,7 +21,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>
 }

--- a/examples/swr/src/gen/.kubb/client.ts
+++ b/examples/swr/src/gen/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/swr/src/gen/.kubb/serializers.ts
+++ b/examples/swr/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/swr/src/gen/clients/pet/findPetsByStatus.ts
+++ b/examples/swr/src/gen/clients/pet/findPetsByStatus.ts
@@ -21,7 +21,7 @@ export function findPetsByStatus<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByStatus',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { status: { explode: true } } },
+    styles: { query: { status: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/examples/swr/src/gen/clients/pet/findPetsByTags.ts
+++ b/examples/swr/src/gen/clients/pet/findPetsByTags.ts
@@ -21,7 +21,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>
 }

--- a/examples/vue-query/src/gen/.kubb/client.ts
+++ b/examples/vue-query/src/gen/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/examples/vue-query/src/gen/.kubb/serializers.ts
+++ b/examples/vue-query/src/gen/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/examples/vue-query/src/gen/clients/pet/findPetsByStatus.ts
+++ b/examples/vue-query/src/gen/clients/pet/findPetsByStatus.ts
@@ -21,7 +21,7 @@ export function findPetsByStatus<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByStatus',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { status: { explode: true } } },
+    styles: { query: { status: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/examples/vue-query/src/gen/clients/pet/findPetsByTags.ts
+++ b/examples/vue-query/src/gen/clients/pet/findPetsByTags.ts
@@ -21,7 +21,7 @@ export function findPetsByTags<ThrowOnError extends boolean = true>(
     method: 'GET',
     url: '/pet/findByTags',
     security: [{ type: 'oauth2' }],
-    serialization: { query: { tags: { explode: true } } },
+    styles: { query: { tags: { explode: true } } },
     ...config,
   }) as Promise<RequestResult<FindPetsByTagsResponses, ThrowOnError>>
 }

--- a/internals/client/src/builders/styles.test.ts
+++ b/internals/client/src/builders/styles.test.ts
@@ -1,6 +1,6 @@
 import { ast } from '@kubb/core'
 import { describe, expect, test } from 'vitest'
-import { buildSerializationMetadata } from './serialization.ts'
+import { buildStyles } from './styles.ts'
 
 function createOperation(parameters: Array<Parameters<typeof ast.factory.createParameter>[0]>) {
   return ast.factory.createOperation({
@@ -15,20 +15,20 @@ function createOperation(parameters: Array<Parameters<typeof ast.factory.createP
 
 const stringSchema = () => ast.factory.createSchema({ type: 'string' })
 
-describe('buildSerializationMetadata', () => {
+describe('buildStyles', () => {
   test('returns null when no parameter carries style or explode', () => {
     const node = createOperation([{ name: 'status', in: 'query', schema: stringSchema() }])
-    expect(buildSerializationMetadata({ node })).toBeNull()
+    expect(buildStyles({ node })).toBeNull()
   })
 
   test('emits path style and explode keyed by the camelCased name', () => {
     const node = createOperation([{ name: 'pet_id', in: 'path', schema: stringSchema(), style: 'matrix', explode: true }])
-    expect(buildSerializationMetadata({ node })).toBe("{ path: { petId: { style: 'matrix', explode: true } } }")
+    expect(buildStyles({ node })).toBe("{ path: { petId: { style: 'matrix', explode: true } } }")
   })
 
   test('emits query style and explode', () => {
     const node = createOperation([{ name: 'tags', in: 'query', schema: stringSchema(), style: 'pipeDelimited', explode: false }])
-    expect(buildSerializationMetadata({ node })).toBe("{ query: { tags: { style: 'pipeDelimited', explode: false } } }")
+    expect(buildStyles({ node })).toBe("{ query: { tags: { style: 'pipeDelimited', explode: false } } }")
   })
 
   test('emits only explode for header and cookie parameters', () => {
@@ -36,12 +36,12 @@ describe('buildSerializationMetadata', () => {
       { name: 'X-Ids', in: 'header', schema: stringSchema(), style: 'simple', explode: true },
       { name: 'session_id', in: 'cookie', schema: stringSchema(), explode: false },
     ])
-    expect(buildSerializationMetadata({ node })).toBe('{ header: { xIds: { explode: true } }, cookie: { sessionId: { explode: false } } }')
+    expect(buildStyles({ node })).toBe('{ header: { xIds: { explode: true } }, cookie: { sessionId: { explode: false } } }')
   })
 
   test('quotes a key whose camelCased name is not a bare identifier', () => {
     const node = createOperation([{ name: '2fa', in: 'query', schema: stringSchema(), explode: true }])
-    expect(buildSerializationMetadata({ node })).toBe('{ query: { "2Fa": { explode: true } } }')
+    expect(buildStyles({ node })).toBe('{ query: { "2Fa": { explode: true } } }')
   })
 
   test('groups multiple locations together', () => {
@@ -49,6 +49,6 @@ describe('buildSerializationMetadata', () => {
       { name: 'id', in: 'path', schema: stringSchema(), style: 'label', explode: false },
       { name: 'fields', in: 'query', schema: stringSchema(), explode: true },
     ])
-    expect(buildSerializationMetadata({ node })).toBe("{ path: { id: { style: 'label', explode: false } }, query: { fields: { explode: true } } }")
+    expect(buildStyles({ node })).toBe("{ path: { id: { style: 'label', explode: false } }, query: { fields: { explode: true } } }")
   })
 })

--- a/internals/client/src/builders/styles.ts
+++ b/internals/client/src/builders/styles.ts
@@ -34,10 +34,10 @@ function serializeParameter(parameter: ast.ParameterNode): string | null {
  * @example
  * ```ts
  * // a path param with { style: 'matrix', explode: true } and a query param with { explode: false }
- * buildSerializationMetadata({ node }) // "{ path: { id: { style: 'matrix', explode: true } }, query: { tags: { explode: false } } }"
+ * buildStyles({ node }) // "{ path: { id: { style: 'matrix', explode: true } }, query: { tags: { explode: false } } }"
  * ```
  */
-export function buildSerializationMetadata({ node }: { node: ast.OperationNode }): string | null {
+export function buildStyles({ node }: { node: ast.OperationNode }): string | null {
   if (!ast.isHttpOperationNode(node)) return null
 
   const groups: Record<StyledLocation, Array<string>> = { path: [], query: [], header: [], cookie: [] }

--- a/internals/client/src/components/Operation.tsx
+++ b/internals/client/src/components/Operation.tsx
@@ -8,7 +8,7 @@ import type { KubbReactNode } from '@kubb/renderer-jsx/types'
 import { buildReturnStatement } from '../builders/returnStatement.ts'
 import { type Auth, buildSecurityMetadata } from '../builders/security.ts'
 import { buildGroupedOptionsSignature } from '../builders/signature.ts'
-import { buildSerializationMetadata } from '../builders/serialization.ts'
+import { buildStyles } from '../builders/styles.ts'
 import { buildValidatorHooks } from '../builders/validator.ts'
 import type { ValidatorOptions } from '../types.ts'
 
@@ -53,7 +53,7 @@ export function Operation({ name, node, tsResolver, zodResolver, validator, secu
   const signature = buildGroupedOptionsSignature({ node, tsResolver })
   const validators = buildValidatorHooks({ node, validator, zodResolver })
   const securityLiteral = buildSecurityMetadata({ security })
-  const serializationLiteral = buildSerializationMetadata({ node })
+  const stylesLiteral = buildStyles({ node })
 
   const { defaultContentType } = getContentTypeInfo(node)
   const hasRequestBody = Boolean(node.requestBody?.content?.[0]?.schema)
@@ -84,7 +84,7 @@ export function Operation({ name, node, tsResolver, zodResolver, validator, secu
     `method: '${node.method.toUpperCase()}'`,
     `url: '${Url.toCasedTemplate(node.path, { casing: 'camelcase' })}'`,
     securityLiteral ? `security: ${securityLiteral}` : null,
-    serializationLiteral ? `serialization: ${serializationLiteral}` : null,
+    stylesLiteral ? `styles: ${stylesLiteral}` : null,
     validatorLiteral,
     contentTypeLiteral,
     responseTypeLiteral,

--- a/packages/plugin-axios/src/generators/__snapshots__/listPetsWithStyles/listPetsStyled.ts
+++ b/packages/plugin-axios/src/generators/__snapshots__/listPetsWithStyles/listPetsStyled.ts
@@ -15,7 +15,7 @@ export function listPetsStyled<ThrowOnError extends boolean = true>(
   return request({
     method: 'GET',
     url: '/pets/{petId}',
-    serialization: { path: { petId: { style: 'matrix', explode: true } }, query: { tags: { style: 'pipeDelimited', explode: false } } },
+    styles: { path: { petId: { style: 'matrix', explode: true } }, query: { tags: { style: 'pipeDelimited', explode: false } } },
     ...config,
   }) as Promise<RequestResult<ListPetsStyledResponses, ThrowOnError>>
 }

--- a/packages/plugin-axios/src/generators/clientGenerator.test.tsx
+++ b/packages/plugin-axios/src/generators/clientGenerator.test.tsx
@@ -187,7 +187,7 @@ describe('clientGenerator operation', () => {
     { name: 'getProject', node: getProjectNode, options: {} },
     { name: 'deletePetNoContent', node: deletePetNode, options: {} },
     { name: 'addPetMultiStatus', node: createPetNode, options: {} },
-    // Parameter style/explode flows from the ParameterNode into a `serialization` call-config entry.
+    // Parameter style/explode flows from the ParameterNode into a `styles` call-config entry.
     { name: 'listPetsWithStyles', node: listPetsStyledNode, options: {} },
     // text/event-stream response returns a typed event stream instead of a one-shot result.
     { name: 'streamEventsSse', node: streamEventsNode, options: {} },

--- a/packages/plugin-axios/templates/axios.test.ts
+++ b/packages/plugin-axios/templates/axios.test.ts
@@ -257,14 +257,14 @@ describe('createClientCore', () => {
     expect(calls[0]?.url).toBe('/pet/3,4/x,1,y,2')
   })
 
-  test('honors per-parameter serialization.path metadata', async () => {
+  test('honors per-parameter styles.path metadata', async () => {
     const { instance, calls } = fakeAxios()
     const client = createClientCore({ transport: instance })
     await client({
       method: 'GET',
       url: '/pet/{id}{filter}',
       path: { id: 5, filter: ['a', 'b'] },
-      serialization: { path: { id: { style: 'matrix' }, filter: { style: 'label' } } },
+      styles: { path: { id: { style: 'matrix' }, filter: { style: 'label' } } },
     })
     expect(calls[0]?.url).toBe('/pet/;id=5.a,b')
   })
@@ -308,10 +308,10 @@ describe('createClientCore', () => {
     expect(serializer({ tags: ['a', 'b'] })).toBe('tags=a&tags=b')
   })
 
-  test('passes serialization.query through the axios paramsSerializer', async () => {
+  test('passes styles.query through the axios paramsSerializer', async () => {
     const { instance, calls } = fakeAxios()
     const client = createClientCore({ transport: instance })
-    await client({ method: 'GET', url: '/pet', query: { id: [3, 4, 5] }, serialization: { query: { id: { style: 'pipeDelimited', explode: false } } } })
+    await client({ method: 'GET', url: '/pet', query: { id: [3, 4, 5] }, styles: { query: { id: { style: 'pipeDelimited', explode: false } } } })
     const serializer = calls[0]?.paramsSerializer as (params: Record<string, unknown>) => string
     expect(serializer({ id: [3, 4, 5] })).toBe('id=3|4|5')
   })
@@ -361,7 +361,7 @@ describe('createClientCore', () => {
       method: 'GET',
       url: '/pet',
       headers: { 'X-Ids': [3, 4], 'X-Filter': { role: 'admin' } },
-      serialization: { header: { 'X-Ids': {}, 'X-Filter': { explode: true } } },
+      styles: { header: { 'X-Ids': {}, 'X-Filter': { explode: true } } },
     })
     const headers = calls[0]?.headers as Record<string, string>
     expect(headers['X-Ids']).toBe('3,4')
@@ -565,7 +565,7 @@ describe('content type negotiation', () => {
   test('runs the matching deserializer before validation and feeds result.data', async () => {
     const { instance } = fakeAxiosWith({ data: '<pet><id>1</id></pet>', contentType: 'application/xml' })
     const parseXml = vi.fn(() => ({ id: 1 }))
-    const client = createClientCore({ transport: instance, deserializers: { 'application/xml': parseXml } })
+    const client = createClientCore({ transport: instance, codecs: { 'application/xml': { deserialize: parseXml } } })
     const result = (await client({ method: 'GET', url: '/pet/1' })) as CallResult<AxiosRequestConfig, AxiosResponse>
     expect(parseXml).toHaveBeenCalledWith('<pet><id>1</id></pet>', 'application/xml')
     expect(result.data).toStrictEqual({ id: 1 })
@@ -575,7 +575,7 @@ describe('content type negotiation', () => {
   test('uses a per-content-type bodySerializer for the request body', async () => {
     const { instance, calls } = fakeAxiosWith({})
     const toXml = vi.fn(() => '<pet/>')
-    const client = createClientCore({ transport: instance, bodySerializers: { 'application/xml': toXml } })
+    const client = createClientCore({ transport: instance, codecs: { 'application/xml': { serialize: toXml } } })
     await client({ method: 'POST', url: '/pet', body: { name: 'odie' }, contentType: 'application/xml' })
     expect(toXml).toHaveBeenCalledWith({ name: 'odie' }, 'application/xml')
     expect(calls[0]?.data).toBe('<pet/>')
@@ -619,16 +619,16 @@ describe('getUrl', () => {
     expect(client.getUrl({ url: '/pet/{petId}', path: { petId: 7 }, serializer: { path: ({ value }) => `id-${value as string}` } })).toBe('/pet/id-7')
   })
 
-  test('applies serialization.path metadata to the matching placeholders', () => {
+  test('applies styles.path metadata to the matching placeholders', () => {
     const { instance } = fakeAxios()
     const client = createClientCore({ transport: instance })
-    expect(client.getUrl({ url: '/pet/{petId}', path: { petId: 7 }, serialization: { path: { petId: { style: 'matrix' } } } })).toBe('/pet/;petId=7')
+    expect(client.getUrl({ url: '/pet/{petId}', path: { petId: 7 }, styles: { path: { petId: { style: 'matrix' } } } })).toBe('/pet/;petId=7')
   })
 
-  test('applies serialization.query metadata to the query string', () => {
+  test('applies styles.query metadata to the query string', () => {
     const { instance } = fakeAxios()
     const client = createClientCore({ transport: instance })
-    expect(client.getUrl({ url: '/pets', query: { id: [3, 4, 5] }, serialization: { query: { id: { style: 'pipeDelimited', explode: false } } } })).toBe(
+    expect(client.getUrl({ url: '/pets', query: { id: [3, 4, 5] }, styles: { query: { id: { style: 'pipeDelimited', explode: false } } } })).toBe(
       '/pets?id=3|4|5',
     )
   })

--- a/packages/plugin-axios/templates/axios.ts
+++ b/packages/plugin-axios/templates/axios.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/packages/plugin-axios/templates/serializers.ts
+++ b/packages/plugin-axios/templates/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/packages/plugin-fetch/src/generators/__snapshots__/listPetsWithStyles/listPetsStyled.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/listPetsWithStyles/listPetsStyled.ts
@@ -15,7 +15,7 @@ export function listPetsStyled<ThrowOnError extends boolean = true>(
   return request({
     method: 'GET',
     url: '/pets/{petId}',
-    serialization: { path: { petId: { style: 'matrix', explode: true } }, query: { tags: { style: 'pipeDelimited', explode: false } } },
+    styles: { path: { petId: { style: 'matrix', explode: true } }, query: { tags: { style: 'pipeDelimited', explode: false } } },
     ...config,
   }) as Promise<RequestResult<ListPetsStyledResponses, ThrowOnError>>
 }

--- a/packages/plugin-fetch/src/generators/clientGenerator.test.tsx
+++ b/packages/plugin-fetch/src/generators/clientGenerator.test.tsx
@@ -218,7 +218,7 @@ describe('clientGenerator operation', () => {
     { name: 'addPetMultiStatus', node: createPetNode, options: {} },
     // multipart/form-data request body bakes a `contentType` into the call config.
     { name: 'uploadFileMultipart', node: uploadFileNode, options: {} },
-    // Parameter style/explode flows from the ParameterNode into a `serialization` call-config entry.
+    // Parameter style/explode flows from the ParameterNode into a `styles` call-config entry.
     { name: 'listPetsWithStyles', node: listPetsStyledNode, options: {} },
     // text/event-stream response returns a typed event stream instead of a one-shot result.
     { name: 'streamEventsSse', node: streamEventsNode, options: {} },

--- a/packages/plugin-fetch/templates/fetch.test.ts
+++ b/packages/plugin-fetch/templates/fetch.test.ts
@@ -263,24 +263,24 @@ describe('createClientCore', () => {
     expect(calls[0]?.url).toBe('/pet/3,4/x,1,y,2')
   })
 
-  test('honors per-parameter serialization.path metadata', async () => {
+  test('honors per-parameter styles.path metadata', async () => {
     const { client, calls } = createClient()
     await client({
       method: 'GET',
       url: '/pet/{id}{filter}',
       path: { id: 5, filter: ['a', 'b'] },
-      serialization: { path: { id: { style: 'matrix' }, filter: { style: 'label' } } },
+      styles: { path: { id: { style: 'matrix' }, filter: { style: 'label' } } },
     })
     expect(calls[0]?.url).toBe('/pet/;id=5.a,b')
   })
 
-  test('honors per-parameter serialization.query metadata', async () => {
+  test('honors per-parameter styles.query metadata', async () => {
     const { client, calls } = createClient()
     await client({
       method: 'GET',
       url: '/pets',
       query: { id: [3, 4], filter: { a: 1 } },
-      serialization: { query: { id: { style: 'pipeDelimited', explode: false }, filter: { style: 'deepObject' } } },
+      styles: { query: { id: { style: 'pipeDelimited', explode: false }, filter: { style: 'deepObject' } } },
     })
     expect(calls[0]?.url).toBe('/pets?id=3|4&filter%5Ba%5D=1')
   })
@@ -304,7 +304,7 @@ describe('createClientCore', () => {
       method: 'GET',
       url: '/pet',
       headers: { 'X-Ids': [3, 4], 'X-Filter': { role: 'admin' } },
-      serialization: { header: { 'X-Ids': {}, 'X-Filter': { explode: true } } },
+      styles: { header: { 'X-Ids': {}, 'X-Filter': { explode: true } } },
     })
     expect(calls[0]?.headers['X-Ids']).toBe('3,4')
     expect(calls[0]?.headers['X-Filter']).toBe('role=admin')
@@ -502,7 +502,7 @@ describe('content type negotiation', () => {
   test('runs the matching deserializer before validation and feeds result.data', async () => {
     const { transport } = transportWith({ data: '<pet><id>1</id></pet>', contentType: 'application/xml' })
     const parseXml = vi.fn(() => ({ id: 1 }))
-    const client = createClientCore<string, string>({ defaultTransport: transport, deserializers: { 'application/xml': parseXml } })
+    const client = createClientCore<string, string>({ defaultTransport: transport, codecs: { 'application/xml': { deserialize: parseXml } } })
     const result = (await client({ method: 'GET', url: '/pet/1' })) as CallResult<string, string>
     expect(parseXml).toHaveBeenCalledWith('<pet><id>1</id></pet>', 'application/xml')
     expect(result.data).toStrictEqual({ id: 1 })
@@ -513,8 +513,8 @@ describe('content type negotiation', () => {
     const { transport } = transportWith({ data: 'raw', contentType: 'application/xml; charset=utf-8' })
     const clientLevel = vi.fn(() => ({ from: 'client' }))
     const perCall = vi.fn(() => ({ from: 'call' }))
-    const client = createClientCore<string, string>({ defaultTransport: transport, deserializers: { 'application/xml': clientLevel } })
-    const result = (await client({ method: 'GET', url: '/pet/1', deserializers: { 'application/xml': perCall } })) as CallResult<string, string>
+    const client = createClientCore<string, string>({ defaultTransport: transport, codecs: { 'application/xml': { deserialize: clientLevel } } })
+    const result = (await client({ method: 'GET', url: '/pet/1', codecs: { 'application/xml': { deserialize: perCall } } })) as CallResult<string, string>
     expect(clientLevel).not.toHaveBeenCalled()
     expect(perCall).toHaveBeenCalledTimes(1)
     expect(result.data).toStrictEqual({ from: 'call' })
@@ -523,7 +523,7 @@ describe('content type negotiation', () => {
   test('uses a per-content-type bodySerializer for the request body', async () => {
     const { transport, calls } = transportWith({})
     const toXml = vi.fn(() => '<pet/>')
-    const client = createClientCore<string, string>({ defaultTransport: transport, bodySerializers: { 'application/xml': toXml } })
+    const client = createClientCore<string, string>({ defaultTransport: transport, codecs: { 'application/xml': { serialize: toXml } } })
     await client({ method: 'POST', url: '/pet', body: { name: 'odie' }, contentType: 'application/xml' })
     expect(toXml).toHaveBeenCalledWith({ name: 'odie' }, 'application/xml')
     expect(calls[0]?.body).toBe('<pet/>')
@@ -564,14 +564,14 @@ describe('getUrl', () => {
     expect(client.getUrl({ url: '/pet/{petId}', path: { petId: 7 }, serializer: { path: ({ value }) => `id-${value as string}` } })).toBe('/pet/id-7')
   })
 
-  test('applies serialization.path metadata to the matching placeholders', () => {
+  test('applies styles.path metadata to the matching placeholders', () => {
     const { client } = createClient()
-    expect(client.getUrl({ url: '/pet/{petId}', path: { petId: 7 }, serialization: { path: { petId: { style: 'matrix' } } } })).toBe('/pet/;petId=7')
+    expect(client.getUrl({ url: '/pet/{petId}', path: { petId: 7 }, styles: { path: { petId: { style: 'matrix' } } } })).toBe('/pet/;petId=7')
   })
 
-  test('applies serialization.query metadata to the query string', () => {
+  test('applies styles.query metadata to the query string', () => {
     const { client } = createClient()
-    expect(client.getUrl({ url: '/pets', query: { id: [3, 4, 5] }, serialization: { query: { id: { style: 'spaceDelimited', explode: false } } } })).toBe(
+    expect(client.getUrl({ url: '/pets', query: { id: [3, 4, 5] }, styles: { query: { id: { style: 'spaceDelimited', explode: false } } } })).toBe(
       '/pets?id=3%204%205',
     )
   })

--- a/packages/plugin-fetch/templates/fetch.ts
+++ b/packages/plugin-fetch/templates/fetch.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/packages/plugin-fetch/templates/serializers.ts
+++ b/packages/plugin-fetch/templates/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/client.ts
@@ -1,5 +1,5 @@
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -91,14 +91,24 @@ export type RequestCredentials = 'omit' | 'same-origin' | 'include'
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => BodyInit | undefined
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -151,7 +161,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   credentials?: RequestCredentials
   options?: FetchOptions
@@ -161,8 +171,7 @@ export type RequestConfig<TBody = unknown, TRequest = Request, TResponse = Respo
   client?: ClientInstance<TRequest, TResponse>
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -192,8 +201,7 @@ export type ClientConfig<TRequest = Request, TResponse = Response> = {
   throwOnError?: boolean
   transport?: Transport<TRequest, TResponse>
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -445,10 +453,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -465,17 +472,17 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const rawBody = requestConfig.body
     const validatedBody = await runValidator(requestConfig.validator?.request, rawBody)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so the runtime appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -486,9 +493,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const url = serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
 
     const options = config.options || requestConfig.options ? { ...config.options, ...requestConfig.options } : undefined
@@ -514,8 +521,8 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     const contentType = result.contentType ?? getResponseContentType(result.headers)
     let decoded = result.data
     if (contentType) {
-      const deserialize = deserializers[contentType]
-      if (deserialize) decoded = await deserialize(result.data, contentType)
+      const codec = codecs[contentType]
+      if (codec?.deserialize) decoded = await codec.deserialize(result.data, contentType)
     }
 
     const parsedErrorData = !isSuccess ? await runValidator(requestConfig.validator?.error, decoded) : undefined
@@ -558,9 +565,9 @@ export function createClientCore<TRequest = Request, TResponse = Response>(
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/client.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { applyHeaderStyles, defaultBodySerializer, defaultPathSerializer, defaultQuerySerializer, serializeCookies } from './serializers'
-import type { HeadersInit, PathParamStyle, PathSerializer, RequestSerialization, Serializers } from './serializers'
+import type { HeadersInit, PathParamStyle, PathSerializer, Serializers, Styles } from './serializers'
 import { type StandardSchemaValidator, validateStandardSchema } from './standardSchema.ts'
 
 /**
@@ -92,14 +92,24 @@ export type DataShape = { body?: unknown; cookies?: unknown; headers?: unknown; 
 export type ResponseType = 'arraybuffer' | 'blob' | 'document' | 'json' | 'text' | 'stream' | 'formdata'
 
 /**
- * Turns a raw response body into a parsed value, registered per media type on `deserializers` to handle formats the runtime does not decode itself.
+ * Turns a raw response body into a parsed value, registered per media type as a codec's `deserialize` to handle formats the runtime does not decode itself.
  */
 export type Deserializer<T = unknown> = (raw: unknown, contentType: string) => T | Promise<T>
 
 /**
- * Serializes a request body for a single media type, registered per content type on `bodySerializers` to encode formats the default serializer does not handle.
+ * Serializes a request body for a single media type, registered per content type as a codec's `serialize` to encode formats the default serializer does not handle.
  */
 export type ContentBodySerializer = (body: unknown, contentType?: string) => unknown
+
+/**
+ * A per-content-type codec registered on `codecs`, keyed by content type. `serialize` encodes the
+ * request body for that media type and `deserialize` decodes the response body. Either half is
+ * optional, so a codec can handle one direction.
+ */
+export type Codec = {
+  serialize?: ContentBodySerializer
+  deserialize?: Deserializer
+}
 
 /**
  * The per-call content type selection, where a bare string sets the request content type and the object form also sets the response format sent as `Accept`.
@@ -152,7 +162,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   cookies?: Record<string, unknown>
   body?: TBody
   headers?: HeadersInit
-  serialization?: RequestSerialization
+  styles?: Styles
   signal?: AbortSignal
   options?: AxiosOptions
   contentType?: ContentType
@@ -162,8 +172,7 @@ export type RequestConfig<TBody = unknown, TRequest = AxiosRequestConfig, TRespo
   client?: ClientInstance<TRequest, TResponse>
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   validator?: { request?: Validator; response?: Validator; error?: Validator }
   security?: Array<Auth>
   auth?: AuthResolver
@@ -193,8 +202,7 @@ export type ClientConfig = {
   validateStatus?: (status: number) => boolean
   transport?: AxiosInstance
   serializer?: Serializers
-  bodySerializers?: Record<string, ContentBodySerializer>
-  deserializers?: Record<string, Deserializer>
+  codecs?: Record<string, Codec>
   auth?: AuthResolver
 }
 
@@ -525,10 +533,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     const querySerializer = requestConfig.serializer?.query ?? config.serializer?.query ?? defaultQuerySerializer
     const bodySerializer = requestConfig.serializer?.body ?? config.serializer?.body ?? defaultBodySerializer
     const pathSerializer = requestConfig.serializer?.path ?? config.serializer?.path ?? defaultPathSerializer
-    const bodySerializers = { ...config.bodySerializers, ...requestConfig.bodySerializers }
-    const deserializers = { ...config.deserializers, ...requestConfig.deserializers }
+    const codecs = { ...config.codecs, ...requestConfig.codecs }
 
-    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.serialization?.header))
+    const headers = mergeHeaders(config.headers, applyHeaderStyles(requestConfig.headers, requestConfig.styles?.header))
     const { request: requestContentTypeOption, response: responseContentType } = resolveContentType(requestConfig.contentType)
     const requestContentType = requestContentTypeOption ?? headers['Content-Type'] ?? headers['content-type']
     if (responseContentType && headers['Accept'] === undefined && headers['accept'] === undefined) {
@@ -545,16 +552,16 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     })
 
     if (requestConfig.cookies) {
-      const cookie = serializeCookies(requestConfig.cookies, requestConfig.serialization?.cookie)
+      const cookie = serializeCookies(requestConfig.cookies, requestConfig.styles?.cookie)
       if (cookie) headers.Cookie = [headers.Cookie, cookie].filter(Boolean).join('; ')
     }
 
     const validatedBody = await runValidator(requestConfig.validator?.request, requestConfig.body)
     const requestContentTypeBase = baseContentType(requestContentType)
-    const contentBodySerializer = requestContentTypeBase ? bodySerializers[requestContentTypeBase] : undefined
-    const body = contentBodySerializer
-      ? contentBodySerializer(validatedBody, requestContentType)
-      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.serialization?.body })
+    const contentCodec = requestContentTypeBase ? codecs[requestContentTypeBase] : undefined
+    const body = contentCodec?.serialize
+      ? contentCodec.serialize(validatedBody, requestContentType)
+      : bodySerializer({ body: validatedBody, contentType: requestContentType, encoding: requestConfig.styles?.body })
     // A FormData body must keep its Content-Type unset so axios appends the multipart boundary.
     if (body instanceof FormData) {
       delete headers['Content-Type']
@@ -564,7 +571,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     }
     const pathParams = requestConfig.path ?? {}
     const url = (requestConfig.url ?? '').replace(/\{([^{}]+)\}/g, (_, key: string) =>
-      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.serialization?.path?.[key] }),
+      pathSerializer({ name: key, value: pathParams[key], options: requestConfig.styles?.path?.[key] }),
     )
     const baseURL = [config.baseURL, requestConfig.baseURL].filter(Boolean).join('') || undefined
 
@@ -580,7 +587,7 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       method: requestConfig.method ?? 'GET',
       headers,
       params: query,
-      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.serialization?.query),
+      paramsSerializer: (params) => querySerializer(params as Record<string, unknown>, requestConfig.styles?.query),
       data: body,
       transformRequest: (data) => data,
       signal: requestConfig.signal,
@@ -600,8 +607,8 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
       const contentType = getResponseContentType(response.headers as Record<string, unknown>)
       let decoded: unknown = response.data
       if (contentType) {
-        const deserialize = deserializers[contentType]
-        if (deserialize) decoded = await deserialize(response.data, contentType)
+        const codec = codecs[contentType]
+        if (codec?.deserialize) decoded = await codec.deserialize(response.data, contentType)
       }
       const data = isSuccess ? await runValidator(requestConfig.validator?.response, decoded) : undefined
       const error = isSuccess ? undefined : await runValidator(requestConfig.validator?.error, decoded)
@@ -641,9 +648,9 @@ export function createClientCore<TRequest = AxiosRequestConfig, TResponse = Axio
     return serializeUrl({
       parts: [config.baseURL, requestConfig.baseURL, requestConfig.url],
       pathParams: requestConfig.path ?? {},
-      search: querySerializer(query, requestConfig.serialization?.query),
+      search: querySerializer(query, requestConfig.styles?.query),
       pathSerializer,
-      pathStyles: requestConfig.serialization?.path,
+      pathStyles: requestConfig.styles?.path,
     })
   }
   client.interceptors = interceptors

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/serializers.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/.kubb/serializers.ts
@@ -99,10 +99,11 @@ export type Serializers = {
 }
 
 /**
- * The per-parameter serialization metadata a generated request carries, grouped by location. Each
- * map is keyed by parameter name, mirroring the `serializer` grouping.
+ * The per-parameter OpenAPI `style` / `explode` metadata a generated request carries, grouped by
+ * location and keyed by parameter name. Mirrors the `serializer` grouping and feeds the default
+ * serializers; `body` carries the form `encoding` for a urlencoded or multipart body.
  */
-export type RequestSerialization = {
+export type Styles = {
   path?: Record<string, PathParamStyle>
   query?: Record<string, QueryParamStyle>
   header?: Record<string, HeaderParamStyle>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/clients/findPetsByStatus.ts
@@ -15,5 +15,5 @@ import { client } from '../.kubb/client.ts'
 export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
-  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], serialization: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
+  return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
 }


### PR DESCRIPTION
## Changes

Two breaking renames to the generated client's runtime config (`@kubb/plugin-fetch` and `@kubb/plugin-axios`), to remove a pair of confusing name collisions.

### `bodySerializers` + `deserializers` → `codecs`

The per-content-type request and response maps merge into one `codecs` map, keyed by content type, where each entry holds a `serialize` and a `deserialize` function (either half optional). This removes the overlap with the single `serializer.body` function and pairs request encoding with response decoding per media type.

```ts
// before
client.setConfig({
  bodySerializers: { 'application/xml': (body) => build(body) },
  deserializers: { 'application/xml': (raw) => parse(raw) },
})

// after
client.setConfig({
  codecs: {
    'application/xml': { serialize: (body) => build(body), deserialize: (raw) => parse(raw) },
  },
})
```

### `serialization` → `styles`

The per-parameter OpenAPI `style`/`explode` metadata (a generated operation carries it, and it is overridable per call) is renamed to `styles`, so it no longer reads like the `serializer` functions. Generated operations now emit a `styles:` entry, and the internal `buildSerializationMetadata` builder becomes `buildStyles` (`builders/serialization.ts` → `builders/styles.ts`).

```ts
// before:  serialization: { query: { tags: { style: 'pipeDelimited', explode: false } } }
// after:   styles:        { query: { tags: { style: 'pipeDelimited', explode: false } } }
```

## Why

`serializer.body` (the single body serializer) versus `bodySerializers` (the per-content-type map), and `serializer` (functions) versus `serialization` (style metadata), were too easy to confuse. The naming here follows the convention in other generators: a codec selected by content type (Dart, Spring's message converters) and OpenAPI's own `style` term for the per-parameter metadata.

## Scope

- Runtime templates: `plugin-fetch/templates/{fetch,serializers}.ts`, `plugin-axios/templates/{axios,serializers}.ts`
- Generator: `internals/client/src/components/Operation.tsx` and the renamed `builders/styles.ts`
- Tests and `__snapshots__` updated; consumers (react-query, vue-query, swr, mcp) typecheck unchanged
- Changeset added (minor bump on both client plugins)

Verified: `plugin-fetch` (111), `plugin-axios` (102), `@internals/client` (46) test suites pass; typecheck passes for the client plugins and their consumers; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gDd1kadwn4PionXob97We

---
_Generated by [Claude Code](https://claude.ai/code/session_016gDd1kadwn4PionXob97We)_