### PR TITLE
refactor(tanstack-query): share value-or-getter type wrappers across plugins

### DIFF
--- a/.changeset/share-value-or-getter-wrappers.md
+++ b/.changeset/share-value-or-getter-wrappers.md
@@ -1,4 +1,0 @@
----
----
-
-Internal refactor with no release. The `maybeRefOrGetter` (vue-query) and `maybeValueOrGetter` (react-query) request-param type wrappers now live in the shared `@internals/tanstack-query` package, so the value-or-getter concept has one home. A doc comment there records why the unwrap strategy stays per plugin. Vue resolves lazily through `toValue` because its query keys are reactive. React resolves once at the hook boundary because React Query hashes keys. Both plugins re-export the wrappers and the generated output stays byte-identical.

--- a/.changeset/share-value-or-getter-wrappers.md
+++ b/.changeset/share-value-or-getter-wrappers.md
@@ -1,0 +1,4 @@
+---
+---
+
+Internal refactor with no release. The `maybeRefOrGetter` (vue-query) and `maybeValueOrGetter` (react-query) request-param type wrappers now live in the shared `@internals/tanstack-query` package, so the value-or-getter concept has one home. A doc comment there records why the unwrap strategy stays per plugin. Vue resolves lazily through `toValue` because its query keys are reactive. React resolves once at the hook boundary because React Query hashes keys. Both plugins re-export the wrappers and the generated output stays byte-identical.

--- a/internals/tanstack-query/src/index.ts
+++ b/internals/tanstack-query/src/index.ts
@@ -6,6 +6,8 @@ export {
   buildQueryKeyParams,
   buildQueryOptionsParams,
   buildClientCall,
+  maybeRefOrGetter,
+  maybeValueOrGetter,
   resolveOperationOverrides,
   resolveQueryParamsParser,
   resolveRequestParser,

--- a/internals/tanstack-query/src/utils.ts
+++ b/internals/tanstack-query/src/utils.ts
@@ -12,6 +12,24 @@ const requestGroupOrder = ['path', 'query', 'body', 'headers'] as const
 type RequestGroupKey = (typeof requestGroupOrder)[number]
 
 /**
+ * Widens a request-group member type so a generated TanStack hook accepts either the value or a
+ * deferred value. Both plugins apply this through the `memberTypeWrapper` of `buildGroupedRequestParam`;
+ * they only differ in how the deferred form is later resolved.
+ *
+ * `maybeRefOrGetter` is used by vue-query, which keeps the ref/getter live and unwraps it lazily with
+ * `toValue` because vue-query keys are reactive. `maybeValueOrGetter` is used by react-query, which
+ * resolves the getter once at the hook boundary and forwards a plain value because React Query hashes
+ * keys structurally and cannot hold a function.
+ */
+export function maybeRefOrGetter(type: string): string {
+  return `MaybeRefOrGetter<${type}>`
+}
+
+export function maybeValueOrGetter(type: string): string {
+  return `${type} | (() => ${type})`
+}
+
+/**
  * Builds the grouped `{ path, query, body, headers }` parameter that mirrors the client
  * function signature. Only the groups the operation carries are emitted, typed from the
  * operation's `RequestConfig`. `keys` narrows the emitted groups, used by the query key which

--- a/packages/plugin-react-query/src/utils.ts
+++ b/packages/plugin-react-query/src/utils.ts
@@ -1,19 +1,10 @@
 import { getRequestGroups } from '@internals/shared'
 import type { ast } from '@kubb/core'
 
-export { buildQueryKeyParams, resolveOperationOverrides, resolveZodSchemaNames } from '@internals/tanstack-query'
+export { buildQueryKeyParams, maybeValueOrGetter, resolveOperationOverrides, resolveZodSchemaNames } from '@internals/tanstack-query'
 export { buildClientOptionType, buildOperationComments as getComments, buildRequestConfigType, resolveErrorNames, resolveSuccessNames } from '@internals/shared'
 
 const requestGroupOrder = ['path', 'query', 'body', 'headers'] as const
-
-/**
- * Widens a type string to `T | (() => T)` so a generated hook signature accepts either the value or a
- * zero-arg getter. React has no `MaybeRefOrGetter`/`toValue` runtime to import, so the union is inlined
- * rather than referencing a named type.
- */
-export function maybeValueOrGetter(type: string): string {
-  return `${type} | (() => ${type})`
-}
 
 /**
  * Builds the object literal that resolves each request group to a concrete value, unwrapping a getter

--- a/packages/plugin-vue-query/src/utils.ts
+++ b/packages/plugin-vue-query/src/utils.ts
@@ -1,15 +1,8 @@
 import { getRequestGroups } from '@internals/shared'
 import type { ast } from '@kubb/core'
 
-export { buildQueryKeyParams, resolveOperationOverrides, resolveZodSchemaNames } from '@internals/tanstack-query'
+export { buildQueryKeyParams, maybeRefOrGetter, resolveOperationOverrides, resolveZodSchemaNames } from '@internals/tanstack-query'
 export { buildClientOptionType, buildOperationComments as getComments, buildRequestConfigType, resolveErrorNames, resolveSuccessNames } from '@internals/shared'
-
-/**
- * Wraps a type string in `MaybeRefOrGetter<…>` so a vue-query signature accepts refs or getters.
- */
-export function maybeRefOrGetter(type: string): string {
-  return `MaybeRefOrGetter<${type}>`
-}
 
 const requestGroupOrder = ['path', 'query', 'body', 'headers'] as const
 


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #597. Now that both react-query and vue-query express their request params as "value or deferred value", this gives that concept a single home.

`maybeRefOrGetter` (vue-query) and `maybeValueOrGetter` (react-query) were one-line type wrappers defined separately in each plugin's `utils.ts`. Both are applied the same way, through the shared `buildGroupedRequestParam`'s `memberTypeWrapper` hook, so they now live together in `@internals/tanstack-query`. Each plugin re-exports its wrapper, so the components are untouched and generated output is byte-identical.

A doc comment next to the two wrappers records why only the type wrapper is shared and the unwrap strategy stays per plugin: vue-query keeps the ref/getter live and resolves it lazily with `toValue` because its query keys are reactive, while react-query resolves once at the hook boundary and forwards a plain value because React Query hashes keys structurally. Merging the unwrap would break one or the other, so `buildVueClientCall` (lazy) and `buildResolvedRequestParams` (eager) intentionally stay in their plugins.

Scope: two wrappers moved into `internals/tanstack-query` plus the matching re-export lines. No behavior change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

Verification: `pnpm typecheck` (react-query + vue-query) and `pnpm lint` green, `oxfmt --check` clean, and the full suite passes with no snapshot changes (1157 tests, 65 files) — confirming byte-identical output.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [x] Internal-only refactor, no release. An empty changeset documents it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWT8hxH2fD8FaWCri2zWVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AWT8hxH2fD8FaWCri2zWVo)_