### PR TITLE
fix: client optional options parameter

### DIFF
--- a/.changeset/optional-client-options.md
+++ b/.changeset/optional-client-options.md
@@ -1,0 +1,6 @@
+---
+"@kubb/plugin-axios": patch
+"@kubb/plugin-fetch": patch
+---
+
+Default generated `options` parameters to `{}` when an operation has no required request data, allowing calls like `getInventory()` without passing an empty object.

--- a/internals/client/src/builders/signature.test.ts
+++ b/internals/client/src/builders/signature.test.ts
@@ -14,11 +14,31 @@ const addPet = ast.factory.createOperation({
   responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
 })
 
+const listPets = ast.factory.createOperation({
+  operationId: 'listPets',
+  method: 'GET',
+  path: '/pets',
+  parameters: [
+    ast.factory.createParameter({
+      name: 'limit',
+      in: 'query',
+      required: false,
+      schema: ast.factory.createSchema({ type: 'integer' }),
+    }),
+  ],
+  responses: [ast.factory.createResponse({ statusCode: '200', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'ok' })],
+})
+
 describe('buildGroupedOptionsSignature', () => {
   test('emits a single grouped options parameter with a ThrowOnError generic', () => {
     const signature = buildGroupedOptionsSignature({ node: addPet, tsResolver: resolverTs })
     expect(signature.paramsSignature).toBe('options: Options<AddPetRequestConfig, ThrowOnError>')
     expect(signature.generics).toStrictEqual(['ThrowOnError extends boolean = true'])
+  })
+
+  test('defaults the options parameter when the operation has no required request data', () => {
+    const signature = buildGroupedOptionsSignature({ node: listPets, tsResolver: resolverTs })
+    expect(signature.paramsSignature).toBe('options: Options<ListPetsRequestConfig, ThrowOnError> = {}')
   })
 
   test('keys the return type on the plugin-ts per-status responses record', () => {

--- a/internals/client/src/builders/signature.ts
+++ b/internals/client/src/builders/signature.ts
@@ -1,4 +1,5 @@
 import type { ast } from '@kubb/core'
+import { getRequestGroupOptionality } from '@internals/shared'
 import { createFunctionParameter, createFunctionParameters, functionPrinter, type ResolverTs } from '@kubb/plugin-ts'
 import { buildRequestResultGenerics } from './generics.ts'
 
@@ -43,11 +44,12 @@ export function buildGroupedOptionsSignature({ node, tsResolver }: { node: ast.O
   const requestConfigName = tsResolver.resolveRequestConfigName(node)
   const responsesName = tsResolver.resolveResponsesName(node)
   const resultGenerics = buildRequestResultGenerics({ node, tsResolver })
+  const { isOptional } = getRequestGroupOptionality(node)
 
   const paramsSignature =
     declarationPrinter.print(
       createFunctionParameters({
-        params: [createFunctionParameter({ name: 'options', type: `Options<${requestConfigName}, ThrowOnError>` })],
+        params: [createFunctionParameter({ name: 'options', type: `Options<${requestConfigName}, ThrowOnError>`, ...(isOptional ? { default: '{}' } : {}) })],
       }),
     ) ?? ''
 

--- a/packages/plugin-axios/src/generators/__snapshots__/sdkClass/storeClient.ts
+++ b/packages/plugin-axios/src/generators/__snapshots__/sdkClass/storeClient.ts
@@ -15,7 +15,7 @@ export class StoreClient {
    * {@link /store/inventory}
    */
   public getInventory<ThrowOnError extends boolean = true>(
-    options: Options<GetInventoryRequestConfig, ThrowOnError>,
+    options: Options<GetInventoryRequestConfig, ThrowOnError> = {},
   ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 

--- a/packages/plugin-axios/src/generators/__snapshots__/sdkClassWithName/storeClient.ts
+++ b/packages/plugin-axios/src/generators/__snapshots__/sdkClassWithName/storeClient.ts
@@ -15,7 +15,7 @@ export class StoreClient {
    * {@link /store/inventory}
    */
   public getInventory<ThrowOnError extends boolean = true>(
-    options: Options<GetInventoryRequestConfig, ThrowOnError>,
+    options: Options<GetInventoryRequestConfig, ThrowOnError> = {},
   ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 

--- a/packages/plugin-axios/src/generators/__snapshots__/sdkSingle/petStore.ts
+++ b/packages/plugin-axios/src/generators/__snapshots__/sdkSingle/petStore.ts
@@ -40,7 +40,7 @@ export class PetStore {
    * {@link /store/inventory}
    */
   public getInventory<ThrowOnError extends boolean = true>(
-    options: Options<GetInventoryRequestConfig, ThrowOnError>,
+    options: Options<GetInventoryRequestConfig, ThrowOnError> = {},
   ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 

--- a/packages/plugin-axios/src/generators/__snapshots__/streamEventsSse/streamEvents.ts
+++ b/packages/plugin-axios/src/generators/__snapshots__/streamEventsSse/streamEvents.ts
@@ -8,7 +8,7 @@ import { client, toEventStream } from './.kubb/client'
  * {@link /events}
  */
 export function streamEvents<ThrowOnError extends boolean = true>(
-  options: Options<StreamEventsRequestConfig, ThrowOnError>,
+  options: Options<StreamEventsRequestConfig, ThrowOnError> = {},
 ): Promise<EventStreamResult<SuccessOf<StreamEventsResponses>>> {
   const { client: request = client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/sdkClass/storeClient.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/sdkClass/storeClient.ts
@@ -15,7 +15,7 @@ export class StoreClient {
    * {@link /store/inventory}
    */
   public getInventory<ThrowOnError extends boolean = true>(
-    options: Options<GetInventoryRequestConfig, ThrowOnError>,
+    options: Options<GetInventoryRequestConfig, ThrowOnError> = {},
   ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/sdkClassWithName/storeClient.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/sdkClassWithName/storeClient.ts
@@ -15,7 +15,7 @@ export class StoreClient {
    * {@link /store/inventory}
    */
   public getInventory<ThrowOnError extends boolean = true>(
-    options: Options<GetInventoryRequestConfig, ThrowOnError>,
+    options: Options<GetInventoryRequestConfig, ThrowOnError> = {},
   ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/sdkClassWithSecurity/petStore.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/sdkClassWithSecurity/petStore.ts
@@ -45,7 +45,7 @@ export class PetStore {
    * {@link /store/inventory}
    */
   public getInventory<ThrowOnError extends boolean = true>(
-    options: Options<GetInventoryRequestConfig, ThrowOnError>,
+    options: Options<GetInventoryRequestConfig, ThrowOnError> = {},
   ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/sdkSingle/petStore.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/sdkSingle/petStore.ts
@@ -40,7 +40,7 @@ export class PetStore {
    * {@link /store/inventory}
    */
   public getInventory<ThrowOnError extends boolean = true>(
-    options: Options<GetInventoryRequestConfig, ThrowOnError>,
+    options: Options<GetInventoryRequestConfig, ThrowOnError> = {},
   ): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 

--- a/packages/plugin-fetch/src/generators/__snapshots__/streamEventsSse/streamEvents.ts
+++ b/packages/plugin-fetch/src/generators/__snapshots__/streamEventsSse/streamEvents.ts
@@ -8,7 +8,7 @@ import { client, toEventStream } from './.kubb/client'
  * {@link /events}
  */
 export function streamEvents<ThrowOnError extends boolean = true>(
-  options: Options<StreamEventsRequestConfig, ThrowOnError>,
+  options: Options<StreamEventsRequestConfig, ThrowOnError> = {},
 ): Promise<EventStreamResult<SuccessOf<StreamEventsResponses>>> {
   const { client: request = client, ...config } = options
 

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/clients/petClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/clients/petClient.ts
@@ -34,7 +34,7 @@ export class PetClient {
    * @summary Finds Pets by status
    * {@link /pet/findByStatus}
    */
-    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/clients/storeClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/clients/storeClient.ts
@@ -20,7 +20,7 @@ export class StoreClient {
    * @summary Returns pet inventories by status
    * {@link /store/inventory}
    */
-    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/clients/petClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/clients/petClient.ts
@@ -34,7 +34,7 @@ export class PetClient {
    * @summary Finds Pets by status
    * {@link /pet/findByStatus}
    */
-    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/clients/storeClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/clients/storeClient.ts
@@ -20,7 +20,7 @@ export class StoreClient {
    * @summary Returns pet inventories by status
    * {@link /store/inventory}
    */
-    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/clients/petStore.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/clients/petStore.ts
@@ -36,7 +36,7 @@ export class PetStore {
    * @summary Finds Pets by status
    * {@link /pet/findByStatus}
    */
-    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
@@ -79,7 +79,7 @@ export class PetStore {
    * @summary Returns pet inventories by status
    * {@link /store/inventory}
    */
-    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/clients/petClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/clients/petClient.ts
@@ -34,7 +34,7 @@ export class PetClient {
    * @summary Finds Pets by status
    * {@link /pet/findByStatus}
    */
-    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/clients/storeClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/clients/storeClient.ts
@@ -20,7 +20,7 @@ export class StoreClient {
    * @summary Returns pet inventories by status
    * {@link /store/inventory}
    */
-    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/clients/petClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/clients/petClient.ts
@@ -34,7 +34,7 @@ export class PetClient {
    * @summary Finds Pets by status
    * {@link /pet/findByStatus}
    */
-    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/clients/storeClient.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/clients/storeClient.ts
@@ -20,7 +20,7 @@ export class StoreClient {
    * @summary Returns pet inventories by status
    * {@link /store/inventory}
    */
-    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/clients/petStore.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/clients/petStore.ts
@@ -36,7 +36,7 @@ export class PetStore {
    * @summary Finds Pets by status
    * {@link /pet/findByStatus}
    */
-    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+    public findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>
@@ -79,7 +79,7 @@ export class PetStore {
    * @summary Returns pet inventories by status
    * {@link /store/inventory}
    */
-    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+    public getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
     const { client: request = this.client, ...config } = options
 
     return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/clients/findPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/clients/findPetsByStatus.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Finds Pets by status
  * {@link /pet/findByStatus}
  */
-export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError>): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
+export function findPetsByStatus<ThrowOnError extends boolean = true>(options: Options<FindPetsByStatusRequestConfig, ThrowOnError> = {}): Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/pet/findByStatus', security: [{ type: 'oauth2' }], styles: { query: { status: { explode: true } } }, ...config }) as Promise<RequestResult<FindPetsByStatusResponses, ThrowOnError>>

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/clients/getInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/clients/getInventory.ts
@@ -12,7 +12,7 @@ import { client } from '../.kubb/client.ts'
  * @summary Returns pet inventories by status
  * {@link /store/inventory}
  */
-export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError>): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
+export function getInventory<ThrowOnError extends boolean = true>(options: Options<GetInventoryRequestConfig, ThrowOnError> = {}): Promise<RequestResult<GetInventoryResponses, ThrowOnError>> {
   const { client: request = client, ...config } = options
 
   return request({ method: 'GET', url: '/store/inventory', security: [{ type: 'apiKey', name: 'api_key', in: 'header' }], ...config }) as Promise<RequestResult<GetInventoryResponses, ThrowOnError>>

--- a/tests/3.0.x/pluginReactQuery.test.ts
+++ b/tests/3.0.x/pluginReactQuery.test.ts
@@ -273,7 +273,7 @@ const configs: Array<{ name: string; config: BuildConfig }> = [
 
 describe(`plugin-react-query options ${version}`, () => {
   test.each(configs)('config testing with config as $name', async ({ name, config }) => {
-    const tmpDir = path.join(os.tmpdir(), `kubb-test-${name}-${Date.now()}`)
+    const tmpDir = path.join(os.tmpdir(), `kubb-test-react-query-${name}-${Date.now()}`)
     const output = path.join(tmpDir, name)
     const { files, diagnostics } = await createKubb(
       {

--- a/tests/3.0.x/pluginSwr.test.ts
+++ b/tests/3.0.x/pluginSwr.test.ts
@@ -228,7 +228,7 @@ const configs: Array<{ name: string; config: BuildConfig }> = [
 
 describe(`plugin-swr options ${version}`, () => {
   test.each(configs)('config testing with config as $name', async ({ name, config }) => {
-    const tmpDir = path.join(os.tmpdir(), `kubb-test-${name}-${Date.now()}`)
+    const tmpDir = path.join(os.tmpdir(), `kubb-test-swr-${name}-${Date.now()}`)
     const output = path.join(tmpDir, name)
     const { files, diagnostics } = await createKubb(
       {

--- a/tests/3.0.x/pluginVueQuery.test.ts
+++ b/tests/3.0.x/pluginVueQuery.test.ts
@@ -223,7 +223,7 @@ const configs: Array<{ name: string; config: BuildConfig }> = [
 
 describe(`plugin-vue-query options ${version}`, () => {
   test.each(configs)('config testing with config as $name', async ({ name, config }) => {
-    const tmpDir = path.join(os.tmpdir(), `kubb-test-${name}-${Date.now()}`)
+    const tmpDir = path.join(os.tmpdir(), `kubb-test-vue-query-${name}-${Date.now()}`)
     const output = path.join(tmpDir, name)
     const { files, diagnostics } = await createKubb(
       {


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Add a default `= {}` to `options` param in client if it is not required. (to avoid having to set it on list endpoints for example).

```ts
// before
await petList({})

// after
await petList()
```

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

---  

I also added a unique tempDir per plugin to avoid race conditions.