### PR TITLE
docs(query): align mutation.methods JSDoc default with the runtime

### DIFF
--- a/.changeset/query-mutation-methods-default-patch.md
+++ b/.changeset/query-mutation-methods-default-patch.md
@@ -1,0 +1,7 @@
+---
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-swr": patch
+---
+
+Correct the documented `mutation.methods` default so the JSDoc matches the runtime. The query plugins already treat `patch` as a mutation method, so the default reads `['post', 'put', 'patch', 'delete']`.

--- a/packages/plugin-react-query/src/types.ts
+++ b/packages/plugin-react-query/src/types.ts
@@ -167,7 +167,7 @@ type Mutation = {
    * HTTP methods treated as mutations. Operations using these methods produce
    * `useMutation`-style hooks.
    *
-   * @default ['post', 'put', 'delete']
+   * @default ['post', 'put', 'patch', 'delete']
    */
   methods?: Array<string>
   /**

--- a/packages/plugin-swr/src/types.ts
+++ b/packages/plugin-swr/src/types.ts
@@ -89,7 +89,7 @@ type Mutation = {
   /**
    * HTTP methods to use for mutations.
    *
-   * @default ['post', 'put', 'delete', 'patch']
+   * @default ['post', 'put', 'patch', 'delete']
    */
   methods?: Array<string>
   /**

--- a/packages/plugin-vue-query/src/types.ts
+++ b/packages/plugin-vue-query/src/types.ts
@@ -106,7 +106,7 @@ type Mutation = {
   /**
    * HTTP methods treated as mutations.
    *
-   * @default ['post', 'put', 'delete']
+   * @default ['post', 'put', 'patch', 'delete']
    */
   methods?: Array<string>
   /**


### PR DESCRIPTION
## 🎯 Changes

The React Query, Vue Query, and SWR generators already treat `patch` as a mutation method, but the `Mutation.methods` JSDoc `@default` read `['post', 'put', 'delete']`. This corrects the JSDoc so it matches what `plugin.ts` resolves (`['post', 'put', 'patch', 'delete']`), so IntelliSense and the kubb.dev docs agree with the actual generated output.

Comment-only change, no runtime behavior change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. Comment-only change; validated with `pnpm turbo run typecheck lint` on the three packages (both green).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (patch bump for the three query plugins).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111o1hdeMur96uwgcuskeDM

---
_Generated by [Claude Code](https://claude.ai/code/session_0111o1hdeMur96uwgcuskeDM)_