### PR TITLE
fix: keep baseURL with template strings

### DIFF
--- a/.changeset/six-pigs-scream.md
+++ b/.changeset/six-pigs-scream.md
@@ -1,0 +1,6 @@
+---
+"@kubb/plugin-axios": patch
+"@kubb/plugin-fetch": patch
+---
+
+Fix generated client config for interpolated `baseURL` values. A config such as `baseURL: '${import.meta.env.VITE_API_SERVER}'` now emits a runtime template literal in `.kubb/client.ts` instead of a fixed string, so environment-based base URLs stay dynamic.

--- a/internals/client/src/types.ts
+++ b/internals/client/src/types.ts
@@ -74,6 +74,8 @@ export type Options = OutputOptions & {
   override?: Array<Override<ResolvedOptions>>
   /**
    * Base URL prepended to every request. When omitted, falls back to the adapter's server URL.
+   * Values containing a `${...}` interpolation are emitted as template literals in the generated
+   * client config, which keeps runtime environment reads dynamic.
    */
   baseURL?: string
   /**

--- a/packages/plugin-axios/src/plugin.ts
+++ b/packages/plugin-axios/src/plugin.ts
@@ -80,6 +80,7 @@ export const pluginAxios = definePlugin<PluginAxios>((options) => {
         ctx.addGenerator(...selectedGenerators)
 
         const root = path.resolve(ctx.config.root, ctx.config.output.path)
+        const baseURLExpression = baseURL ? (baseURL.includes('${') ? `\`${baseURL.replaceAll('`', '\\`')}\`` : JSON.stringify(baseURL)) : undefined
 
         ctx.injectFile({
           baseName: 'serializers.ts',
@@ -91,7 +92,7 @@ export const pluginAxios = definePlugin<PluginAxios>((options) => {
           baseName: 'client.ts',
           path: path.resolve(root, '.kubb/client.ts'),
           copy: axiosClientTemplatePath,
-          footer: baseURL ? `client.setConfig({ baseURL: ${JSON.stringify(baseURL)} })` : undefined,
+          footer: baseURLExpression ? `client.setConfig({ baseURL: ${baseURLExpression} })` : undefined,
         })
 
         ctx.injectFile({

--- a/packages/plugin-fetch/src/plugin.ts
+++ b/packages/plugin-fetch/src/plugin.ts
@@ -80,6 +80,7 @@ export const pluginFetch = definePlugin<PluginFetch>((options) => {
         ctx.addGenerator(...selectedGenerators)
 
         const root = path.resolve(ctx.config.root, ctx.config.output.path)
+        const baseURLExpression = baseURL ? (baseURL.includes('${') ? `\`${baseURL.replaceAll('`', '\\`')}\`` : JSON.stringify(baseURL)) : undefined
 
         ctx.injectFile({
           baseName: 'serializers.ts',
@@ -91,7 +92,7 @@ export const pluginFetch = definePlugin<PluginFetch>((options) => {
           baseName: 'client.ts',
           path: path.resolve(root, '.kubb/client.ts'),
           copy: fetchClientTemplatePath,
-          footer: baseURL ? `client.setConfig({ baseURL: ${JSON.stringify(baseURL)} })` : undefined,
+          footer: baseURLExpression ? `client.setConfig({ baseURL: ${baseURLExpression} })` : undefined,
         })
 
         ctx.injectFile({

--- a/tests/3.0.x/pluginAxios.test.ts
+++ b/tests/3.0.x/pluginAxios.test.ts
@@ -114,6 +114,42 @@ describe(`plugin-axios options ${version}`, () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  test('emits template baseURL as a runtime expression in the client config', async () => {
+    const tmpDir = path.join(os.tmpdir(), `kubb-test-axios-base-url-template-${Date.now()}`)
+    const output = path.join(tmpDir, 'gen')
+    const { files, diagnostics } = await createKubb(
+      {
+        root: __dirname,
+        input: { path: '../../schemas/3.0.x/petStore.yaml' },
+        output: { path: output, barrel: false },
+        adapter: adapterOas({ validate: false, enums: 'root' }),
+        parsers: [parserTs],
+        reporters: [],
+        storage: fsStorage(),
+        plugins: [
+          pluginTs({ output: { path: './types', barrel: false } }),
+          pluginAxios({
+            output: { path: './clients', barrel: false },
+            baseURL: '${import.meta.env.VITE_API_SERVER}',
+          }),
+        ],
+      } as Config,
+      { hooks: new AsyncEventEmitter<KubbHooks>() },
+    ).safeBuild()
+
+    expect(files.length).toBeGreaterThan(0)
+    expect(Diagnostics.hasError(diagnostics)).toBe(false)
+
+    const clientRuntime = files.find((file) => file.path === path.join(output, '.kubb/client.ts'))
+    expect(clientRuntime).toBeDefined()
+
+    const source = await fs.readFile(clientRuntime!.path, 'utf-8')
+    expect(source).toContain('client.setConfig({ baseURL: `${import.meta.env.VITE_API_SERVER}` })')
+    expect(source).not.toContain('baseURL: "${import.meta.env.VITE_API_SERVER}"')
+
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
   // The petstore tag `pet` and schema `Pet` share a name. With the barrel middleware active, the
   // root `index.ts` re-exports both, so the generated sdk class must be `PetClient` to avoid a
   // TS2300 duplicate-identifier error. Asserted on the barrel string so it stays robust across

--- a/tests/3.0.x/pluginFetch.test.ts
+++ b/tests/3.0.x/pluginFetch.test.ts
@@ -114,6 +114,42 @@ describe(`plugin-fetch options ${version}`, () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  test('emits template baseURL as a runtime expression in the client config', async () => {
+    const tmpDir = path.join(os.tmpdir(), `kubb-test-fetch-base-url-template-${Date.now()}`)
+    const output = path.join(tmpDir, 'gen')
+    const { files, diagnostics } = await createKubb(
+      {
+        root: __dirname,
+        input: { path: '../../schemas/3.0.x/petStore.yaml' },
+        output: { path: output, barrel: false },
+        adapter: adapterOas({ validate: false, enums: 'root' }),
+        parsers: [parserTs],
+        reporters: [],
+        storage: fsStorage(),
+        plugins: [
+          pluginTs({ output: { path: './types', barrel: false } }),
+          pluginFetch({
+            output: { path: './clients', barrel: false },
+            baseURL: '${import.meta.env.VITE_API_SERVER}',
+          }),
+        ],
+      } as Config,
+      { hooks: new AsyncEventEmitter<KubbHooks>() },
+    ).safeBuild()
+
+    expect(files.length).toBeGreaterThan(0)
+    expect(Diagnostics.hasError(diagnostics)).toBe(false)
+
+    const clientRuntime = files.find((file) => file.path === path.join(output, '.kubb/client.ts'))
+    expect(clientRuntime).toBeDefined()
+
+    const source = await fs.readFile(clientRuntime!.path, 'utf-8')
+    expect(source).toContain('client.setConfig({ baseURL: `${import.meta.env.VITE_API_SERVER}` })')
+    expect(source).not.toContain('baseURL: "${import.meta.env.VITE_API_SERVER}"')
+
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
   // The petstore tag `pet` and schema `Pet` share a name. With the barrel middleware active, the
   // root `index.ts` re-exports both, so the generated sdk class must be `PetClient` to avoid a
   // TS2300 duplicate-identifier error. Asserted on the barrel string so it stays robust across


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
In the pluginAxios and pluginFetch, the baseUrl option is a fixed string, making it impossible to be dynamic (with env variables for example). Those plugins now evaluate if the string is dynamic to keep it as-is if it's the case.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
