### PR TITLE
ci: pin GitHub Actions to node 22.22.3

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Fix formatting
         run: pnpm run format

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm build
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm build
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Test
         run: pnpm run test --coverage
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Linting
         env:
@@ -123,7 +123,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm build
@@ -146,7 +146,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build
@@ -186,7 +186,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Report compressed bundle size
         uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2
@@ -215,7 +215,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build
@@ -259,7 +259,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node-version: [22]
+        node-version: ['22.22.3']
 
     runs-on: ${{ matrix.os }}
 
@@ -272,7 +272,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build


### PR DESCRIPTION
## 🎯 Changes

Pin the `node-version` used by `actions/setup-node` in every workflow to `22.22.3` instead of the floating `22` tag, so CI runs a consistent, exact Node version.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVcqp7M2DJvuFrpMY8NULD)_