### PR TITLE
Add @kubb/core as a peerDependency across all plugins

### DIFF
--- a/.changeset/kubb-core-peer-dependency.md
+++ b/.changeset/kubb-core-peer-dependency.md
@@ -1,0 +1,16 @@
+---
+"@kubb/plugin-axios": minor
+"@kubb/plugin-cypress": minor
+"@kubb/plugin-faker": minor
+"@kubb/plugin-fetch": minor
+"@kubb/plugin-mcp": minor
+"@kubb/plugin-msw": minor
+"@kubb/plugin-react-query": minor
+"@kubb/plugin-redoc": minor
+"@kubb/plugin-swr": minor
+"@kubb/plugin-ts": minor
+"@kubb/plugin-vue-query": minor
+"@kubb/plugin-zod": minor
+---
+
+Move `@kubb/core` from `dependencies` to `peerDependencies`, matching the existing `@kubb/renderer-jsx` peer setup and the pattern used by Vite/Vue plugin ecosystems. Plugins run against a single shared `@kubb/core` instance owned by the host CLI, so bundling a second copy risks version drift and `instanceof` mismatches across plugin boundaries. Consumers now resolve `@kubb/core` against the version installed alongside `kubb` instead of each plugin pulling in its own copy.

--- a/.changeset/kubb-core-peer-dependency.md
+++ b/.changeset/kubb-core-peer-dependency.md
@@ -13,4 +13,4 @@
 "@kubb/plugin-zod": minor
 ---
 
-Move `@kubb/core` from `dependencies` to `peerDependencies`, matching the existing `@kubb/renderer-jsx` peer setup and the pattern used by Vite/Vue plugin ecosystems. Plugins run against a single shared `@kubb/core` instance owned by the host CLI, so bundling a second copy risks version drift and `instanceof` mismatches across plugin boundaries. Consumers now resolve `@kubb/core` against the version installed alongside `kubb` instead of each plugin pulling in its own copy.
+Add `@kubb/core` as a `peerDependency`, alongside its existing `dependencies` entry, matching the pattern used by Vite and Vue plugin ecosystems. Plugins run against a single shared `@kubb/core` instance owned by the host CLI, so a mismatched version risks `instanceof` errors and other subtle bugs across plugin boundaries. The peer range signals that constraint to package managers, while keeping `@kubb/core` in `dependencies` too keeps install working out of the box across npm, Yarn, and pnpm without requiring consumers to install `@kubb/core` themselves.

--- a/packages/plugin-axios/package.json
+++ b/packages/plugin-axios/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
@@ -75,6 +74,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:",
     "axios": "^1.7.2"
   },

--- a/packages/plugin-axios/package.json
+++ b/packages/plugin-axios/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"

--- a/packages/plugin-cypress/package.json
+++ b/packages/plugin-cypress/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },

--- a/packages/plugin-cypress/package.json
+++ b/packages/plugin-cypress/package.json
@@ -57,7 +57,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },
@@ -66,6 +65,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-faker/package.json
+++ b/packages/plugin-faker/package.json
@@ -68,7 +68,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },
@@ -77,6 +76,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-faker/package.json
+++ b/packages/plugin-faker/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },

--- a/packages/plugin-fetch/package.json
+++ b/packages/plugin-fetch/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"

--- a/packages/plugin-fetch/package.json
+++ b/packages/plugin-fetch/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
@@ -74,6 +73,7 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"

--- a/packages/plugin-mcp/package.json
+++ b/packages/plugin-mcp/package.json
@@ -57,7 +57,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/plugin-zod": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
@@ -68,6 +67,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-msw/package.json
+++ b/packages/plugin-msw/package.json
@@ -74,6 +74,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-faker": "workspace:*",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"

--- a/packages/plugin-msw/package.json
+++ b/packages/plugin-msw/package.json
@@ -74,7 +74,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-faker": "workspace:*",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
@@ -84,6 +83,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },
@@ -81,6 +80,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-react-query/package.json
+++ b/packages/plugin-react-query/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },

--- a/packages/plugin-redoc/package.json
+++ b/packages/plugin-redoc/package.json
@@ -58,7 +58,8 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@kubb/adapter-oas": "catalog:"
+    "@kubb/adapter-oas": "catalog:",
+    "@kubb/core": "catalog:"
   },
   "devDependencies": {
     "@internals/utils": "workspace:*"

--- a/packages/plugin-redoc/package.json
+++ b/packages/plugin-redoc/package.json
@@ -58,11 +58,13 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@kubb/adapter-oas": "catalog:",
-    "@kubb/core": "catalog:"
+    "@kubb/adapter-oas": "catalog:"
   },
   "devDependencies": {
     "@internals/utils": "workspace:*"
+  },
+  "peerDependencies": {
+    "@kubb/core": "catalog:"
   },
   "engines": {
     "node": ">=22"

--- a/packages/plugin-swr/package.json
+++ b/packages/plugin-swr/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },

--- a/packages/plugin-swr/package.json
+++ b/packages/plugin-swr/package.json
@@ -68,7 +68,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },
@@ -79,6 +78,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-ts/package.json
+++ b/packages/plugin-ts/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/parser-ts": "catalog:",
     "@kubb/renderer-jsx": "catalog:",
     "typescript": "catalog:"

--- a/packages/plugin-ts/package.json
+++ b/packages/plugin-ts/package.json
@@ -56,7 +56,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/parser-ts": "catalog:",
     "@kubb/renderer-jsx": "catalog:",
     "typescript": "catalog:"
@@ -66,6 +65,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-vue-query/package.json
+++ b/packages/plugin-vue-query/package.json
@@ -72,7 +72,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },
@@ -83,6 +82,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-vue-query/package.json
+++ b/packages/plugin-vue-query/package.json
@@ -72,6 +72,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/plugin-ts": "workspace:*",
     "@kubb/renderer-jsx": "catalog:"
   },

--- a/packages/plugin-zod/package.json
+++ b/packages/plugin-zod/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
-    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {
@@ -66,6 +65,7 @@
     "@internals/utils": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "engines": {

--- a/packages/plugin-zod/package.json
+++ b/packages/plugin-zod/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@kubb/ast": "catalog:",
+    "@kubb/core": "catalog:",
     "@kubb/renderer-jsx": "catalog:"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🎯 Changes

Adds `@kubb/core` to `peerDependencies` in all 12 plugin packages (`plugin-axios`, `plugin-cypress`, `plugin-faker`, `plugin-fetch`, `plugin-mcp`, `plugin-msw`, `plugin-react-query`, `plugin-redoc`, `plugin-swr`, `plugin-ts`, `plugin-vue-query`, `plugin-zod`), while keeping it in `dependencies` too.

Plugins run against a single shared `@kubb/core` instance owned by the host CLI (`PluginManager`, resolvers, etc.), so a mismatched `@kubb/core` version pulled in by a plugin risks `instanceof`/type mismatches across plugin boundaries — the same reasoning Vite and Vue use for peering their host package in their plugin ecosystems. This matches the existing `@kubb/renderer-jsx` peer setup here, and the precedent already set in `kubb-labs/kubb` by `@kubb/plugin-barrel`, which lists `@kubb/core` in both `dependencies` and `peerDependencies`.

`@kubb/core` stays in `dependencies` as well (rather than moving it) so plugins keep installing cleanly out of the box on npm and Yarn, which don't reliably auto-install peers the way pnpm does — `peerDependencies` here signals the single-instance version constraint without changing install behavior.

`@kubb/ast` is left untouched since it's a stateless utility library, not a singleton the core engine performs identity checks against.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test` (also ran `pnpm typecheck` and `pnpm lint` across the affected packages — all pass).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
