### PR TITLE
docs(jsdoc): align generated-name and handler-order descriptions with the output

### DIFF
--- a/.changeset/docs-accuracy-jsdoc-fixes.md
+++ b/.changeset/docs-accuracy-jsdoc-fixes.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-msw': patch
+'@kubb/plugin-react-query': patch
+'@kubb/plugin-vue-query': patch
+---
+
+Correct stale JSDoc descriptions so they match the generated output. The vue-query plugin and both query resolvers now describe hooks as `useFoo`/`useFooInfinite` instead of the old `useFooQuery`/`useFooMutation` names, and the MSW handlers generator states that `handlers.ts` re-exports handlers in operation order, not grouped by HTTP method.

--- a/packages/plugin-msw/src/generators/handlersGenerator.ts
+++ b/packages/plugin-msw/src/generators/handlersGenerator.ts
@@ -3,8 +3,8 @@ import type { PluginMsw } from '../types'
 
 /**
  * Aggregate generator enabled by `pluginMsw({ handlers: true })`. Emits a
- * `handlers.ts` file that re-exports every generated handler grouped by HTTP
- * method, ready to spread into `setupServer(...handlers)` or
+ * `handlers.ts` file that re-exports every generated handler in operation
+ * order, ready to spread into `setupServer(...handlers)` or
  * `setupWorker(...handlers)`.
  */
 export const handlersGenerator = defineGenerator<PluginMsw>({

--- a/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
+++ b/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
@@ -8,8 +8,8 @@ function capitalize(name: string): string {
 
 /**
  * Default resolver used by `@kubb/plugin-react-query`. Decides the names and
- * file paths for every generated TanStack Query hook (`useFooQuery`,
- * `useFooMutation`, `useFooInfiniteQuery`, ...) and its companion helpers
+ * file paths for every generated TanStack Query hook (`useFoo`,
+ * `useFooSuspense`, `useFooInfinite`, ...) and its companion helpers
  * (`fooQueryKey`, `fooQueryOptions`).
  *
  * Functions and files use camelCase; hooks get the `use` prefix; suspense and

--- a/packages/plugin-vue-query/src/plugin.ts
+++ b/packages/plugin-vue-query/src/plugin.ts
@@ -16,8 +16,8 @@ export const pluginVueQueryName = 'plugin-vue-query' satisfies PluginVueQuery['n
 
 /**
  * Generates one TanStack Query composable per OpenAPI operation for Vue's
- * Composition API. Queries become `useFooQuery` (and optionally
- * `useFooInfiniteQuery`). Mutations become `useFooMutation`. Each composable
+ * Composition API. Queries become `useFoo` (and optionally
+ * `useFooInfinite`). Mutations become `useFoo` as well. Each composable
  * is fully typed end to end.
  *
  * @example

--- a/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
+++ b/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
@@ -8,8 +8,8 @@ function capitalize(name: string): string {
 
 /**
  * Default resolver used by `@kubb/plugin-vue-query`. Decides the names and
- * file paths for every generated TanStack Query composable (`useFooQuery`,
- * `useFooMutation`, `useFooInfiniteQuery`) and its companion helpers.
+ * file paths for every generated TanStack Query composable (`useFoo`,
+ * `useFooInfinite`) and its companion helpers.
  *
  * Functions and files use camelCase; composables get the `use` prefix.
  *


### PR DESCRIPTION
## 🎯 Changes

A docs accuracy audit against the plugin sources surfaced three JSDoc blocks that no longer match what the plugins generate:

- `plugin-vue-query/src/plugin.ts` and `resolvers/resolverVueQuery.ts` described the generated composables as `useFooQuery`/`useFooMutation`/`useFooInfiniteQuery`, while `resolveQueryName`/`resolveInfiniteQueryName`/`resolveMutationName` emit `useFoo` and `useFooInfinite` (the examples in the same blocks already showed the correct names).
- `plugin-react-query/src/resolvers/resolverReactQuery.ts` had the same stale `useFooQuery` phrasing; the resolver emits `useFoo`, `useFooSuspense`, and `useFooInfinite`.
- `plugin-msw/src/generators/handlersGenerator.ts` claimed `handlers.ts` re-exports handlers grouped by HTTP method; the generator maps nodes in operation order, matching `types.ts` and the snapshot. The docs and `types.ts` were already corrected in 71eeb05, this was the leftover.

Companion PR in kubb-labs/docs fixes the doc-page findings from the same audit.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test` (comment-only changes, no behavior affected).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DED67vzuZGmv6RaJ4D1Wmc

---
_Generated by [Claude Code](https://claude.ai/code/session_01DED67vzuZGmv6RaJ4D1Wmc)_