### PR TITLE
Use uppercase HTTP method tokens for query/mutation defaults

### DIFF
--- a/.changeset/http-method-uppercase-defaults.md
+++ b/.changeset/http-method-uppercase-defaults.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-react-query': patch
+'@kubb/plugin-vue-query': patch
+'@kubb/plugin-swr': patch
+---
+
+Change the default `query.methods`/`mutation.methods` values from lowercase (`['get']`, `['post', 'put', 'patch', 'delete']`) to uppercase (`['GET']`, `['POST', 'PUT', 'PATCH', 'DELETE']`), matching the HTTP method token casing defined in RFC 7231 (and RFC 2616 before it). Matching against the operation's method was already case-insensitive, so this doesn't change generated output, only the documented and default casing.

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.test.tsx
@@ -28,10 +28,10 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/react-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post', 'put', 'patch', 'delete'],
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
     importPath: '@tanstack/react-query',
   },
   suspense: false,

--- a/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.test.tsx
@@ -28,10 +28,10 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/react-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post', 'put', 'patch', 'delete'],
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
     importPath: '@tanstack/react-query',
   },
   suspense: false,

--- a/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.test.tsx
@@ -30,10 +30,10 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/react-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post', 'put', 'patch', 'delete'],
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
     importPath: '@tanstack/react-query',
   },
   suspense: false,

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.test.tsx
@@ -28,10 +28,10 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/react-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post', 'put', 'patch', 'delete'],
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
     importPath: '@tanstack/react-query',
   },
   suspense: false,

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.test.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.test.tsx
@@ -28,10 +28,10 @@ const defaultOptions: PluginReactQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/react-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post', 'put', 'patch', 'delete'],
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
     importPath: '@tanstack/react-query',
   },
   suspense: false,

--- a/packages/plugin-react-query/src/plugin.ts
+++ b/packages/plugin-react-query/src/plugin.ts
@@ -105,7 +105,7 @@ export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
               ? false
               : {
                   importPath: '@tanstack/react-query',
-                  methods: ['get'],
+                  methods: ['GET'],
                   ...query,
                 },
           mutationKey,
@@ -114,7 +114,7 @@ export const pluginReactQuery = definePlugin<PluginReactQuery>((options) => {
               ? false
               : {
                   importPath: '@tanstack/react-query',
-                  methods: ['post', 'put', 'patch', 'delete'],
+                  methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
                   ...mutation,
                 },
           infinite: infinite

--- a/packages/plugin-react-query/src/types.ts
+++ b/packages/plugin-react-query/src/types.ts
@@ -148,7 +148,7 @@ type Query = {
    * HTTP methods treated as queries. Operations using these methods produce
    * `useQuery`-style hooks.
    *
-   * @default ['get']
+   * @default ['GET']
    */
   methods?: Array<string>
   /**
@@ -166,7 +166,7 @@ type Mutation = {
    * HTTP methods treated as mutations. Operations using these methods produce
    * `useMutation`-style hooks.
    *
-   * @default ['post', 'put', 'patch', 'delete']
+   * @default ['POST', 'PUT', 'PATCH', 'DELETE']
    */
   methods?: Array<string>
   /**

--- a/packages/plugin-swr/src/generators/mutationGenerator.test.tsx
+++ b/packages/plugin-swr/src/generators/mutationGenerator.test.tsx
@@ -28,10 +28,10 @@ const defaultOptions: PluginSwr['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: 'swr',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post', 'put', 'patch', 'delete'],
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
     importPath: 'swr/mutation',
   },
   exclude: [],

--- a/packages/plugin-swr/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-swr/src/generators/queryGenerator.test.tsx
@@ -30,10 +30,10 @@ const defaultOptions: PluginSwr['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: 'swr',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post', 'put', 'patch', 'delete'],
+    methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
     importPath: 'swr/mutation',
   },
   exclude: [],

--- a/packages/plugin-swr/src/plugin.ts
+++ b/packages/plugin-swr/src/plugin.ts
@@ -81,7 +81,7 @@ export const pluginSwr = definePlugin<PluginSwr>((options) => {
               ? false
               : {
                   importPath: 'swr',
-                  methods: ['get'],
+                  methods: ['GET'],
                   ...query,
                 },
           mutationKey,
@@ -90,7 +90,7 @@ export const pluginSwr = definePlugin<PluginSwr>((options) => {
               ? false
               : {
                   importPath: 'swr/mutation',
-                  methods: ['post', 'put', 'patch', 'delete'],
+                  methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
                   ...mutation,
                 },
           group: groupConfig,

--- a/packages/plugin-swr/src/types.ts
+++ b/packages/plugin-swr/src/types.ts
@@ -71,7 +71,7 @@ type Query = {
   /**
    * HTTP methods to use for queries.
    *
-   * @default ['get']
+   * @default ['GET']
    */
   methods?: Array<string>
   /**
@@ -88,7 +88,7 @@ type Mutation = {
   /**
    * HTTP methods to use for mutations.
    *
-   * @default ['post', 'put', 'patch', 'delete']
+   * @default ['POST', 'PUT', 'PATCH', 'DELETE']
    */
   methods?: Array<string>
   /**

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.test.tsx
@@ -29,10 +29,10 @@ const defaultOptions: PluginVueQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/react-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post'],
+    methods: ['POST'],
     importPath: '@tanstack/react-query',
   },
   infinite: false,

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.test.tsx
@@ -29,10 +29,10 @@ const defaultOptions: PluginVueQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/vue-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post'],
+    methods: ['POST'],
     importPath: '@tanstack/vue-query',
   },
   infinite: false,

--- a/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.test.tsx
@@ -31,10 +31,10 @@ const defaultOptions: PluginVueQuery['resolvedOptions'] = {
   mutationKey: mutationKeyTransformer,
   query: {
     importPath: '@tanstack/react-query',
-    methods: ['get'],
+    methods: ['GET'],
   },
   mutation: {
-    methods: ['post'],
+    methods: ['POST'],
     importPath: '@tanstack/react-query',
   },
   infinite: false,

--- a/packages/plugin-vue-query/src/plugin.ts
+++ b/packages/plugin-vue-query/src/plugin.ts
@@ -89,7 +89,7 @@ export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
               ? false
               : {
                   importPath: '@tanstack/vue-query',
-                  methods: ['get'],
+                  methods: ['GET'],
                   ...query,
                 },
           mutationKey,
@@ -98,7 +98,7 @@ export const pluginVueQuery = definePlugin<PluginVueQuery>((options) => {
               ? false
               : {
                   importPath: '@tanstack/vue-query',
-                  methods: ['post', 'put', 'patch', 'delete'],
+                  methods: ['POST', 'PUT', 'PATCH', 'DELETE'],
                   ...mutation,
                 },
           infinite: infinite

--- a/packages/plugin-vue-query/src/types.ts
+++ b/packages/plugin-vue-query/src/types.ts
@@ -93,7 +93,7 @@ type Query = {
   /**
    * HTTP methods treated as queries.
    *
-   * @default ['get']
+   * @default ['GET']
    */
   methods?: Array<string>
   /**
@@ -109,7 +109,7 @@ type Mutation = {
   /**
    * HTTP methods treated as mutations.
    *
-   * @default ['post', 'put', 'patch', 'delete']
+   * @default ['POST', 'PUT', 'PATCH', 'DELETE']
    */
   methods?: Array<string>
   /**


### PR DESCRIPTION
## Summary

- Changed the default `query.methods`/`mutation.methods` values in `plugin-react-query`, `plugin-vue-query`, and `plugin-swr` from lowercase (`['get']`, `['post', 'put', 'patch', 'delete']`) to uppercase (`['GET']`, `['POST', 'PUT', 'PATCH', 'DELETE']`), matching the `Method` token casing defined in RFC 7231 (and RFC 2616 §9 before it) — method tokens are case-sensitive, and the standard tokens are uppercase.
- Updated matching JSDoc `@default` annotations in each plugin's `types.ts`.
- Updated `defaultOptions` test fixtures in the generator test suites to match (left the handful of test cases that deliberately pass lowercase/mixed-case input alone, since the actual method matching (`node.method.toLowerCase() === method.toLowerCase()`) is case-insensitive by design and those tests exist to prove that).
- No behavior change: matching against the operation's HTTP method is already case-insensitive, so generated output is identical regardless of the array's casing. This is a documentation/consistency fix, not a functional one.

Companion PRs updating the docs examples and Kubb Studio's UI to the same casing:
- kubb-labs/docs (plugin-react-query, plugin-vue-query, plugin-swr reference/index pages)
- kubb-labs/platform (Kubb Studio's Query/Mutation Methods fields now uppercase user input)

## Test plan

- [x] `pnpm --filter @kubb/plugin-react-query --filter @kubb/plugin-vue-query --filter @kubb/plugin-swr test run` — 40 tests passed
- [x] `npx oxlint` on the changed packages — clean
- [x] Added a changeset


---
_Generated by [Claude Code](https://claude.ai/code/session_01BvFJFyniqB2m9Djxb4PFhn)_