### PR TITLE
chore: disable cypress postinstall

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - tests/**
 
 allowBuilds:
+  cypress: false
   es5-ext: true
   esbuild: true
   msw: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,6 @@ packages:
   - tests/**
 
 allowBuilds:
-  cypress: true
   es5-ext: true
   esbuild: true
   msw: true


### PR DESCRIPTION
## 🎯 Changes

Remove `cypress` from the `allowBuilds` allowlist in `pnpm-workspace.yaml` so pnpm no longer runs Cypress's postinstall (the binary download) on install.

The Cypress binary isn't needed in this repo:
- `@kubb/plugin-cypress` only *generates* Cypress code — it never runs Cypress.
- The `cypress` and `advanced` examples keep `cypress` as a devDependency purely for the type definitions; their `test`/`typecheck` scripts don't launch the Cypress binary.

Dropping it from the pnpm build allowlist skips the several-hundred-MB binary download and speeds up installs.

> Note: the sibling `kubb-labs/kubb` repo mentioned in the task has no `cypress` dependency or build script at all, so there was nothing to disable there.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

This is a repo tooling/config change only — it does not touch published package code, so neither release box applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgugfBh33oiZrdzDYaL3mt

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgugfBh33oiZrdzDYaL3mt)_