### PR TITLE
ci: make compressed-size and e2e wait on the build job to reuse the Turbo cache

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -177,6 +177,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     if: github.actor != 'github-actions[bot]' && github.event_name == 'pull_request'
+    needs: build
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -255,6 +256,7 @@ jobs:
     name: Build and test on ${{ matrix.os }}
     timeout-minutes: 30
     if: github.actor != 'github-actions[bot]'
+    needs: build
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
## 🎯 Changes

Aligns the PR workflow with the platform repo: every job that runs a build should wait on the `build` job so it reuses the warm Turbo cache instead of building from a cold cache in parallel.

The setup action (`kubb-labs/config/.github/setup`) wires up `rharkor/caching-for-turbo`, which backs Turbo's remote cache with the GitHub Actions cache. That cache is shared across jobs in a run, so once the `build` job populates it, downstream jobs get a Turbo cache hit for their build step.

`typecheck`, `tests`, `benchmarks`, `prerelease`, and `update-examples` already declared `needs: build`. The two jobs that ran a build without depending on `build` now do:

- `compressed-size` (builds via the action's `build-script: 'build'`)
- `e2e` (runs `pnpm run build` before generating examples)

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. <!-- CI-only YAML change; validated that pr.yml parses as YAML -->

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release). <!-- CI-only change, no published code and no docs -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AjAAnmLMBPiKJKZb1RoYa

---
_Generated by [Claude Code](https://claude.ai/code/session_017AjAAnmLMBPiKJKZb1RoYa)_