### PR TITLE
refactor: reach AST helpers via kubb/kit instead of kubb/ast

### DIFF
--- a/.changeset/plugins-ast-via-kit.md
+++ b/.changeset/plugins-ast-via-kit.md
@@ -1,0 +1,9 @@
+---
+'@kubb/plugin-ts': patch
+'@kubb/plugin-zod': patch
+'@kubb/plugin-faker': patch
+'@kubb/plugin-react-query': patch
+'@kubb/plugin-vue-query': patch
+---
+
+Reach the AST helpers through the `ast` namespace from `kubb/kit` instead of the removed `kubb/ast` subpath. Generated output is unchanged.

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -1,6 +1,4 @@
-import { jsStringEscape } from 'kubb/ast'
-import type { ast } from 'kubb/kit'
-import { containsCircularRef } from 'kubb/ast'
+import { ast } from 'kubb/kit'
 import { createFunctionParameter, createFunctionParameters, functionPrinter } from '@kubb/plugin-ts'
 import { File, Function } from 'kubb/jsx'
 import type { KubbReactNode } from 'kubb/jsx'
@@ -80,7 +78,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
         <Function
           export
           name={name}
-          JSDoc={{ comments: description ? [`@description ${jsStringEscape(description)}`] : [] }}
+          JSDoc={{ comments: description ? [`@description ${ast.jsStringEscape(description)}`] : [] }}
           params={canOverride ? paramsSignature : undefined}
           returnType={returnType ?? undefined}
         >
@@ -97,7 +95,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   }
 
   // Generate function with defaultFakeData structure
-  const jsdoc = description ? `/**\n   * @description ${jsStringEscape(description)}\n   */\n  ` : ''
+  const jsdoc = description ? `/**\n   * @description ${ast.jsStringEscape(description)}\n   */\n  ` : ''
   const functionSignature = `${jsdoc}export function ${name}<TData extends Partial<${typeName}> = object>(data?: TData)`
 
   const seedCode = seed ? `faker.seed(${JSON.stringify(seed)})\n  ` : ''
@@ -111,7 +109,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   const hasGetters =
     node.type === 'object' &&
     !!cyclicSchemas &&
-    (node.properties ?? []).some((p) => containsCircularRef(p.schema, { circularSchemas: cyclicSchemas, excludeName: schemaName }))
+    (node.properties ?? []).some((p) => ast.containsCircularRef(p.schema, { circularSchemas: cyclicSchemas, excludeName: schemaName }))
 
   const functionBody = hasGetters
     ? `{

--- a/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
@@ -1,7 +1,6 @@
 import { aliasConflictingImports, rewriteAliasedImports } from '@internals/utils'
 import type { Config } from 'kubb/kit'
 import { ast, memoryStorage } from 'kubb/kit'
-import { findCircularSchemas } from 'kubb/ast'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation, renderGeneratorSchema } from 'kubb/kit/testing'
 import { parserTs } from '@kubb/parser-ts'
 import { type PluginTs, resolverTs } from '@kubb/plugin-ts'
@@ -174,7 +173,7 @@ describe('fakerGenerator — schema', () => {
       config: testConfig,
       adapter: createMockedAdapter(),
       meta: {
-        circularNames: [...findCircularSchemas([categorySchema, emojiSchema, errorSchema, petSchema, treeNodeSchema, petPolySchema, catSchema, dogSchema])],
+        circularNames: [...ast.findCircularSchemas([categorySchema, emojiSchema, errorSchema, petSchema, treeNodeSchema, petPolySchema, catSchema, dogSchema])],
         enumNames: [],
       },
       driver,
@@ -321,7 +320,7 @@ describe('fakerGenerator — operation', () => {
       config: testConfig,
       adapter: createMockedAdapter(),
       meta: {
-        circularNames: [...findCircularSchemas([categorySchema, errorSchema, petSchema, treeNodeSchema])],
+        circularNames: [...ast.findCircularSchemas([categorySchema, errorSchema, petSchema, treeNodeSchema])],
         enumNames: [],
       },
       driver,

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -1,6 +1,4 @@
-import { buildObject, extractRefName, mapSchemaItems, mapSchemaMembers, objectKey, stringify, toRegExpString } from 'kubb/ast'
 import { ast } from 'kubb/kit'
-import { containsCircularRef } from 'kubb/ast'
 import type { PluginFaker, ResolverFaker } from '../types.ts'
 
 /**
@@ -186,7 +184,7 @@ const fakerKeywordMapper = {
   },
   matches: (value = '', regexGenerator: 'faker' | 'randexp' = 'faker') => {
     if (regexGenerator === 'randexp') {
-      return `${toRegExpString(value, 'RandExp')}.gen()`
+      return `${ast.toRegExpString(value, 'RandExp')}.gen()`
     }
 
     return `faker.helpers.fromRegExp("${value}")`
@@ -205,7 +203,7 @@ function getEnumValues(node: ast.EnumSchemaNode): Array<string | number | boolea
 
 function parseEnumValue(value: string | number | boolean | undefined) {
   if (typeof value === 'string') {
-    return stringify(value)
+    return ast.stringify(value)
   }
 
   return value
@@ -296,7 +294,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         // `nameMapping` (keyed by the full $ref) carries the collision-resolved name when the
         // referenced component was renamed; otherwise fall back to the short ref name.
         const refName = node.ref
-          ? (this.options.nameMapping?.get(node.ref) ?? extractRefName(node.ref) ?? node.name ?? node.schema?.name)
+          ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name ?? node.schema?.name)
           : (node.name ?? node.schema?.name)
 
         if (!refName) {
@@ -324,7 +322,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         const { discriminatorPropertyName } = node
         const baseTypeName = this.options.typeName
 
-        const items: Array<string> = mapSchemaMembers(node, (member) => {
+        const items: Array<string> = ast.mapSchemaMembers(node, (member) => {
           // For a discriminated union, narrow each variant to its own branch so nested
           // `NonNullable<T>[K]` indexes resolve against that branch instead of the whole union.
           const value = discriminatorPropertyName ? getDiscriminatorValue(member, discriminatorPropertyName) : undefined
@@ -346,7 +344,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.union(items)
       },
       intersection(node): string {
-        const items: Array<string> = mapSchemaMembers(node, (member) =>
+        const items: Array<string> = ast.mapSchemaMembers(node, (member) =>
           printNested(member, {
             nestedInObject: true,
           }),
@@ -359,7 +357,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.and(items)
       },
       array(node): string {
-        const items: Array<string> = mapSchemaItems(node, (member) =>
+        const items: Array<string> = ast.mapSchemaItems(node, (member) =>
           printNested(member, {
             typeName: this.options.typeName ? `NonNullable<${this.options.typeName}>[number]` : undefined,
             nestedInObject: true,
@@ -396,14 +394,14 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
           // emit a memoizing lazy getter. On first access it computes the value,
           // replaces itself with a plain data property via Object.defineProperty,
           // and returns the cached value, so every subsequent read is stable.
-          if (cyclicSchemas && containsCircularRef(property.schema, { circularSchemas: cyclicSchemas, excludeName: this.options.schemaName })) {
-            return `get ${objectKey(property.name)}() { const _value = ${value}; Object.defineProperty(this, ${JSON.stringify(property.name)}, { value: _value, configurable: true, writable: true, enumerable: true }); return _value }`
+          if (cyclicSchemas && ast.containsCircularRef(property.schema, { circularSchemas: cyclicSchemas, excludeName: this.options.schemaName })) {
+            return `get ${ast.objectKey(property.name)}() { const _value = ${value}; Object.defineProperty(this, ${JSON.stringify(property.name)}, { value: _value, configurable: true, writable: true, enumerable: true }); return _value }`
           }
 
-          return `${objectKey(property.name)}: ${value}`
+          return `${ast.objectKey(property.name)}: ${value}`
         })
 
-        return buildObject(entries)
+        return ast.buildObject(entries)
       },
       ...options.nodes,
     },

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -322,33 +322,35 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         const { discriminatorPropertyName } = node
         const baseTypeName = this.options.typeName
 
-        const items: Array<string> = ast.mapSchemaMembers(node, (member) => {
-          // For a discriminated union, narrow each variant to its own branch so nested
-          // `NonNullable<T>[K]` indexes resolve against that branch instead of the whole union.
-          const value = discriminatorPropertyName ? getDiscriminatorValue(member, discriminatorPropertyName) : undefined
+        const items: Array<string> = ast
+          .mapSchemaMembers(node, (member) => {
+            // For a discriminated union, narrow each variant to its own branch so nested
+            // `NonNullable<T>[K]` indexes resolve against that branch instead of the whole union.
+            const value = discriminatorPropertyName ? getDiscriminatorValue(member, discriminatorPropertyName) : undefined
 
-          if (baseTypeName && value !== undefined) {
-            const typeName = `Extract<NonNullable<${baseTypeName}>, { ${JSON.stringify(discriminatorPropertyName)}: ${parseEnumValue(value)} }>`
+            if (baseTypeName && value !== undefined) {
+              const typeName = `Extract<NonNullable<${baseTypeName}>, { ${JSON.stringify(discriminatorPropertyName)}: ${parseEnumValue(value)} }>`
 
-            return printNested(member, { typeName, nestedInObject: true })
-          }
+              return printNested(member, { typeName, nestedInObject: true })
+            }
 
-          // Without a discriminator, keep the union type but guard each indexed access (see
-          // `indexedTypeName`) so a key carried by only some branches resolves to `unknown`
-          // rather than erroring with TS2339.
-          return printNested(member, { typeName: baseTypeName, nestedInObject: true, nestedInUnion: true })
-        })
+            // Without a discriminator, keep the union type but guard each indexed access (see
+            // `indexedTypeName`) so a key carried by only some branches resolves to `unknown`
+            // rather than erroring with TS2339.
+            return printNested(member, { typeName: baseTypeName, nestedInObject: true, nestedInUnion: true })
+          })
           .map(({ output }) => output)
           .filter((item): item is string => Boolean(item))
 
         return fakerKeywordMapper.union(items)
       },
       intersection(node): string {
-        const items: Array<string> = ast.mapSchemaMembers(node, (member) =>
-          printNested(member, {
-            nestedInObject: true,
-          }),
-        )
+        const items: Array<string> = ast
+          .mapSchemaMembers(node, (member) =>
+            printNested(member, {
+              nestedInObject: true,
+            }),
+          )
           .map(({ output }) => output)
           // An `allOf` member with no shape (any/unknown/void → 'undefined') adds no
           // constraint. Keeping it would spread `...undefined` into the merged object.
@@ -357,12 +359,13 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.and(items)
       },
       array(node): string {
-        const items: Array<string> = ast.mapSchemaItems(node, (member) =>
-          printNested(member, {
-            typeName: this.options.typeName ? `NonNullable<${this.options.typeName}>[number]` : undefined,
-            nestedInObject: true,
-          }),
-        )
+        const items: Array<string> = ast
+          .mapSchemaItems(node, (member) =>
+            printNested(member, {
+              typeName: this.options.typeName ? `NonNullable<${this.options.typeName}>[number]` : undefined,
+              nestedInObject: true,
+            }),
+          )
           .map(({ output }) => output)
           .filter((item): item is string => Boolean(item))
 

--- a/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
@@ -1,7 +1,6 @@
 import { getOperationParameters } from '@internals/shared'
 import { buildClientCall } from '@internals/tanstack-query'
-import { getNestedAccessor } from 'kubb/ast'
-import type { ast } from 'kubb/kit'
+import { ast } from 'kubb/kit'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import { functionPrinter } from '@kubb/plugin-ts'
 import { File, Function } from 'kubb/jsx'
@@ -84,8 +83,8 @@ export function InfiniteQueryOptions({
 
   const [getNextPageParamExpr, getPreviousPageParamExpr] = (() => {
     if (hasNewParams) {
-      const nextAccessor = nextParam ? getNestedAccessor(nextParam, 'lastPage') : null
-      const prevAccessor = previousParam ? getNestedAccessor(previousParam, 'firstPage') : null
+      const nextAccessor = nextParam ? ast.getNestedAccessor(nextParam, 'lastPage') : null
+      const prevAccessor = previousParam ? ast.getNestedAccessor(previousParam, 'firstPage') : null
       return [
         nextAccessor ? `getNextPageParam: (lastPage) => ${nextAccessor}` : null,
         prevAccessor ? `getPreviousPageParam: (firstPage) => ${prevAccessor}` : null,

--- a/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
@@ -1,7 +1,6 @@
 import { getOperationParameters } from '@internals/shared'
 import { buildClientCall } from '@internals/tanstack-query'
-import { getNestedAccessor } from 'kubb/ast'
-import type { ast } from 'kubb/kit'
+import { ast } from 'kubb/kit'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import { functionPrinter } from '@kubb/plugin-ts'
 import { File, Function } from 'kubb/jsx'
@@ -84,8 +83,8 @@ export function SuspenseInfiniteQueryOptions({
 
   const [getNextPageParamExpr, getPreviousPageParamExpr] = (() => {
     if (hasNewParams) {
-      const nextAccessor = nextParam ? getNestedAccessor(nextParam, 'lastPage') : null
-      const prevAccessor = previousParam ? getNestedAccessor(previousParam, 'firstPage') : null
+      const nextAccessor = nextParam ? ast.getNestedAccessor(nextParam, 'lastPage') : null
+      const prevAccessor = previousParam ? ast.getNestedAccessor(previousParam, 'firstPage') : null
       return [
         nextAccessor ? `getNextPageParam: (lastPage) => ${nextAccessor}` : null,
         prevAccessor ? `getPreviousPageParam: (firstPage) => ${prevAccessor}` : null,

--- a/packages/plugin-ts/src/components/Enum.tsx
+++ b/packages/plugin-ts/src/components/Enum.tsx
@@ -1,6 +1,5 @@
 import { camelCase } from '@internals/utils'
-import { trimQuotes } from 'kubb/ast'
-import type { ast } from 'kubb/kit'
+import { ast } from 'kubb/kit'
 import { parserTs } from '@kubb/parser-ts'
 import { File } from 'kubb/jsx'
 import type { KubbReactNode } from 'kubb/jsx'
@@ -62,8 +61,8 @@ export function Enum({ node, enum: enumOptions, resolver }: Props): KubbReactNod
   const [nameNode, typeNode] = factory.createEnumDeclaration({
     name: enumName,
     typeName,
-    enums: ((node.namedEnumValues as Array<NamedEnumValue> | undefined)?.map((v) => [trimQuotes(v.name.toString()), v.value, v.description]) ??
-      node.enumValues?.filter((v): v is NonNullable<typeof v> => v !== null && v !== undefined).map((v) => [trimQuotes(v.toString()), v]) ??
+    enums: ((node.namedEnumValues as Array<NamedEnumValue> | undefined)?.map((v) => [ast.trimQuotes(v.name.toString()), v.value, v.description]) ??
+      node.enumValues?.filter((v): v is NonNullable<typeof v> => v !== null && v !== undefined).map((v) => [ast.trimQuotes(v.toString()), v]) ??
       []) as Array<[string | number, string | number | boolean, string?]>,
     type: enumOptions.type,
     enumKeyCasing: enumOptions.keyCasing,

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -1,6 +1,5 @@
 import { camelCase, pascalCase, screamingSnakeCase, snakeCase } from '@internals/utils'
-import { syncSchemaRef } from 'kubb/ast'
-import type { ast } from 'kubb/kit'
+import { ast } from 'kubb/kit'
 import ts from 'typescript'
 import { OPTIONAL_ADDS_UNDEFINED } from './constants.ts'
 
@@ -923,7 +922,7 @@ export function buildPropertyType(
   optional?: boolean,
 ): ts.TypeNode {
   const addsUndefined = OPTIONAL_ADDS_UNDEFINED.has(optionalType)
-  const meta = syncSchemaRef(schema)
+  const meta = ast.syncSchemaRef(schema)
 
   let type = baseType
 

--- a/packages/plugin-ts/src/printers/operationParams.ts
+++ b/packages/plugin-ts/src/printers/operationParams.ts
@@ -1,6 +1,6 @@
 import { caseParams } from '@internals/shared'
 import type { OperationParamsResolver } from '@internals/shared'
-import type { OperationNode, ParameterNode } from 'kubb/ast'
+import type { ast } from 'kubb/kit'
 import { createFunctionParameter, createFunctionParameters, createIndexedAccessType, createTypeLiteral } from './functionParams.ts'
 import type { FunctionParameterNode, FunctionParametersNode, TypeExpression, TypeLiteralNode } from './functionParams.ts'
 
@@ -119,8 +119,8 @@ function resolveParamType({
   param,
   resolver,
 }: {
-  node: OperationNode
-  param: ParameterNode
+  node: ast.OperationNode
+  param: ast.ParameterNode
   resolver: OperationParamsResolver | undefined
 }): TypeExpression {
   if (!resolver) {
@@ -158,8 +158,8 @@ function resolveGroupType({
   group,
   resolver,
 }: {
-  node: OperationNode
-  params: Array<ParameterNode>
+  node: ast.OperationNode
+  params: Array<ast.ParameterNode>
   group: 'query' | 'header'
   resolver: OperationParamsResolver | undefined
 }): ParamGroupType | null {
@@ -183,7 +183,7 @@ function resolveGroupType({
  * `pathParamsType` controls how path params render in inline mode. Provide a `resolver` for type
  * name resolution and `extraParams` for plugin-specific trailing parameters such as an `options` object.
  */
-export function createOperationParams(node: OperationNode, options: CreateOperationParamsOptions): FunctionParametersNode {
+export function createOperationParams(node: ast.OperationNode, options: CreateOperationParamsOptions): FunctionParametersNode {
   const { paramsType, pathParamsType, paramsCasing, resolver, pathParamsDefault, extraParams = [], paramNames, typeWrapper } = options
 
   const dataName = paramNames?.data ?? 'data'
@@ -201,7 +201,7 @@ export function createOperationParams(node: OperationNode, options: CreateOperat
   const queryParams = casedParams.filter((p) => p.in === 'query')
   const headerParams = casedParams.filter((p) => p.in === 'header')
 
-  const toProperty = (param: ParameterNode): GroupProperty => ({
+  const toProperty = (param: ast.ParameterNode): GroupProperty => ({
     name: param.name,
     type: wrapTypeExpression(resolveParamType({ node, param, resolver })),
     optional: !param.required,
@@ -255,8 +255,8 @@ export function createOperationParams(node: OperationNode, options: CreateOperat
  */
 type BuildGroupArgs = {
   name: string
-  node: OperationNode
-  params: Array<ParameterNode>
+  node: ast.OperationNode
+  params: Array<ast.ParameterNode>
   groupType: ParamGroupType | null
   resolver: OperationParamsResolver | undefined
   wrapType: (type: string) => string
@@ -298,8 +298,8 @@ function buildTypeLiteral({
   params,
   resolver,
 }: {
-  node: OperationNode
-  params: Array<ParameterNode>
+  node: ast.OperationNode
+  params: Array<ast.ParameterNode>
   resolver: OperationParamsResolver | undefined
 }): TypeLiteralNode {
   return createTypeLiteral({

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -234,7 +234,8 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         return factory.createIntersectionDeclaration({ withParentheses: true, nodes: factory.buildMemberNodes(node.members, this.transform) }) ?? null
       },
       array(node) {
-        const itemNodes = ast.mapSchemaItems(node, (item) => this.transform(item))
+        const itemNodes = ast
+          .mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(isNonNullable)
 
@@ -248,21 +249,23 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
 
         const addsQuestionToken = OPTIONAL_ADDS_QUESTION_TOKEN.has(options.optionalType)
 
-        const propertyNodes: Array<ts.TypeElement> = ast.mapSchemaProperties(node, (schema) => transform(schema)).map(({ name, property, output }) => {
-          const baseType = output ?? factory.keywordTypeNodes.unknown
-          const optional = !property.required || !!property.schema.optional || !!property.schema.nullish
-          const type = factory.buildPropertyType(property.schema, baseType, options.optionalType, optional)
-          const propMeta = ast.syncSchemaRef(property.schema)
+        const propertyNodes: Array<ts.TypeElement> = ast
+          .mapSchemaProperties(node, (schema) => transform(schema))
+          .map(({ name, property, output }) => {
+            const baseType = output ?? factory.keywordTypeNodes.unknown
+            const optional = !property.required || !!property.schema.optional || !!property.schema.nullish
+            const type = factory.buildPropertyType(property.schema, baseType, options.optionalType, optional)
+            const propMeta = ast.syncSchemaRef(property.schema)
 
-          const propertyNode = factory.createPropertySignature({
-            questionToken: optional ? addsQuestionToken : false,
-            name,
-            type,
-            readOnly: propMeta?.readOnly,
+            const propertyNode = factory.createPropertySignature({
+              questionToken: optional ? addsQuestionToken : false,
+              name,
+              type,
+              readOnly: propMeta?.readOnly,
+            })
+
+            return factory.appendJSDocToNode({ node: propertyNode, comments: buildPropertyJSDocComments(property.schema, optional) })
           })
-
-          return factory.appendJSDocToNode({ node: propertyNode, comments: buildPropertyJSDocComments(property.schema, optional) })
-        })
 
         const allElements = [...propertyNodes, ...factory.buildIndexSignatures(node, propertyNodes.length, transform)]
 

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -1,6 +1,4 @@
-import { extractRefName, mapSchemaItems, mapSchemaProperties } from 'kubb/ast'
 import { ast } from 'kubb/kit'
-import { isStringType, syncSchemaRef } from 'kubb/ast'
 import { parserTs } from '@kubb/parser-ts'
 import type ts from 'typescript'
 import { ENUM_TYPES_WITH_KEY_SUFFIX, OPTIONAL_ADDS_QUESTION_TOKEN, OPTIONAL_ADDS_UNDEFINED } from '../constants.ts'
@@ -168,7 +166,7 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         // referenced component was renamed to resolve a name collision, `nameMapping` (keyed by the
         // full $ref) carries the renamed name; otherwise fall back to the short ref name.
         // Inline refs (without $ref) from utils already carry resolved type names.
-        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? extractRefName(node.ref) ?? node.name) : node.name
+        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name) : node.name
 
         // When a Key suffix is configured, enum refs must use the suffixed name (e.g. `StatusKey`)
         // so the reference matches what the enum file actually exports.
@@ -211,12 +209,12 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
           const enumNode = ast.narrowSchema(m, ast.schemaTypes.enum)
           return enumNode?.primitive === 'string'
         })
-        const hasPlainString = members.some((m) => isStringType(m))
+        const hasPlainString = members.some((m) => ast.isStringType(m))
 
         if (hasStringLiteral && hasPlainString) {
           const memberNodes = members
             .map((m) => {
-              if (isStringType(m)) {
+              if (ast.isStringType(m)) {
                 return factory.createIntersectionDeclaration({
                   nodes: [factory.keywordTypeNodes.string, factory.createTypeLiteralNode([])],
                   withParentheses: true,
@@ -236,7 +234,7 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         return factory.createIntersectionDeclaration({ withParentheses: true, nodes: factory.buildMemberNodes(node.members, this.transform) }) ?? null
       },
       array(node) {
-        const itemNodes = mapSchemaItems(node, (item) => this.transform(item))
+        const itemNodes = ast.mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(isNonNullable)
 
@@ -250,11 +248,11 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
 
         const addsQuestionToken = OPTIONAL_ADDS_QUESTION_TOKEN.has(options.optionalType)
 
-        const propertyNodes: Array<ts.TypeElement> = mapSchemaProperties(node, (schema) => transform(schema)).map(({ name, property, output }) => {
+        const propertyNodes: Array<ts.TypeElement> = ast.mapSchemaProperties(node, (schema) => transform(schema)).map(({ name, property, output }) => {
           const baseType = output ?? factory.keywordTypeNodes.unknown
           const optional = !property.required || !!property.schema.optional || !!property.schema.nullish
           const type = factory.buildPropertyType(property.schema, baseType, options.optionalType, optional)
-          const propMeta = syncSchemaRef(property.schema)
+          const propMeta = ast.syncSchemaRef(property.schema)
 
           const propertyNode = factory.createPropertySignature({
             questionToken: optional ? addsQuestionToken : false,
@@ -283,7 +281,7 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
       if (!transformed) return null
 
       // For ref nodes, structural metadata lives on node.schema rather than the ref node itself.
-      const meta = syncSchemaRef(node)
+      const meta = ast.syncSchemaRef(node)
 
       // Without name, apply modifiers inline and return.
       if (!name) {

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -1,7 +1,5 @@
-import { jsStringEscape, stringify } from 'kubb/ast'
 import { getOperationParameters, resolveContentTypeVariants } from '@internals/shared'
 import { ast } from 'kubb/kit'
-import { syncSchemaRef } from 'kubb/ast'
 import type { ResolverTs } from './types.ts'
 
 /**
@@ -30,7 +28,7 @@ function isSchemaOptional(schema: ast.SchemaNode): boolean {
 }
 
 export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: boolean): Array<string | undefined> {
-  const meta = syncSchemaRef(schema)
+  const meta = ast.syncSchemaRef(schema)
 
   const isArray = meta?.primitive === 'array'
 
@@ -48,7 +46,7 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: bo
   const exampleValues = meta?.examples ?? []
 
   return [
-    hasDescription ? `@description ${jsStringEscape(meta.description)}` : null,
+    hasDescription ? `@description ${ast.jsStringEscape(meta.description)}` : null,
     ...formatComment,
     meta && 'deprecated' in meta && meta.deprecated ? '@deprecated' : null,
     // minItems/maxItems on arrays should not be emitted as @minLength/@maxLength
@@ -56,7 +54,7 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: bo
     !isArray && meta && 'max' in meta && meta.max !== undefined ? `@maxLength ${meta.max}` : null,
     meta && 'pattern' in meta && meta.pattern ? `@pattern ${meta.pattern}` : null,
     meta && 'default' in meta && meta.default !== undefined
-      ? `@default ${'primitive' in meta && meta.primitive === 'string' ? stringify(meta.default as string) : meta.default}`
+      ? `@default ${'primitive' in meta && meta.primitive === 'string' ? ast.stringify(meta.default as string) : meta.default}`
       : null,
     ...exampleValues.map((example) => `@example ${example}`),
     meta && 'primitive' in meta && meta.primitive

--- a/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
@@ -1,6 +1,5 @@
 import { getOperationParameters } from '@internals/shared'
-import { getNestedAccessor } from 'kubb/ast'
-import type { ast } from 'kubb/kit'
+import { ast } from 'kubb/kit'
 import type { ResolverTs } from '@kubb/plugin-ts'
 import { functionPrinter } from '@kubb/plugin-ts'
 import { File, Function } from 'kubb/jsx'
@@ -84,8 +83,8 @@ export function InfiniteQueryOptions({
 
   const [getNextPageParamExpr, getPreviousPageParamExpr] = (() => {
     if (hasNewParams) {
-      const nextAccessor = nextParam ? getNestedAccessor(nextParam, 'lastPage') : null
-      const prevAccessor = previousParam ? getNestedAccessor(previousParam, 'firstPage') : null
+      const nextAccessor = nextParam ? ast.getNestedAccessor(nextParam, 'lastPage') : null
+      const prevAccessor = previousParam ? ast.getNestedAccessor(previousParam, 'firstPage') : null
       return [
         nextAccessor ? `getNextPageParam: (lastPage) => ${nextAccessor}` : null,
         prevAccessor ? `getPreviousPageParam: (firstPage) => ${prevAccessor}` : null,

--- a/packages/plugin-zod/src/generators/zodGenerator.test.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.test.tsx
@@ -3,7 +3,6 @@ import { camelCase } from '@internals/utils'
 
 import type { Config, Group } from 'kubb/kit'
 import { ast, memoryStorage } from 'kubb/kit'
-import { findCircularSchemas } from 'kubb/ast'
 import { createMockedAdapter, createMockedPlugin, createMockedPluginDriver, renderGeneratorOperation, renderGeneratorSchema } from 'kubb/kit/testing'
 import { describe, expect, test } from 'vitest'
 import { matchFiles, rawSources } from '#mocks'
@@ -348,7 +347,7 @@ describe('zodGenerator — Schema', () => {
         resolvedOptions: { dateType: 'string' },
       }),
       meta: {
-        circularNames: [...findCircularSchemas([petPolySchema, catCycleSchema])],
+        circularNames: [...ast.findCircularSchemas([petPolySchema, catCycleSchema])],
         enumNames: [],
       },
       driver,
@@ -380,7 +379,7 @@ describe('zodGenerator — Schema', () => {
       config: testConfig,
       adapter: createMockedAdapter({ resolvedOptions: { dateType: 'string' } }),
       meta: {
-        circularNames: [...findCircularSchemas([errorDetailsSchema])],
+        circularNames: [...ast.findCircularSchemas([errorDetailsSchema])],
         enumNames: [],
       },
       driver,

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -171,37 +171,39 @@ function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): stri
   const isCyclic = (schema: ast.SchemaNode): boolean =>
     ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
 
-  const entries = ast.mapSchemaProperties(objectNode, (schema) => {
-    // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
-    // nested refs by temporarily clearing cyclicSchemas.
-    const hasSelfRef = isCyclic(schema)
-    const savedCyclicSchemas = ctx.options.cyclicSchemas
-    if (hasSelfRef) ctx.options.cyclicSchemas = undefined
-    const baseOutput = ctx.transform(schema) ?? ctx.transform(ast.factory.createSchema({ type: 'unknown' }))!
-    if (hasSelfRef) ctx.options.cyclicSchemas = savedCyclicSchemas
-    return baseOutput
-  }).map(({ name: propName, property, output: baseOutput }) => {
-    const { schema } = property
-    const meta = ast.syncSchemaRef(schema)
-
-    // When a property schema is not a ref but the metadata is from a ref (e.g., discriminator
-    // property override), skip applying the description from the ref target to avoid applying
-    // metadata from a replaced schema.
-    const descriptionToApply = schema.type !== 'ref' && meta.type === 'ref' ? undefined : meta.description
-
-    const value = applyModifiers({
-      value: baseOutput,
-      schema,
-      nullable: meta.nullable,
-      optional: schema.optional || property.required === false,
-      nullish: schema.nullish,
-      defaultValue: meta.default,
-      description: descriptionToApply,
-      examples: meta.examples,
+  const entries = ast
+    .mapSchemaProperties(objectNode, (schema) => {
+      // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
+      // nested refs by temporarily clearing cyclicSchemas.
+      const hasSelfRef = isCyclic(schema)
+      const savedCyclicSchemas = ctx.options.cyclicSchemas
+      if (hasSelfRef) ctx.options.cyclicSchemas = undefined
+      const baseOutput = ctx.transform(schema) ?? ctx.transform(ast.factory.createSchema({ type: 'unknown' }))!
+      if (hasSelfRef) ctx.options.cyclicSchemas = savedCyclicSchemas
+      return baseOutput
     })
+    .map(({ name: propName, property, output: baseOutput }) => {
+      const { schema } = property
+      const meta = ast.syncSchemaRef(schema)
 
-    return isCyclic(schema) ? ast.lazyGetter({ name: propName, body: value }) : `${ast.objectKey(propName)}: ${value}`
-  })
+      // When a property schema is not a ref but the metadata is from a ref (e.g., discriminator
+      // property override), skip applying the description from the ref target to avoid applying
+      // metadata from a replaced schema.
+      const descriptionToApply = schema.type !== 'ref' && meta.type === 'ref' ? undefined : meta.description
+
+      const value = applyModifiers({
+        value: baseOutput,
+        schema,
+        nullable: meta.nullable,
+        optional: schema.optional || property.required === false,
+        nullish: schema.nullish,
+        defaultValue: meta.default,
+        description: descriptionToApply,
+        examples: meta.examples,
+      })
+
+      return isCyclic(schema) ? ast.lazyGetter({ name: propName, body: value }) : `${ast.objectKey(propName)}: ${value}`
+    })
 
   return ast.buildObject(entries)
 }
@@ -361,7 +363,8 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
         return result
       },
       array(node) {
-        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast
+          .mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
         const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
@@ -370,7 +373,8 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
         return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
       },
       tuple(node) {
-        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast
+          .mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
 
@@ -378,7 +382,8 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
       },
       union(node) {
         const nodeMembers = node.members ?? []
-        const members = ast.mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
+        const members = ast
+          .mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
           .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema, cyclicSchemaNames) : output))
           .filter(Boolean)
         if (members.length === 0) return ''

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -1,7 +1,4 @@
-import { buildList, buildObject, extractRefName, lazyGetter, mapSchemaItems, mapSchemaMembers, mapSchemaProperties, objectKey, stringify } from 'kubb/ast'
-
 import { ast } from 'kubb/kit'
-import { containsCircularRef, syncSchemaRef } from 'kubb/ast'
 import type { PluginZod, ResolverZod } from '../types.ts'
 import {
   applyModifiers,
@@ -129,12 +126,12 @@ function strictOneOfMember(member: string, node: ast.SchemaNode, cyclicSchemas?:
     // A cyclic ref is annotated `z.ZodType`, and a nullable/optional ref is wrapped in
     // ZodNullable/ZodOptional, and neither exposes `.strict()`. Only a bare `ZodObject` ref takes it.
     // A union member ref may carry only `node.name` (no `node.ref`), so fall back to it like `ref()`.
-    const refName = (node.ref ? extractRefName(node.ref) : undefined) ?? node.name
+    const refName = (node.ref ? ast.extractRefName(node.ref) : undefined) ?? node.name
     if (refName && cyclicSchemas?.has(refName)) {
       return member
     }
 
-    const schema = syncSchemaRef(node)
+    const schema = ast.syncSchemaRef(node)
 
     if (schema.nullable || schema.optional || node.nullable || node.optional) {
       return member
@@ -172,9 +169,9 @@ function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): stri
   if (!objectNode) return '{}'
 
   const isCyclic = (schema: ast.SchemaNode): boolean =>
-    ctx.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
+    ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
 
-  const entries = mapSchemaProperties(objectNode, (schema) => {
+  const entries = ast.mapSchemaProperties(objectNode, (schema) => {
     // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
     // nested refs by temporarily clearing cyclicSchemas.
     const hasSelfRef = isCyclic(schema)
@@ -185,7 +182,7 @@ function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): stri
     return baseOutput
   }).map(({ name: propName, property, output: baseOutput }) => {
     const { schema } = property
-    const meta = syncSchemaRef(schema)
+    const meta = ast.syncSchemaRef(schema)
 
     // When a property schema is not a ref but the metadata is from a ref (e.g., discriminator
     // property override), skip applying the description from the ref target to avoid applying
@@ -203,10 +200,10 @@ function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): stri
       examples: meta.examples,
     })
 
-    return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
+    return isCyclic(schema) ? ast.lazyGetter({ name: propName, body: value }) : `${ast.objectKey(propName)}: ${value}`
   })
 
-  return buildObject(entries)
+  return ast.buildObject(entries)
 }
 
 /**
@@ -313,7 +310,7 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
         if (!node.name) return null
         // `nameMapping` (keyed by the full $ref) carries the collision-resolved name when the
         // referenced component was renamed; otherwise fall back to the short ref name.
-        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? extractRefName(node.ref) ?? node.name) : node.name
+        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name) : node.name
 
         // In the input direction, a date-bearing component resolves to its `${name}InputSchema`
         // variant so request bodies encode `Date → string` instead of decoding.
@@ -364,7 +361,7 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
         return result
       },
       array(node) {
-        const items = mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
         const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
@@ -373,15 +370,15 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
         return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
       },
       tuple(node) {
-        const items = mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
 
-        return `z.tuple(${buildList(items)})`
+        return `z.tuple(${ast.buildList(items)})`
       },
       union(node) {
         const nodeMembers = node.members ?? []
-        const members = mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
+        const members = ast.mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
           .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema, cyclicSchemaNames) : output))
           .filter(Boolean)
         if (members.length === 0) return ''
@@ -391,10 +388,10 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
         // non-objects fall back to z.union.
         const allDiscriminable = nodeMembers.every((m) => isObjectSchemaNode(m, cyclicSchemaNames))
         if (node.discriminatorPropertyName && allDiscriminable) {
-          return `z.discriminatedUnion(${stringify(node.discriminatorPropertyName)}, ${buildList(members)})`
+          return `z.discriminatedUnion(${ast.stringify(node.discriminatorPropertyName)}, ${ast.buildList(members)})`
         }
 
-        return `z.union(${buildList(members)})`
+        return `z.union(${ast.buildList(members)})`
       },
       intersection(node) {
         const members = node.members ?? []
@@ -427,7 +424,7 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
       const transformed = this.transform(node)
       if (!transformed) return null
 
-      const meta = syncSchemaRef(node)
+      const meta = ast.syncSchemaRef(node)
 
       const base = (() => {
         if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -1,7 +1,4 @@
-import { buildList, buildObject, extractRefName, lazyGetter, mapSchemaItems, mapSchemaMembers, mapSchemaProperties, objectKey, stringify } from 'kubb/ast'
-
 import { ast } from 'kubb/kit'
-import { containsCircularRef, syncSchemaRef } from 'kubb/ast'
 import type { PluginZod, ResolverZod } from '../types.ts'
 import {
   applyMiniModifiers,
@@ -115,9 +112,9 @@ function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNod
   if (!objectNode) return '{}'
 
   const isCyclic = (schema: ast.SchemaNode): boolean =>
-    ctx.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
+    ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
 
-  const entries = mapSchemaProperties(objectNode, (schema) => {
+  const entries = ast.mapSchemaProperties(objectNode, (schema) => {
     const hasSelfRef = isCyclic(schema)
     const savedCyclicSchemas = ctx.options.cyclicSchemas
     if (hasSelfRef) ctx.options.cyclicSchemas = undefined
@@ -126,7 +123,7 @@ function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNod
     return baseOutput
   }).map(({ name: propName, property, output: baseOutput }) => {
     const { schema } = property
-    const meta = syncSchemaRef(schema)
+    const meta = ast.syncSchemaRef(schema)
 
     const value = applyMiniModifiers({
       value: baseOutput,
@@ -137,10 +134,10 @@ function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNod
       defaultValue: meta.default,
     })
 
-    return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
+    return isCyclic(schema) ? ast.lazyGetter({ name: propName, body: value }) : `${ast.objectKey(propName)}: ${value}`
   })
 
-  return buildObject(entries)
+  return ast.buildObject(entries)
 }
 
 /**
@@ -232,7 +229,7 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
         if (!node.name) return null
         // `nameMapping` (keyed by the full $ref) carries the collision-resolved name when the
         // referenced component was renamed; otherwise fall back to the short ref name.
-        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? extractRefName(node.ref) ?? node.name) : node.name
+        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name) : node.name
         const resolvedName = node.ref ? (this.options.resolver?.default(refName, 'function') ?? refName) : node.name
 
         if (node.ref && this.options.cyclicSchemas?.has(refName)) {
@@ -269,7 +266,7 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
         return objectBase
       },
       array(node) {
-        const items = mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
         const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
@@ -278,15 +275,15 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
         return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
       },
       tuple(node) {
-        const items = mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
 
-        return `z.tuple(${buildList(items)})`
+        return `z.tuple(${ast.buildList(items)})`
       },
       union(node) {
         const nodeMembers = node.members ?? []
-        const members = mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
+        const members = ast.mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
           .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema) : output))
           .filter(Boolean)
         if (members.length === 0) return ''
@@ -296,10 +293,10 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
         // non-objects fall back to z.union.
         const allDiscriminable = nodeMembers.every((m) => isObjectSchemaNode(m, cyclicSchemaNames))
         if (node.discriminatorPropertyName && allDiscriminable) {
-          return `z.discriminatedUnion(${stringify(node.discriminatorPropertyName)}, ${buildList(members)})`
+          return `z.discriminatedUnion(${ast.stringify(node.discriminatorPropertyName)}, ${ast.buildList(members)})`
         }
 
-        return `z.union(${buildList(members)})`
+        return `z.union(${ast.buildList(members)})`
       },
       intersection(node) {
         const members = node.members ?? []
@@ -332,7 +329,7 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
       const transformed = this.transform(node)
       if (!transformed) return null
 
-      const meta = syncSchemaRef(node)
+      const meta = ast.syncSchemaRef(node)
 
       const base = (() => {
         if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -114,28 +114,30 @@ function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNod
   const isCyclic = (schema: ast.SchemaNode): boolean =>
     ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
 
-  const entries = ast.mapSchemaProperties(objectNode, (schema) => {
-    const hasSelfRef = isCyclic(schema)
-    const savedCyclicSchemas = ctx.options.cyclicSchemas
-    if (hasSelfRef) ctx.options.cyclicSchemas = undefined
-    const baseOutput = ctx.transform(schema) ?? ctx.transform(ast.factory.createSchema({ type: 'unknown' }))!
-    if (hasSelfRef) ctx.options.cyclicSchemas = savedCyclicSchemas
-    return baseOutput
-  }).map(({ name: propName, property, output: baseOutput }) => {
-    const { schema } = property
-    const meta = ast.syncSchemaRef(schema)
-
-    const value = applyMiniModifiers({
-      value: baseOutput,
-      schema,
-      nullable: meta.nullable,
-      optional: schema.optional || property.required === false,
-      nullish: schema.nullish,
-      defaultValue: meta.default,
+  const entries = ast
+    .mapSchemaProperties(objectNode, (schema) => {
+      const hasSelfRef = isCyclic(schema)
+      const savedCyclicSchemas = ctx.options.cyclicSchemas
+      if (hasSelfRef) ctx.options.cyclicSchemas = undefined
+      const baseOutput = ctx.transform(schema) ?? ctx.transform(ast.factory.createSchema({ type: 'unknown' }))!
+      if (hasSelfRef) ctx.options.cyclicSchemas = savedCyclicSchemas
+      return baseOutput
     })
+    .map(({ name: propName, property, output: baseOutput }) => {
+      const { schema } = property
+      const meta = ast.syncSchemaRef(schema)
 
-    return isCyclic(schema) ? ast.lazyGetter({ name: propName, body: value }) : `${ast.objectKey(propName)}: ${value}`
-  })
+      const value = applyMiniModifiers({
+        value: baseOutput,
+        schema,
+        nullable: meta.nullable,
+        optional: schema.optional || property.required === false,
+        nullish: schema.nullish,
+        defaultValue: meta.default,
+      })
+
+      return isCyclic(schema) ? ast.lazyGetter({ name: propName, body: value }) : `${ast.objectKey(propName)}: ${value}`
+    })
 
   return ast.buildObject(entries)
 }
@@ -266,7 +268,8 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
         return objectBase
       },
       array(node) {
-        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast
+          .mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
         const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
@@ -275,7 +278,8 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
         return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
       },
       tuple(node) {
-        const items = ast.mapSchemaItems(node, (item) => this.transform(item))
+        const items = ast
+          .mapSchemaItems(node, (item) => this.transform(item))
           .map(({ output }) => output)
           .filter(Boolean)
 
@@ -283,7 +287,8 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
       },
       union(node) {
         const nodeMembers = node.members ?? []
-        const members = ast.mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
+        const members = ast
+          .mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
           .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema) : output))
           .filter(Boolean)
         if (members.length === 0) return ''

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -1,6 +1,4 @@
-import { extractRefName, stringify, toRegExpString } from 'kubb/ast'
 import { ast } from 'kubb/kit'
-import { syncSchemaRef } from 'kubb/ast'
 import type { PluginZod } from './types.ts'
 
 /**
@@ -87,12 +85,12 @@ export function containsCodec(node: ast.SchemaNode | undefined, seen: Set<string
 
   if (node.type === 'ref') {
     if (!node.ref) return false
-    const refName = extractRefName(node.ref)
+    const refName = ast.extractRefName(node.ref)
     if (refName) {
       if (seen.has(refName)) return false
       seen.add(refName)
     }
-    const resolved = syncSchemaRef(node)
+    const resolved = ast.syncSchemaRef(node)
     if (resolved.type === 'ref') return false
     return containsCodec(resolved, seen)
   }
@@ -112,7 +110,7 @@ export function containsCodec(node: ast.SchemaNode | undefined, seen: Set<string
  */
 export function collectCodecRefNames(node: ast.SchemaNode): Array<string> {
   return ast.collect<string>(node, {
-    schema: (n) => (n.type === 'ref' && n.ref && containsCodec(n) ? (extractRefName(n.ref) ?? undefined) : undefined),
+    schema: (n) => (n.type === 'ref' && n.ref && containsCodec(n) ? (ast.extractRefName(n.ref) ?? undefined) : undefined),
   })
 }
 
@@ -137,9 +135,9 @@ export function isObjectSchemaNode(node: ast.SchemaNode, cyclicSchemas?: Readonl
   if (node.type === 'object') return true
 
   if (node.type === 'ref') {
-    const refName = (node.ref ? extractRefName(node.ref) : undefined) ?? node.name
+    const refName = (node.ref ? ast.extractRefName(node.ref) : undefined) ?? node.name
     if (refName && cyclicSchemas?.has(refName)) return false
-    const resolved = syncSchemaRef(node)
+    const resolved = ast.syncSchemaRef(node)
     // An unresolved ref keeps its `ref` type; assume it resolves to an object (matches the printer's
     // prior optimism that only a resolved intersection blocks a discriminated union).
     return resolved.type === 'ref' || isObjectSchemaNode(resolved, cyclicSchemas)
@@ -169,7 +167,7 @@ export function isObjectComposableIntersection(node: ast.SchemaNode, cyclicSchem
  * Objects become `{}`, primitives become their string representation, strings are quoted.
  */
 export function formatDefault(value: unknown): string {
-  if (typeof value === 'string') return stringify(value)
+  if (typeof value === 'string') return ast.stringify(value)
   if (typeof value === 'object' && value !== null) return '{}'
 
   return String(value ?? '')
@@ -215,7 +213,7 @@ export function defaultLiteral(node: ast.SchemaNode | undefined, value: unknown)
  * Strings are quoted; numbers and booleans are emitted raw.
  */
 export function formatLiteral(v: string | number | boolean): string {
-  if (typeof v === 'string') return stringify(v)
+  if (typeof v === 'string') return ast.stringify(v)
 
   return String(v)
 }
@@ -288,7 +286,7 @@ export function patternKeySchemaMini({ patterns, regexType }: { patterns: Array<
 
 function patternKeySource({ patterns, regexType }: { patterns: Array<string>; regexType?: PluginZod['resolvedOptions']['regexType'] }): string {
   const source = patterns.length === 1 ? patterns[0]! : patterns.map((pattern) => `(${pattern})`).join('|')
-  return toRegExpString(source, regexFunc(regexType))
+  return ast.toRegExpString(source, regexFunc(regexType))
 }
 
 /**
@@ -327,7 +325,7 @@ export function lengthConstraints({ min, max, pattern, regexType }: LengthConstr
   return [
     min !== undefined ? `.min(${min})` : '',
     max !== undefined ? `.max(${max})` : '',
-    pattern !== undefined ? `.regex(${toRegExpString(pattern, regexFunc(regexType))})` : '',
+    pattern !== undefined ? `.regex(${ast.toRegExpString(pattern, regexFunc(regexType))})` : '',
   ].join('')
 }
 
@@ -351,7 +349,7 @@ export function lengthChecksMini({ min, max, pattern, regexType }: LengthConstra
   const checks: Array<string> = []
   if (min !== undefined) checks.push(`z.minLength(${min})`)
   if (max !== undefined) checks.push(`z.maxLength(${max})`)
-  if (pattern !== undefined) checks.push(`z.regex(${toRegExpString(pattern, regexFunc(regexType))})`)
+  if (pattern !== undefined) checks.push(`z.regex(${ast.toRegExpString(pattern, regexFunc(regexType))})`)
   return checks.length ? `.check(${checks.join(', ')})` : ''
 }
 
@@ -368,7 +366,7 @@ export function applyModifiers({ value, schema, nullable, optional, nullish, def
   })()
   const literal = defaultValue !== undefined ? defaultLiteral(schema, defaultValue) : null
   const withDefault = literal !== null ? `${withModifier}.default(${literal})` : withModifier
-  const withDescription = description ? `${withDefault}.describe(${stringify(description)})` : withDefault
+  const withDescription = description ? `${withDefault}.describe(${ast.stringify(description)})` : withDefault
   return examples?.length ? `${withDescription}.meta({ examples: [${examples.map(formatDefault).join(', ')}] })` : withDescription
 }
 


### PR DESCRIPTION
## 🎯 Changes

The `kubb/ast` subpath is being removed from the `kubb` package. This migrates every plugin that imported AST helpers from `kubb/ast` over to the `ast` namespace on `kubb/kit`, which is where the same symbols already live.

Across `plugin-ts`, `plugin-zod`, `plugin-faker`, `plugin-react-query`, and `plugin-vue-query` (15 files, 22 imports), each `import { extractRefName, … } from 'kubb/ast'` becomes `import { ast } from 'kubb/kit'` and the call sites read `ast.extractRefName`, `ast.syncSchemaRef`, `ast.containsCircularRef`, and so on. The one type-only import (`operationParams.ts`) uses `import type { ast } from 'kubb/kit'` with `ast.OperationNode` / `ast.ParameterNode` in type positions. Generated output is unchanged.

Every changed package typechecks and lints clean, and no `kubb/ast` import remains in `packages/*/src`.

This depends on the matching `kubb` change that removes the subpath (kubb-labs/kubb).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCSYy6fJUJ32P7Qqmyb5F9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCSYy6fJUJ32P7Qqmyb5F9)_