### PR TITLE
fix(ci): clean up orphaned chore/update-generated-examples branches

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -8,7 +8,13 @@ permissions: {}
 
 jobs:
   delete-branch:
-    if: github.event.pull_request.merged == true
+    # Bot-generated `chore/update-generated-examples-*` branches are excepted from the
+    # merged-only guard: their PR targets the source PR's own branch (see pr.yml), so when
+    # that source branch merges or closes first, GitHub auto-closes this PR unmerged and
+    # the branch would otherwise never get cleaned up.
+    if: >-
+      github.event.pull_request.merged == true ||
+      startsWith(github.event.pull_request.head.ref, 'chore/update-generated-examples-')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 🎯 Changes

`chore/update-generated-examples-<PR#>` branches were not being removed by the cleanup action.

Root cause: the `update-examples` job in `pr.yml` opens its PR against the source PR's own branch (`base: ${{ github.head_ref }}`), not `master`/`next`. When the source PR merges or closes first, GitHub auto-closes this stacked "update examples" PR as unmerged (its base branch is gone). `cleanup-branches.yml` only deleted the head branch `if: github.event.pull_request.merged == true`, so these auto-closed, never-merged branches were skipped and piled up.

Fix: also run the delete step when the closed PR's branch matches the `chore/update-generated-examples-` prefix, regardless of merge state, since those branches are disposable bot output and never need to survive their PR closing.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BvM21n8mNp3sMUDFQ6wm2j)_