### PR TITLE
chore: remove fixed version group so plugins publish independently

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
     }
   ],
   "commit": false,
-  "fixed": [["@kubb/plugin-*"]],
+  "fixed": [],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",


### PR DESCRIPTION
## 🎯 Changes

Removes the `fixed` version group covering `@kubb/plugin-*` from `.changeset/config.json` (now `"fixed": []`). Until now, a changeset touching any single plugin bumped and published every `@kubb/plugin-*` package at the same version. With the group removed, each plugin versions and publishes independently: only packages with a changeset (plus internal dependents per `updateInternalDependencies: "patch"`) get a release.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. (Release tooling config only, no code changes.)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release). (Release tooling config only, no changeset needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcRosA8tsWADCF5CSc128D

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcRosA8tsWADCF5CSc128D)_