### PR TITLE
refactor(resolvers): simplify resolver names to body/path/query/headers

### DIFF
--- a/.changeset/simplify-resolver-names.md
+++ b/.changeset/simplify-resolver-names.md
@@ -1,0 +1,38 @@
+---
+"@kubb/plugin-react-query": minor
+"@kubb/plugin-vue-query": minor
+"@kubb/plugin-cypress": minor
+"@kubb/plugin-faker": minor
+"@kubb/plugin-fetch": minor
+"@kubb/plugin-axios": minor
+"@kubb/plugin-swr": minor
+"@kubb/plugin-msw": minor
+"@kubb/plugin-mcp": minor
+"@kubb/plugin-ts": minor
+"@kubb/plugin-zod": minor
+---
+
+Simplify the resolver naming API so the request-part resolvers line up with the generated object keys, and drop the redundant `resolvePathName`.
+
+`resolvePathName(name, type)` duplicated `default(name, type)` on every resolver, so it is removed. Call `default` directly where you previously called `resolvePathName`:
+
+```ts
+// before
+resolver.resolveFile({ name: resolver.resolvePathName(name, 'file'), extname: '.ts' }, context)
+
+// after
+resolver.resolveFile({ name: resolver.default(name, 'file'), extname: '.ts' }, context)
+```
+
+The request-part resolvers now use the same `body` / `path` / `query` / `headers` vocabulary as the generated `RequestConfig` object:
+
+| Before | After |
+| --- | --- |
+| `resolveDataName` | `resolveBodyName` |
+| `resolvePathParamsName` | `resolvePathName` |
+| `resolveQueryParamsName` | `resolveQueryName` |
+| `resolveHeaderParamsName` | `resolveHeadersName` |
+
+The request body type also drops its `Data` suffix in favor of `Body`, so generated names change: `CreatePetData` becomes `CreatePetBody`, and the Zod schema `createPetDataSchema` becomes `createPetBodySchema`. Custom resolvers that override these methods, and code that imports the generated names, need updating.
+
+Note that `resolvePathName` is reused: the old file-name method of that name is gone, and it now names the grouped path-parameters resolver `resolvePathName(node, param)`.

--- a/examples/zod/operationsPlugin.ts
+++ b/examples/zod/operationsPlugin.ts
@@ -61,11 +61,11 @@ function buildSchemaNames(node: ast.OperationNode, resolver: ResolverZod) {
   responses['default'] = resolver.resolveResponseName(node)
 
   return {
-    request: node.requestBody?.content?.[0]?.schema ? resolver.resolveDataName(node) : null,
+    request: node.requestBody?.content?.[0]?.schema ? resolver.resolveBodyName(node) : null,
     parameters: {
-      path: pathParam ? resolver.resolvePathParamsName(node, pathParam) : null,
-      query: queryParam ? resolver.resolveQueryParamsName(node, queryParam) : null,
-      header: headerParam ? resolver.resolveHeaderParamsName(node, headerParam) : null,
+      path: pathParam ? resolver.resolvePathName(node, pathParam) : null,
+      query: queryParam ? resolver.resolveQueryName(node, queryParam) : null,
+      header: headerParam ? resolver.resolveHeadersName(node, headerParam) : null,
     },
     responses,
     errors,

--- a/internals/client/src/builders/validator.test.ts
+++ b/internals/client/src/builders/validator.test.ts
@@ -50,19 +50,19 @@ describe('buildValidatorHooks', () => {
     expect(hooks.importedZodNames).toStrictEqual(['addPetResponseSchema', 'addPetErrorSchema'])
   })
 
-  test('the object form wires the request validator from the data schema', () => {
+  test('the object form wires the request validator from the body schema', () => {
     const hooks = buildValidatorHooks({ node: addPet, validator: { request: 'zod' }, zodResolver: resolverZod })
-    expect(hooks.request).toBe('addPetDataSchema')
+    expect(hooks.request).toBe('addPetBodySchema')
     expect(hooks.response).toBeNull()
     expect(hooks.error).toBeNull()
-    expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema'])
+    expect(hooks.importedZodNames).toStrictEqual(['addPetBodySchema'])
   })
 
   test('wires both directions when both are enabled', () => {
     const hooks = buildValidatorHooks({ node: addPet, validator: { request: 'zod', response: 'zod' }, zodResolver: resolverZod })
-    expect(hooks.request).toBe('addPetDataSchema')
+    expect(hooks.request).toBe('addPetBodySchema')
     expect(hooks.response).toBe('addPetResponseSchema')
     expect(hooks.error).toBeNull()
-    expect(hooks.importedZodNames).toStrictEqual(['addPetDataSchema', 'addPetResponseSchema'])
+    expect(hooks.importedZodNames).toStrictEqual(['addPetBodySchema', 'addPetResponseSchema'])
   })
 })

--- a/internals/client/src/builders/validator.ts
+++ b/internals/client/src/builders/validator.ts
@@ -47,7 +47,7 @@ export function buildValidatorHooks({
   const importedZodNames: Array<string> = []
 
   const hasRequestBody = Boolean(node.requestBody?.content?.[0]?.schema)
-  const zodRequestName = zodResolver && resolveRequestValidator(validator) === 'zod' && hasRequestBody ? zodResolver.resolveDataName?.(node) : null
+  const zodRequestName = zodResolver && resolveRequestValidator(validator) === 'zod' && hasRequestBody ? zodResolver.resolveBodyName?.(node) : null
   const request = zodRequestName ?? null
   if (zodRequestName) importedZodNames.push(zodRequestName)
 

--- a/internals/client/src/generators/sdkGenerator.tsx
+++ b/internals/client/src/generators/sdkGenerator.tsx
@@ -55,8 +55,8 @@ function resolveZodImportNames(node: ast.OperationNode, zodResolver: ResolverZod
   const names: Array<string | null | undefined> = [
     resolveResponseValidator(validator) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
     resolveResponseValidator(validator) === 'zod' ? (buildZodErrorParse(node, zodResolver)?.expression ?? null) : null,
-    resolveRequestValidator(validator) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveDataName?.(node) : null,
-    resolveQueryParamsValidator(validator) === 'zod' && queryParams.length > 0 ? zodResolver.resolveQueryParamsName?.(node, queryParams[0]!) : null,
+    resolveRequestValidator(validator) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveBodyName?.(node) : null,
+    resolveQueryParamsValidator(validator) === 'zod' && queryParams.length > 0 ? zodResolver.resolveQueryName?.(node, queryParams[0]!) : null,
   ]
   return names.filter((n): n is string => Boolean(n))
 }

--- a/internals/client/src/resolver.ts
+++ b/internals/client/src/resolver.ts
@@ -22,9 +22,6 @@ export const resolverClient = defineResolver<PluginContractClient>(() => ({
   resolveName(name) {
     return this.default(name, 'function')
   },
-  resolvePathName(name, type) {
-    return this.default(name, type)
-  },
   resolveClassName(name) {
     return ensureValidVarName(pascalCase(name))
   },

--- a/internals/client/src/types.ts
+++ b/internals/client/src/types.ts
@@ -31,10 +31,6 @@ export type ResolverClient = Resolver & {
    */
   resolveName(this: ResolverClient, name: string): string
   /**
-   * Resolves the output file name for a generated client module.
-   */
-  resolvePathName(this: ResolverClient, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-  /**
    * Resolves the generated class name for class-based clients.
    */
   resolveClassName(this: ResolverClient, name: string): string

--- a/internals/shared/src/operation.test.ts
+++ b/internals/shared/src/operation.test.ts
@@ -26,16 +26,16 @@ import {
 } from './operation.ts'
 
 const resolver: RequestConfigResolver & ResponseNameResolver & ResponseStatusNameResolver & OperationTypeNameResolver = {
-  resolveDataName(node) {
+  resolveBodyName(node) {
     return `${node.operationId}Data`
   },
-  resolvePathParamsName(_node, param) {
+  resolvePathName(_node, param) {
     return `${param.name}PathParams`
   },
-  resolveQueryParamsName(_node, param) {
+  resolveQueryName(_node, param) {
     return `${param.name}QueryParams`
   },
-  resolveHeaderParamsName(_node, param) {
+  resolveHeadersName(_node, param) {
     return `${param.name}HeaderParams`
   },
   resolveResponseName(node) {

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -31,7 +31,7 @@ export type ContentTypeInfo = {
 }
 
 export type RequestConfigResolver = {
-  resolveDataName(node: ast.OperationNode): string
+  resolveBodyName(node: ast.OperationNode): string
 }
 
 export type ResponseStatusNameResolver = {
@@ -44,9 +44,9 @@ export type ResponseNameResolver = ResponseStatusNameResolver & {
 
 export type OperationTypeNameResolver = RequestConfigResolver &
   ResponseNameResolver & {
-    resolvePathParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
-    resolveQueryParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
-    resolveHeaderParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
+    resolvePathName(node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveQueryName(node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveHeadersName(node: ast.OperationNode, param: ast.ParameterNode): string
   }
 
 /**
@@ -66,33 +66,33 @@ export type OperationParamsResolver = {
    * Resolves the request body type name.
    *
    * @example Request body type name
-   * `resolver.resolveDataName(node) // → 'CreatePetData'`
+   * `resolver.resolveBodyName(node) // → 'CreatePetBody'`
    */
-  resolveDataName(node: ast.OperationNode): string
+  resolveBodyName(node: ast.OperationNode): string
   /**
    * Resolves the grouped path parameters type name.
    * When the return value equals `resolveParamName`, no indexed access is emitted.
    *
    * @example Grouped path params type name
-   * `resolver.resolvePathParamsName(node, param) // → 'DeletePetPathParams'`
+   * `resolver.resolvePathName(node, param) // → 'DeletePetPath'`
    */
-  resolvePathParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
+  resolvePathName(node: ast.OperationNode, param: ast.ParameterNode): string
   /**
    * Resolves the grouped query parameters type name.
    * When the return value equals `resolveParamName`, an inline struct type is emitted instead.
    *
    * @example Grouped query params type name
-   * `resolver.resolveQueryParamsName(node, param) // → 'FindPetsByStatusQueryParams'`
+   * `resolver.resolveQueryName(node, param) // → 'FindPetsByStatusQuery'`
    */
-  resolveQueryParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
+  resolveQueryName(node: ast.OperationNode, param: ast.ParameterNode): string
   /**
    * Resolves the grouped header parameters type name.
    * When the return value equals `resolveParamName`, an inline struct type is emitted instead.
    *
    * @example Grouped header params type name
-   * `resolver.resolveHeaderParamsName(node, param) // → 'DeletePetHeaderParams'`
+   * `resolver.resolveHeadersName(node, param) // → 'DeletePetHeaders'`
    */
-  resolveHeaderParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
+  resolveHeadersName(node: ast.OperationNode, param: ast.ParameterNode): string
 }
 
 export type OperationCommentLink = 'pathTemplate' | 'urlPath' | false | ((node: ast.OperationNode) => string | undefined)
@@ -473,11 +473,11 @@ export function resolveOperationTypeNames(
     options.includeParams === false
       ? []
       : [
-          ...path.map((param) => resolver.resolvePathParamsName(node, param)),
-          ...query.map((param) => resolver.resolveQueryParamsName(node, param)),
-          ...header.map((param) => resolver.resolveHeaderParamsName(node, param)),
+          ...path.map((param) => resolver.resolvePathName(node, param)),
+          ...query.map((param) => resolver.resolveQueryName(node, param)),
+          ...header.map((param) => resolver.resolveHeadersName(node, param)),
         ]
-  const bodyAndResponseNames = [node.requestBody?.content?.[0]?.schema ? resolver.resolveDataName(node) : null, resolver.resolveResponseName(node)]
+  const bodyAndResponseNames = [node.requestBody?.content?.[0]?.schema ? resolver.resolveBodyName(node) : null, resolver.resolveResponseName(node)]
   const names =
     options.order === 'body-response-first'
       ? [...bodyAndResponseNames, ...paramNames, ...responseStatusNames]

--- a/internals/tanstack-query/src/utils.ts
+++ b/internals/tanstack-query/src/utils.ts
@@ -178,8 +178,8 @@ export function resolveOperationOverrides<TOptions>(node: ast.OperationNode, ove
 
 type ZodSchemaNameResolverLike = {
   resolveResponseName?: (node: ast.OperationNode) => string | undefined
-  resolveDataName?: (node: ast.OperationNode) => string | undefined
-  resolveQueryParamsName?: (node: ast.OperationNode, param: ast.ParameterNode) => string | undefined
+  resolveBodyName?: (node: ast.OperationNode) => string | undefined
+  resolveQueryName?: (node: ast.OperationNode, param: ast.ParameterNode) => string | undefined
 }
 
 type ParserOption = false | 'zod' | { request?: 'zod'; response?: 'zod' } | undefined
@@ -228,8 +228,8 @@ export function resolveZodSchemaNames(node: ast.OperationNode, zodResolver: ZodS
   const { query: queryParams } = getOperationParameters(node, { paramsCasing: 'original' })
   return [
     resolveResponseParser(parser) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
-    resolveRequestParser(parser) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveDataName?.(node) : null,
-    resolveQueryParamsParser(parser) === 'zod' && queryParams.length > 0 ? zodResolver.resolveQueryParamsName?.(node, queryParams[0]!) : null,
+    resolveRequestParser(parser) === 'zod' && node.requestBody?.content?.[0]?.schema ? zodResolver.resolveBodyName?.(node) : null,
+    resolveQueryParamsParser(parser) === 'zod' && queryParams.length > 0 ? zodResolver.resolveQueryName?.(node, queryParams[0]!) : null,
   ].filter((n): n is string => Boolean(n))
 }
 

--- a/packages/plugin-axios/src/generators/clientGenerator.tsx
+++ b/packages/plugin-axios/src/generators/clientGenerator.tsx
@@ -44,7 +44,7 @@ export const clientGenerator = defineGenerator<PluginAxios>({
       ? [
           resolveResponseValidator(validator) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
           resolveResponseValidator(validator) === 'zod' ? (buildZodErrorParse(node, zodResolver)?.expression ?? null) : null,
-          resolveRequestValidator(validator) === 'zod' && hasRequestBody ? zodResolver.resolveDataName?.(node) : null,
+          resolveRequestValidator(validator) === 'zod' && hasRequestBody ? zodResolver.resolveBodyName?.(node) : null,
         ].filter((name): name is string => Boolean(name))
       : []
 

--- a/packages/plugin-cypress/src/resolvers/resolverCypress.ts
+++ b/packages/plugin-cypress/src/resolvers/resolverCypress.ts
@@ -23,7 +23,4 @@ export const resolverCypress = defineResolver<PluginCypress>(() => ({
   resolveName(name) {
     return this.default(name, 'function')
   },
-  resolvePathName(name, type) {
-    return this.default(name, type)
-  },
 }))

--- a/packages/plugin-cypress/src/types.ts
+++ b/packages/plugin-cypress/src/types.ts
@@ -11,10 +11,6 @@ export type ResolverCypress = Resolver & {
    * `resolver.resolveName('show pet by id') // -> 'showPetById'`
    */
   resolveName(this: ResolverCypress, name: string): string
-  /**
-   * Resolves the output file name for a Cypress request module.
-   */
-  resolvePathName(this: ResolverCypress, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
 }
 
 /**

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createCreatePet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createCreatePet.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { CreatePetData, CreatePetResponse, CreatePetStatus201 } from './types/CreatePet'
+import type { CreatePetBody, CreatePetResponse, CreatePetStatus201 } from './types/CreatePet'
 import { faker } from '@faker-js/faker'
 
 /**
@@ -16,7 +16,7 @@ export function createCreatePetStatus201(data?: Partial<CreatePetStatus201>): Cr
 /**
  * @description Pet to add
  */
-export function createCreatePetData<TData extends Partial<CreatePetData> = object>(data?: TData) {
+export function createCreatePetBody<TData extends Partial<CreatePetBody> = object>(data?: TData) {
   const defaultFakeData = {
     name: faker.string.alpha(),
     category: createCategory(),

--- a/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.test.tsx
@@ -349,6 +349,6 @@ describe('fakerGenerator — operation', () => {
 
   test('default resolver applies create prefix to names', () => {
     expect(resolverFaker.resolveName('Eval')).toBe('createEval')
-    expect(resolverFaker.resolvePathName('Eval', 'file')).toBe('createEval')
+    expect(resolverFaker.default('Eval', 'file')).toBe('createEval')
   })
 })

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -161,8 +161,8 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
     )
     const dataUnits = expandContentUnits(
       node.requestBody?.content ?? [],
-      resolver.resolveDataName(node),
-      tsResolver.resolveDataName(node),
+      resolver.resolveBodyName(node),
+      tsResolver.resolveBodyName(node),
       node.requestBody?.description,
       (schema) => ({ ...schema, description: node.requestBody?.description ?? schema.description }),
     )

--- a/packages/plugin-faker/src/resolvers/resolverFaker.ts
+++ b/packages/plugin-faker/src/resolvers/resolverFaker.ts
@@ -27,9 +27,6 @@ export const resolverFaker = defineResolver<PluginFaker>(() => {
     resolveName(name, type) {
       return this.default(name, type)
     },
-    resolvePathName(name, type) {
-      return this.default(name, type)
-    },
     resolveFile({ name, extname, tag, path: groupPath }, context) {
       const resolvedName = context.output.mode === 'file' ? '' : this.resolveName(name, 'file')
       const inputBaseName = `${resolvedName}${extname}` as `${string}.${string}`
@@ -59,8 +56,8 @@ export const resolverFaker = defineResolver<PluginFaker>(() => {
     resolveParamName(node, param) {
       return this.resolveName(`${node.operationId} ${param.in} ${param.name}`)
     },
-    resolveDataName(node) {
-      return this.resolveName(`${node.operationId} Data`)
+    resolveBodyName(node) {
+      return this.resolveName(`${node.operationId} Body`)
     },
     resolveResponseStatusName(node, statusCode) {
       return this.resolveName(`${node.operationId} Status ${statusCode}`)
@@ -71,13 +68,13 @@ export const resolverFaker = defineResolver<PluginFaker>(() => {
     resolveResponsesName(node) {
       return this.resolveName(`${node.operationId} Responses`)
     },
-    resolvePathParamsName(node, param) {
+    resolvePathName(node, param) {
       return this.resolveParamName(node, param)
     },
-    resolveQueryParamsName(node, param) {
+    resolveQueryName(node, param) {
       return this.resolveParamName(node, param)
     },
-    resolveHeaderParamsName(node, param) {
+    resolveHeadersName(node, param) {
       return this.resolveParamName(node, param)
     },
   }

--- a/packages/plugin-faker/src/types.ts
+++ b/packages/plugin-faker/src/types.ts
@@ -15,19 +15,12 @@ export type ResolverFaker = Resolver &
      */
     resolveName(this: ResolverFaker, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
     /**
-     * Resolves the output file name for a faker module.
-     *
-     * @example Resolving faker file names
-     * `resolver.resolvePathName('show pet by id', 'file') // -> 'showPetById'`
-     */
-    resolvePathName(this: ResolverFaker, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-    /**
      * Resolves the faker function name for a request body.
      *
      * @example Resolving data function names
-     * `resolver.resolveDataName(node) // -> 'createPetsData'`
+     * `resolver.resolveBodyName(node) // -> 'createPetsBody'`
      */
-    resolveDataName(this: ResolverFaker, node: ast.OperationNode): string
+    resolveBodyName(this: ResolverFaker, node: ast.OperationNode): string
     /**
      * Resolves the faker function name for a response by status code.
      *
@@ -53,23 +46,23 @@ export type ResolverFaker = Resolver &
      * Resolves the faker function name for path parameters.
      *
      * @example Path parameters names
-     * `resolver.resolvePathParamsName(node, param) // -> 'showPetByIdPathPetId'`
+     * `resolver.resolvePathName(node, param) // -> 'showPetByIdPathPetId'`
      */
-    resolvePathParamsName(this: ResolverFaker, node: ast.OperationNode, param: ast.ParameterNode): string
+    resolvePathName(this: ResolverFaker, node: ast.OperationNode, param: ast.ParameterNode): string
     /**
      * Resolves the faker function name for query parameters.
      *
      * @example Query parameters names
-     * `resolver.resolveQueryParamsName(node, param) // -> 'listPetsQueryLimit'`
+     * `resolver.resolveQueryName(node, param) // -> 'listPetsQueryLimit'`
      */
-    resolveQueryParamsName(this: ResolverFaker, node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveQueryName(this: ResolverFaker, node: ast.OperationNode, param: ast.ParameterNode): string
     /**
      * Resolves the faker function name for header parameters.
      *
      * @example Header parameters names
-     * `resolver.resolveHeaderParamsName(node, param) // -> 'deletePetHeaderApiKey'`
+     * `resolver.resolveHeadersName(node, param) // -> 'deletePetHeaderApiKey'`
      */
-    resolveHeaderParamsName(this: ResolverFaker, node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveHeadersName(this: ResolverFaker, node: ast.OperationNode, param: ast.ParameterNode): string
   }
 
 /**

--- a/packages/plugin-faker/src/utils.ts
+++ b/packages/plugin-faker/src/utils.ts
@@ -58,17 +58,17 @@ export function canOverrideSchema(node: ast.SchemaNode): boolean {
  * Resolves a parameter name based on its location (path, query, header, etc.) using the provided resolver.
  */
 export function resolveParamNameByLocation(
-  resolver: Pick<ResolverFaker, 'resolvePathParamsName' | 'resolveQueryParamsName' | 'resolveHeaderParamsName' | 'resolveParamName'>,
+  resolver: Pick<ResolverFaker, 'resolvePathName' | 'resolveQueryName' | 'resolveHeadersName' | 'resolveParamName'>,
   node: ast.OperationNode,
   param: ast.ParameterNode,
 ): string {
   switch (param.in) {
     case 'path':
-      return resolver.resolvePathParamsName(node, param)
+      return resolver.resolvePathName(node, param)
     case 'query':
-      return resolver.resolveQueryParamsName(node, param)
+      return resolver.resolveQueryName(node, param)
     case 'header':
-      return resolver.resolveHeaderParamsName(node, param)
+      return resolver.resolveHeadersName(node, param)
     default:
       return resolver.resolveParamName(node, param)
   }

--- a/packages/plugin-fetch/src/generators/clientGenerator.tsx
+++ b/packages/plugin-fetch/src/generators/clientGenerator.tsx
@@ -44,7 +44,7 @@ export const clientGenerator = defineGenerator<PluginFetch>({
       ? [
           resolveResponseValidator(validator) === 'zod' ? zodResolver.resolveResponseName?.(node) : null,
           resolveResponseValidator(validator) === 'zod' ? (buildZodErrorParse(node, zodResolver)?.expression ?? null) : null,
-          resolveRequestValidator(validator) === 'zod' && hasRequestBody ? zodResolver.resolveDataName?.(node) : null,
+          resolveRequestValidator(validator) === 'zod' && hasRequestBody ? zodResolver.resolveBodyName?.(node) : null,
         ].filter((name): name is string => Boolean(name))
       : []
 

--- a/packages/plugin-mcp/src/generators/serverGenerator.tsx
+++ b/packages/plugin-mcp/src/generators/serverGenerator.tsx
@@ -60,7 +60,7 @@ export const serverGenerator = defineGenerator<PluginMcp>({
         },
       )
 
-      const requestName = node.requestBody?.content?.[0]?.schema ? zodResolver.resolveDataName(node) : null
+      const requestName = node.requestBody?.content?.[0]?.schema ? zodResolver.resolveBodyName(node) : null
       const successStatus = findSuccessStatusCode(node.responses)
       const responseName = successStatus ? zodResolver.resolveResponseStatusName(node, successStatus) : null
 

--- a/packages/plugin-mcp/src/resolvers/resolverMcp.ts
+++ b/packages/plugin-mcp/src/resolvers/resolverMcp.ts
@@ -26,9 +26,6 @@ export const resolverMcp = defineResolver<PluginMcp>(() => ({
   resolveName(name) {
     return this.default(name, 'function')
   },
-  resolvePathName(name, type) {
-    return this.default(name, type)
-  },
   resolveHandlerName(node) {
     return this.resolveName(node.operationId)
   },

--- a/packages/plugin-mcp/src/types.ts
+++ b/packages/plugin-mcp/src/types.ts
@@ -13,10 +13,6 @@ export type ResolverMcp = Resolver & {
    */
   resolveName(this: ResolverMcp, name: string): string
   /**
-   * Resolves the output file name for an MCP module.
-   */
-  resolvePathName(this: ResolverMcp, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-  /**
    * Resolves the handler function name for an operation.
    */
   resolveHandlerName(this: ResolverMcp, node: ast.OperationNode): string

--- a/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPet/createPetsHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { CreatePetsResponse, CreatePetsData } from './CreatePets'
+import type { CreatePetsResponse, CreatePetsBody } from './CreatePets'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -13,8 +13,8 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
   })
 }
 
-export function createPetsHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreatePetsData>) {
-  return http.post<Record<string, string>, CreatePetsData>(`/pets`, function handler(info) {
+export function createPetsHandler(data?: string | number | boolean | null | object | HttpResponseResolver<Record<string, string>, CreatePetsBody>) {
+  return http.post<Record<string, string>, CreatePetsBody>(`/pets`, function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data), {

--- a/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
+++ b/packages/plugin-msw/src/generators/__snapshots__/createPetFaker/createPetsHandler.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { CreatePetsResponse, CreatePetsData } from './CreatePets'
+import type { CreatePetsResponse, CreatePetsBody } from './CreatePets'
 import type { HttpResponseResolver } from 'msw'
 import { createCreatePetsResponse } from './createCreatePets'
 import { http } from 'msw'
@@ -14,8 +14,8 @@ export function createPetsHandlerResponse201(data?: CreatePetsResponse) {
   })
 }
 
-export function createPetsHandler(data?: CreatePetsResponse | HttpResponseResolver<Record<string, string>, CreatePetsData>) {
-  return http.post<Record<string, string>, CreatePetsData>('/pets', function handler(info) {
+export function createPetsHandler(data?: CreatePetsResponse | HttpResponseResolver<Record<string, string>, CreatePetsBody>) {
+  return http.post<Record<string, string>, CreatePetsBody>('/pets', function handler(info) {
     if (typeof data === 'function') return data(info)
 
     return new Response(JSON.stringify(data || createCreatePetsResponse(data)), {

--- a/packages/plugin-msw/src/generators/handlersGenerator.ts
+++ b/packages/plugin-msw/src/generators/handlersGenerator.ts
@@ -14,7 +14,7 @@ export const handlersGenerator = defineGenerator<PluginMsw>({
     const { output, group } = ctx.options
 
     const handlersName = resolver.resolveHandlersName()
-    const file = resolver.resolveFile({ name: resolver.resolvePathName(handlersName, 'file'), extname: '.ts' }, { root, output, group: group ?? undefined })
+    const file = resolver.resolveFile({ name: resolver.default(handlersName, 'file'), extname: '.ts' }, { root, output, group: group ?? undefined })
 
     const imports = nodes.map((node) => {
       const operationName = resolver.resolveHandlerName(node)

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -57,7 +57,7 @@ export const mswGenerator = defineGenerator<PluginMsw>({
     const successResponses = getOperationSuccessResponses(node)
     const hasSuccessSchema = successResponses.some((response) => !!response.content?.[0]?.schema)
 
-    const requestName = node.requestBody?.content?.[0]?.schema ? tsResolver.resolveDataName(node) : null
+    const requestName = node.requestBody?.content?.[0]?.schema ? tsResolver.resolveBodyName(node) : null
 
     return (
       <File

--- a/packages/plugin-msw/src/resolvers/resolverMsw.ts
+++ b/packages/plugin-msw/src/resolvers/resolverMsw.ts
@@ -23,9 +23,6 @@ export const resolverMsw = defineResolver<PluginMsw>(() => ({
   resolveName(name) {
     return camelCase(name, { suffix: 'handler' })
   },
-  resolvePathName(name, type) {
-    return this.default(name, type)
-  },
   resolveHandlerName(node) {
     return this.resolveName(node.operationId)
   },

--- a/packages/plugin-msw/src/types.ts
+++ b/packages/plugin-msw/src/types.ts
@@ -9,10 +9,6 @@ export type ResolverMsw = Resolver & {
    */
   resolveName(this: ResolverMsw, name: string): string
   /**
-   * Resolves the output file name for an MSW handler module.
-   */
-  resolvePathName(this: ResolverMsw, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-  /**
    * Resolves the handler function name for an operation.
    */
   resolveHandlerName(this: ResolverMsw, node: ast.OperationNode): string

--- a/packages/plugin-react-query/src/components/InfiniteQuery.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQuery.tsx
@@ -82,7 +82,7 @@ export function InfiniteQuery({
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {
-          const groupName = tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+          const groupName = tsResolver.resolveQueryName(node, rawQueryParams[0]!)
           const individualName = tsResolver.resolveParamName(node, rawQueryParams[0]!)
           return groupName !== individualName ? groupName : null
         })()

--- a/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
@@ -62,7 +62,7 @@ export function InfiniteQueryOptions({
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {
-          const groupName = tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+          const groupName = tsResolver.resolveQueryName(node, rawQueryParams[0]!)
           const individualName = tsResolver.resolveParamName(node, rawQueryParams[0]!)
           return groupName !== individualName ? groupName : null
         })()

--- a/packages/plugin-react-query/src/components/SuspenseInfiniteQuery.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseInfiniteQuery.tsx
@@ -82,7 +82,7 @@ export function SuspenseInfiniteQuery({
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {
-          const groupName = tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+          const groupName = tsResolver.resolveQueryName(node, rawQueryParams[0]!)
           const individualName = tsResolver.resolveParamName(node, rawQueryParams[0]!)
           return groupName !== individualName ? groupName : null
         })()

--- a/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/SuspenseInfiniteQueryOptions.tsx
@@ -62,7 +62,7 @@ export function SuspenseInfiniteQueryOptions({
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {
-          const groupName = tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+          const groupName = tsResolver.resolveQueryName(node, rawQueryParams[0]!)
           const individualName = tsResolver.resolveParamName(node, rawQueryParams[0]!)
           return groupName !== individualName ? groupName : null
         })()

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -65,8 +65,8 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
 
     const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
     const queryParamsTypeName =
-      rawQueryParams.length > 0 && tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
-        ? tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+      rawQueryParams.length > 0 && tsResolver.resolveQueryName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
+        ? tsResolver.resolveQueryName(node, rawQueryParams[0]!)
         : null
 
     const importedTypeNames = [

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -65,8 +65,8 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
 
     const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
     const queryParamsTypeName =
-      rawQueryParams.length > 0 && tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
-        ? tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+      rawQueryParams.length > 0 && tsResolver.resolveQueryName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
+        ? tsResolver.resolveQueryName(node, rawQueryParams[0]!)
         : null
 
     const importedTypeNames = [

--- a/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
+++ b/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
@@ -34,9 +34,6 @@ export const resolverReactQuery = defineResolver<PluginReactQuery>(() => ({
   resolveName(name) {
     return this.default(name, 'function')
   },
-  resolvePathName(name, type) {
-    return this.default(name, type)
-  },
   resolveQueryName(node) {
     return `use${capitalize(this.resolveName(node.operationId))}`
   },

--- a/packages/plugin-react-query/src/types.ts
+++ b/packages/plugin-react-query/src/types.ts
@@ -16,10 +16,6 @@ export type ResolverReactQuery = Resolver & {
    */
   resolveName(this: ResolverReactQuery, name: string): string
   /**
-   * Resolves the output file name for a hook module.
-   */
-  resolvePathName(this: ResolverReactQuery, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-  /**
    * Resolves a query hook function name.
    */
   resolveQueryName(this: ResolverReactQuery, node: ast.OperationNode): string

--- a/packages/plugin-swr/src/resolvers/resolverSwr.ts
+++ b/packages/plugin-swr/src/resolvers/resolverSwr.ts
@@ -23,9 +23,6 @@ export const resolverSwr = defineResolver<PluginSwr>(() => ({
   resolveName(name) {
     return this.default(name, 'function')
   },
-  resolvePathName(name, type) {
-    return this.default(name, type)
-  },
   resolveQueryName(node) {
     return `use${capitalize(this.resolveName(node.operationId))}`
   },

--- a/packages/plugin-swr/src/types.ts
+++ b/packages/plugin-swr/src/types.ts
@@ -16,10 +16,6 @@ export type ResolverSwr = Resolver & {
    */
   resolveName(this: ResolverSwr, name: string): string
   /**
-   * Resolves the output file name for a hook module.
-   */
-  resolvePathName(this: ResolverSwr, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-  /**
    * Resolves a query hook function name.
    */
   resolveQueryName(this: ResolverSwr, node: ast.OperationNode): string

--- a/packages/plugin-ts/src/generators/__snapshots__/addPetPOSTWithRequestBody/AddPet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/addPetPOSTWithRequestBody/AddPet.ts
@@ -16,13 +16,13 @@ export type AddPetStatus405 = object
 /**
  * @type object
  */
-export type AddPetData = object
+export type AddPetBody = object
 
 /**
  * @type object
  */
 export type AddPetRequestConfig = {
-  body: AddPetData
+  body: AddPetBody
   path?: never
   query?: never
   headers?: never

--- a/packages/plugin-ts/src/generators/__snapshots__/multiContentTypePOSTWithJsonAndFormDataRequestBody/UploadFile.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/multiContentTypePOSTWithJsonAndFormDataRequestBody/UploadFile.ts
@@ -16,7 +16,7 @@ export type UploadFileStatus200 = object
 /**
  * @type object
  */
-export type UploadFileJsonData = {
+export type UploadFileBodyJson = {
   /**
    * @type string
    */
@@ -26,20 +26,20 @@ export type UploadFileJsonData = {
 /**
  * @type object
  */
-export type UploadFileFormData = {
+export type UploadFileBodyFormData = {
   /**
    * @type string
    */
   file: string
 }
 
-export type UploadFileData = UploadFileJsonData | UploadFileFormData
+export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
 /**
  * @type object
  */
 export type UploadFileRequestConfig = {
-  body: UploadFileData
+  body: UploadFileBody
   /**
    * @type object
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/paramsCasingCamelcase/UpdatePet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/paramsCasingCamelcase/UpdatePet.ts
@@ -26,7 +26,7 @@ export type UpdatePetStatus200 = object
 /**
  * @type object
  */
-export type UpdatePetData = {
+export type UpdatePetBody = {
   /**
    * @type string
    */
@@ -37,7 +37,7 @@ export type UpdatePetData = {
  * @type object
  */
 export type UpdatePetRequestConfig = {
-  body: UpdatePetData
+  body: UpdatePetBody
   /**
    * @type object
    */

--- a/packages/plugin-ts/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/PlaceOrderPatch.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/PlaceOrderPatch.ts
@@ -22,13 +22,13 @@ export type PlaceOrderPatchStatus405 = object
  * @description Order payload
  * @type object
  */
-export type PlaceOrderPatchData = object
+export type PlaceOrderPatchBody = object
 
 /**
  * @type object
  */
 export type PlaceOrderPatchRequestConfig = {
-  body: PlaceOrderPatchData
+  body: PlaceOrderPatchBody
   /**
    * @type object
    */

--- a/packages/plugin-ts/src/generators/typeGenerator.test.ts
+++ b/packages/plugin-ts/src/generators/typeGenerator.test.ts
@@ -142,7 +142,7 @@ describe('typeGenerator — custom resolver', () => {
 
     expect(source).toContain('export type ApiCreatePetStatus201 = ApiPet')
     expect(source).toContain('export type ApiCreatePetStatus400 = ApiErrorResponse')
-    expect(source).toContain('export type ApiCreatePetData = ApiNewPet')
+    expect(source).toContain('export type ApiCreatePetBody = ApiNewPet')
     expect(source).toContain("import type { ApiPet } from './Pet.ts'")
     expect(source).toContain("import type { ApiErrorResponse } from './ErrorResponse.ts'")
     expect(source).toContain("import type { ApiNewPet } from './NewPet.ts'")

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -187,12 +187,12 @@ export const typeGenerator = defineGenerator<PluginTs>({
             ...entry.schema,
             description: node.requestBody!.description ?? entry.schema.description,
           },
-          name: resolver.resolveDataName(node),
+          name: resolver.resolveBodyName(node),
           keysToOmit: entry.keysToOmit,
         })
       }
       // Multiple content types — generate individual types + union alias
-      return buildContentTypeVariants(requestBodyContent, resolver.resolveDataName(node), (schema) => ({
+      return buildContentTypeVariants(requestBodyContent, resolver.resolveBodyName(node), (schema) => ({
         ...schema,
         description: node.requestBody!.description ?? schema.description,
       }))

--- a/packages/plugin-ts/src/printers/operationParams.test.ts
+++ b/packages/plugin-ts/src/printers/operationParams.test.ts
@@ -48,10 +48,10 @@ function makeResolver(overrides: Partial<OperationParamsResolver> = {}): Operati
   const resolveParamName = overrides.resolveParamName ?? ((_node: OperationNode, param: ParameterNode) => param.name)
   return {
     resolveParamName,
-    resolveDataName: () => 'unknown',
-    resolvePathParamsName: resolveParamName,
-    resolveQueryParamsName: resolveParamName,
-    resolveHeaderParamsName: resolveParamName,
+    resolveBodyName: () => 'unknown',
+    resolvePathName: resolveParamName,
+    resolveQueryName: resolveParamName,
+    resolveHeadersName: resolveParamName,
     ...overrides,
   }
 }
@@ -98,7 +98,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `Types["${param.name}"]`,
-          resolveDataName: () => 'CreatePetRequest',
+          resolveBodyName: () => 'CreatePetRequest',
         }),
         extraParams: [
           createFunctionParameter({
@@ -245,7 +245,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `Types["${param.name}"]`,
-          resolveDataName: () => 'UpdatePetBody',
+          resolveBodyName: () => 'UpdatePetBody',
         }),
         extraParams: [
           createFunctionParameter({
@@ -448,7 +448,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: () => 'unknown',
-          resolveDataName: () => 'CreatePetRequest',
+          resolveBodyName: () => 'CreatePetRequest',
         }),
       })
 
@@ -478,7 +478,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: () => 'unknown',
-          resolveDataName: () => 'UpdatePetRequest',
+          resolveBodyName: () => 'UpdatePetRequest',
         }),
       })
 
@@ -497,7 +497,7 @@ describe('createOperationParams', () => {
   })
 
   describe('resolver with group methods (named group types)', () => {
-    it('uses resolveQueryParamsName for query params in inline mode', () => {
+    it('uses resolveQueryName for query params in inline mode', () => {
       const node = makeOperation({
         parameters: [makePathParam('petId'), makeQueryParam('filter')],
       })
@@ -507,7 +507,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `Types["${param.name}"]`,
-          resolveQueryParamsName: () => 'FindPetsQueryParams',
+          resolveQueryName: () => 'FindPetsQueryParams',
         }),
       })
 
@@ -520,7 +520,7 @@ describe('createOperationParams', () => {
       })
     })
 
-    it('uses resolveQueryParamsName for query params in object mode', () => {
+    it('uses resolveQueryName for query params in object mode', () => {
       const node = makeOperation({
         parameters: [makePathParam('petId'), makeQueryParam('status', { required: true })],
       })
@@ -530,7 +530,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `Types["${param.name}"]`,
-          resolveQueryParamsName: () => 'FindPetsQueryParams',
+          resolveQueryName: () => 'FindPetsQueryParams',
         }),
       })
 
@@ -546,7 +546,7 @@ describe('createOperationParams', () => {
       }
     })
 
-    it('falls back to inline types when resolveQueryParamsName is not provided', () => {
+    it('falls back to inline types when resolveQueryName is not provided', () => {
       const node = makeOperation({
         parameters: [makeQueryParam('filter')],
       })
@@ -566,7 +566,7 @@ describe('createOperationParams', () => {
       })
     })
 
-    it('uses resolveHeaderParamsName for header params in inline mode', () => {
+    it('uses resolveHeadersName for header params in inline mode', () => {
       const node = makeOperation({
         parameters: [makeHeaderParam('x-api-key', { required: true })],
       })
@@ -576,7 +576,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: () => 'string',
-          resolveHeaderParamsName: () => 'FindPetsHeaderParams',
+          resolveHeadersName: () => 'FindPetsHeaderParams',
         }),
       })
 
@@ -593,7 +593,7 @@ describe('createOperationParams', () => {
       })
     })
 
-    it('uses resolveHeaderParamsName for headers in object mode', () => {
+    it('uses resolveHeadersName for headers in object mode', () => {
       const node = makeOperation({
         parameters: [makePathParam('petId'), makeHeaderParam('x-api-key')],
       })
@@ -603,7 +603,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: () => 'string',
-          resolveHeaderParamsName: () => 'HeaderParams',
+          resolveHeadersName: () => 'HeaderParams',
         }),
       })
 
@@ -619,7 +619,7 @@ describe('createOperationParams', () => {
       }
     })
 
-    it('uses resolvePathParamsName for indexed access types on path params', () => {
+    it('uses resolvePathName for indexed access types on path params', () => {
       const node = makeOperation({
         parameters: [makePathParam('petId'), makePathParam('name', { required: false })],
       })
@@ -629,7 +629,7 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `DeletePetPath${param.name}`,
-          resolvePathParamsName: () => 'DeletePetPathParams',
+          resolvePathName: () => 'DeletePetPathParams',
         }),
       })
 
@@ -709,8 +709,8 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `MaybeRefOrGetter<Types["${param.name}"]>`,
-          resolveDataName: () => 'MaybeRefOrGetter<CreatePetRequest>',
-          resolveQueryParamsName: () => 'MaybeRefOrGetter<FindPetsQueryParams>',
+          resolveBodyName: () => 'MaybeRefOrGetter<CreatePetRequest>',
+          resolveQueryName: () => 'MaybeRefOrGetter<FindPetsQueryParams>',
         }),
       })
 
@@ -815,9 +815,9 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `Types["${param.name}"]`,
-          resolveDataName: () => 'CreatePetRequest',
-          resolveQueryParamsName: () => 'GetPetQueryParams',
-          resolveHeaderParamsName: () => 'GetPetHeaderParams',
+          resolveBodyName: () => 'CreatePetRequest',
+          resolveQueryName: () => 'GetPetQueryParams',
+          resolveHeadersName: () => 'GetPetHeaderParams',
         }),
       })
 
@@ -866,9 +866,9 @@ describe('createOperationParams', () => {
         pathParamsType: 'inline',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `Types["${param.name}"]`,
-          resolveDataName: () => 'CreatePetRequest',
-          resolveQueryParamsName: () => 'GetPetQueryParams',
-          resolveHeaderParamsName: () => 'GetPetHeaderParams',
+          resolveBodyName: () => 'CreatePetRequest',
+          resolveQueryName: () => 'GetPetQueryParams',
+          resolveHeadersName: () => 'GetPetHeaderParams',
         }),
       })
 
@@ -896,8 +896,8 @@ describe('createOperationParams', () => {
         pathParamsType: 'object',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `GetPetByIdPathParams["${param.name}"]`,
-          resolvePathParamsName: () => 'GetPetByIdPathParams',
-          resolveQueryParamsName: () => 'GetPetByIdQueryParams',
+          resolvePathName: () => 'GetPetByIdPathParams',
+          resolveQueryName: () => 'GetPetByIdQueryParams',
         }),
       })
 
@@ -947,7 +947,7 @@ describe('createOperationParams', () => {
         paramsCasing: 'camelcase',
         resolver: makeResolver({
           resolveParamName: (_node, param) => `Types["${param.name}"]`,
-          resolveQueryParamsName: () => 'ListPetsQueryParams',
+          resolveQueryName: () => 'ListPetsQueryParams',
         }),
       })
 
@@ -984,7 +984,7 @@ describe('typeWrapper option', () => {
     const params = createOperationParams(node, {
       paramsType: 'inline',
       pathParamsType: 'inline',
-      resolver: makeResolver({ resolveDataName: () => 'CreatePetRequest' }),
+      resolver: makeResolver({ resolveBodyName: () => 'CreatePetRequest' }),
       typeWrapper: (t) => `MaybeRefOrGetter<${t}>`,
     })
 
@@ -1001,7 +1001,7 @@ describe('typeWrapper option', () => {
       paramsType: 'inline',
       pathParamsType: 'inline',
       resolver: makeResolver({
-        resolveQueryParamsName: () => 'ListPetsQueryParams',
+        resolveQueryName: () => 'ListPetsQueryParams',
       }),
       typeWrapper: (t) => `MaybeRefOrGetter<${t}>`,
     })
@@ -1036,7 +1036,7 @@ describe('pathParamsType: inlineSpread', () => {
       paramsType: 'inline',
       pathParamsType: 'inlineSpread',
       resolver: makeResolver({
-        resolvePathParamsName: () => 'GetPetByIdPathParams',
+        resolvePathName: () => 'GetPetByIdPathParams',
       }),
     })
 
@@ -1060,7 +1060,7 @@ describe('pathParamsType: inlineSpread', () => {
       pathParamsType: 'inlineSpread',
       paramNames: { path: 'args' },
       resolver: makeResolver({
-        resolvePathParamsName: () => 'GetPetByIdPathParams',
+        resolvePathName: () => 'GetPetByIdPathParams',
       }),
     })
 
@@ -1079,7 +1079,7 @@ describe('pathParamsType: inlineSpread', () => {
       paramsType: 'inline',
       pathParamsType: 'inlineSpread',
       resolver: makeResolver({
-        resolvePathParamsName: () => 'GetPetByIdPathParams',
+        resolvePathName: () => 'GetPetByIdPathParams',
       }),
       typeWrapper: (t) => `MaybeRefOrGetter<${t}>`,
     })

--- a/packages/plugin-ts/src/printers/operationParams.ts
+++ b/packages/plugin-ts/src/printers/operationParams.ts
@@ -132,9 +132,9 @@ function resolveParamType({
   const groupLocation = param.in === 'path' || param.in === 'query' || param.in === 'header' ? param.in : undefined
 
   const groupResolvers = {
-    path: resolver.resolvePathParamsName,
-    query: resolver.resolveQueryParamsName,
-    header: resolver.resolveHeaderParamsName,
+    path: resolver.resolvePathName,
+    query: resolver.resolveQueryName,
+    header: resolver.resolveHeadersName,
   } as const
 
   const groupName = groupLocation ? groupResolvers[groupLocation].call(resolver, node, param) : undefined
@@ -167,7 +167,7 @@ function resolveGroupType({
     return null
   }
   const firstParam = params[0]!
-  const groupMethod = group === 'query' ? resolver.resolveQueryParamsName : resolver.resolveHeaderParamsName
+  const groupMethod = group === 'query' ? resolver.resolveQueryName : resolver.resolveHeadersName
   const groupName = groupMethod.call(resolver, node, firstParam)
   if (groupName === resolver.resolveParamName(node, firstParam)) {
     return null
@@ -208,7 +208,7 @@ export function createOperationParams(node: ast.OperationNode, options: CreateOp
   })
   const emptyObjectDefault = (props: Array<GroupProperty>): string | undefined => (props.every((p) => p.optional) ? '{}' : undefined)
 
-  const bodyType = node.requestBody?.content?.[0]?.schema ? wrapType(resolver?.resolveDataName(node) ?? 'unknown') : undefined
+  const bodyType = node.requestBody?.content?.[0]?.schema ? wrapType(resolver?.resolveBodyName(node) ?? 'unknown') : undefined
   const bodyProperty: Array<GroupProperty> = bodyType ? [{ name: dataName, type: bodyType, optional: !(node.requestBody?.required ?? false) }] : []
 
   const trailingGroups: Array<BuildGroupArgs> = [
@@ -232,7 +232,7 @@ export function createOperationParams(node: ast.OperationNode, options: CreateOp
     }
   } else {
     if (pathParamsType === 'inlineSpread' && pathParams.length) {
-      const spreadType = resolver?.resolvePathParamsName(node, pathParams[0]!)
+      const spreadType = resolver?.resolvePathName(node, pathParams[0]!)
       params.push(createFunctionParameter({ name: pathName, type: spreadType ? wrapType(spreadType) : undefined, rest: true }))
     } else if (pathParamsType === 'inline') {
       params.push(...pathParams.map((p) => createFunctionParameter(toProperty(p))))

--- a/packages/plugin-ts/src/resolvers/resolverTs.ts
+++ b/packages/plugin-ts/src/resolvers/resolverTs.ts
@@ -16,7 +16,7 @@ import type { PluginTs } from '../types.ts'
  * import { resolverTs } from '@kubb/plugin-ts'
  *
  * resolverTs.default('list pets', 'type')        // 'ListPets'
- * resolverTs.resolvePathName('list pets', 'file') // 'ListPets'
+ * resolverTs.default('list pets', 'file')         // 'ListPets'
  * resolverTs.resolveResponseStatusName(node, 200) // 'ListPetsStatus200'
  * ```
  */
@@ -31,18 +31,14 @@ export const resolverTs = defineResolver<PluginTs>(() => {
     resolveTypeName(name) {
       return ensureValidVarName(pascalCase(name))
     },
-    resolvePathName(name, type) {
-      if (type === 'file') return toFilePath(name, pascalCase)
-      return ensureValidVarName(pascalCase(name))
-    },
     resolveParamName(node, param) {
       return this.resolveTypeName(`${node.operationId} ${param.in} ${param.name}`)
     },
     resolveResponseStatusName(node, statusCode) {
       return this.resolveTypeName(`${node.operationId} Status ${statusCode}`)
     },
-    resolveDataName(node) {
-      return this.resolveTypeName(`${node.operationId} Data`)
+    resolveBodyName(node) {
+      return this.resolveTypeName(`${node.operationId} Body`)
     },
     resolveRequestConfigName(node) {
       // NOTE(v5-stable): the `RequestConfig` suffix is kept through the beta to avoid churn, but it
@@ -58,13 +54,13 @@ export const resolverTs = defineResolver<PluginTs>(() => {
     resolveEnumKeyName(node, enumTypeSuffix = 'key') {
       return `${this.resolveTypeName(node.name ?? '')}${enumTypeSuffix}`
     },
-    resolvePathParamsName(node, param) {
+    resolvePathName(node, param) {
       return this.resolveParamName(node, param)
     },
-    resolveQueryParamsName(node, param) {
+    resolveQueryName(node, param) {
       return this.resolveParamName(node, param)
     },
-    resolveHeaderParamsName(node, param) {
+    resolveHeadersName(node, param) {
       return this.resolveParamName(node, param)
     },
   }

--- a/packages/plugin-ts/src/types.ts
+++ b/packages/plugin-ts/src/types.ts
@@ -16,17 +16,6 @@ export type ResolverTs = Resolver &
      * `resolver.resolveName('list pets status 200') // → 'ListPetsStatus200'`
      */
     resolveTypeName(name: string): string
-    /**
-     * Resolves the file/path name for a given identifier using PascalCase.
-     *
-     * @example Resolving path names
-     * `resolver.resolvePathName('list pets', 'file') // → 'ListPets'`
-     */
-    resolvePathName(name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-    /**
-     * Resolves the request body type name for an operation (required on ResolverTs).
-     */
-    resolveDataName(node: ast.OperationNode): string
 
     /**
      * Resolves the name for an operation response by status code.
@@ -76,23 +65,23 @@ export type ResolverTs = Resolver &
      * Resolves the name for an operation's grouped path parameters type.
      *
      * @example Path parameters names
-     * `resolver.resolvePathParamsName(node, param) // → 'GetPetByIdPathParams'`
+     * `resolver.resolvePathName(node, param) // → 'GetPetByIdPath'`
      */
-    resolvePathParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
+    resolvePathName(node: ast.OperationNode, param: ast.ParameterNode): string
     /**
      * Resolves the name for an operation's grouped query parameters type.
      *
      * @example Query parameters names
-     * `resolver.resolveQueryParamsName(node, param) // → 'FindPetsByStatusQueryParams'`
+     * `resolver.resolveQueryName(node, param) // → 'FindPetsByStatusQuery'`
      */
-    resolveQueryParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveQueryName(node: ast.OperationNode, param: ast.ParameterNode): string
     /**
      * Resolves the name for an operation's grouped header parameters type.
      *
      * @example Header parameters names
-     * `resolver.resolveHeaderParamsName(node, param) // → 'DeletePetHeaderParams'`
+     * `resolver.resolveHeadersName(node, param) // → 'DeletePetHeaders'`
      */
-    resolveHeaderParamsName(node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveHeadersName(node: ast.OperationNode, param: ast.ParameterNode): string
   }
 
 type EnumKeyCasing = 'screamingSnakeCase' | 'snakeCase' | 'pascalCase' | 'camelCase' | 'none'

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -72,7 +72,7 @@ describe('buildData', () => {
 
     expect(printSchema(buildData(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
       "{
-          body: CreatePetData;
+          body: CreatePetBody;
           path?: never;
           query?: never;
           headers?: never;

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -107,7 +107,7 @@ export function buildData(node: ast.OperationNode, { resolver }: BuildOperationS
         name: 'body',
         required: hasBody,
         schema: hasBody
-          ? ast.factory.createSchema({ type: 'ref', name: resolver.resolveDataName(node) })
+          ? ast.factory.createSchema({ type: 'ref', name: resolver.resolveBodyName(node) })
           : ast.factory.createSchema({ type: 'never', primitive: undefined, optional: true }),
       }),
       ast.factory.createProperty({

--- a/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
@@ -62,7 +62,7 @@ export function InfiniteQueryOptions({
   const queryParamsTypeName =
     rawQueryParams.length > 0
       ? (() => {
-          const groupName = tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+          const groupName = tsResolver.resolveQueryName(node, rawQueryParams[0]!)
           const individualName = tsResolver.resolveParamName(node, rawQueryParams[0]!)
           return groupName !== individualName ? groupName : null
         })()

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -65,8 +65,8 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
 
     const rawQueryParams = getOperationParameters(node, { paramsCasing: 'original' }).query
     const queryParamsTypeName =
-      rawQueryParams.length > 0 && tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
-        ? tsResolver.resolveQueryParamsName(node, rawQueryParams[0]!)
+      rawQueryParams.length > 0 && tsResolver.resolveQueryName(node, rawQueryParams[0]!) !== tsResolver.resolveParamName(node, rawQueryParams[0]!)
+        ? tsResolver.resolveQueryName(node, rawQueryParams[0]!)
         : null
 
     const importedTypeNames = [

--- a/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
+++ b/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
@@ -31,9 +31,6 @@ export const resolverVueQuery = defineResolver<PluginVueQuery>(() => ({
   resolveName(name) {
     return this.default(name, 'function')
   },
-  resolvePathName(name, type) {
-    return this.default(name, type)
-  },
   resolveQueryName(node) {
     return `use${capitalize(this.resolveName(node.operationId))}`
   },

--- a/packages/plugin-vue-query/src/types.ts
+++ b/packages/plugin-vue-query/src/types.ts
@@ -16,10 +16,6 @@ export type ResolverVueQuery = Resolver & {
    */
   resolveName(this: ResolverVueQuery, name: string): string
   /**
-   * Resolves the output file name for a hook module.
-   */
-  resolvePathName(this: ResolverVueQuery, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-  /**
    * Resolves a query hook function name.
    */
   resolveQueryName(this: ResolverVueQuery, node: ast.OperationNode): string

--- a/packages/plugin-zod/src/generators/__snapshots__/addPetPOSTMiniMode/addPetMiniSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/addPetPOSTMiniMode/addPetMiniSchema.ts
@@ -9,6 +9,6 @@ export const addPetMiniStatus200Schema = z.object({})
 
 export const addPetMiniResponseSchema = addPetMiniStatus200Schema
 
-export const addPetMiniDataSchema = z.object({
+export const addPetMiniBodySchema = z.object({
   name: z.string(),
 })

--- a/packages/plugin-zod/src/generators/__snapshots__/addPetPOSTWithRequestBody/addPetSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/addPetPOSTWithRequestBody/addPetSchema.ts
@@ -13,4 +13,4 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchema = z.object({})
+export const addPetBodySchema = z.object({})

--- a/packages/plugin-zod/src/generators/__snapshots__/createPetPOSTWithCoercion/createPetSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/createPetPOSTWithCoercion/createPetSchema.ts
@@ -9,7 +9,7 @@ export const createPetStatus201Schema = z.object({})
 
 export const createPetResponseSchema = createPetStatus201Schema
 
-export const createPetDataSchema = z.object({
+export const createPetBodySchema = z.object({
   age: z.coerce.number(),
   name: z.coerce.string(),
 })

--- a/packages/plugin-zod/src/generators/__snapshots__/paramsCasingCamelcase/updatePetSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/paramsCasingCamelcase/updatePetSchema.ts
@@ -13,6 +13,6 @@ export const updatePetStatus200Schema = z.object({})
 
 export const updatePetResponseSchema = updatePetStatus200Schema
 
-export const updatePetDataSchema = z.object({
+export const updatePetBodySchema = z.object({
   name: z.string(),
 })

--- a/packages/plugin-zod/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/placeOrderPatchSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/placeOrderPatchSchema.ts
@@ -15,4 +15,4 @@ export const placeOrderPatchResponseSchema = placeOrderPatchStatus200Schema
 
 export const placeOrderPatchErrorSchema = placeOrderPatchStatus405Schema
 
-export const placeOrderPatchDataSchema = z.object({}).describe('Order payload')
+export const placeOrderPatchBodySchema = z.object({}).describe('Order payload')

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -372,14 +372,14 @@ export const zodGenerator = defineGenerator<PluginZod>({
         if (!entry.schema) return null
         return renderSchemaEntry({
           schema: { ...entry.schema, description: node.requestBody!.description ?? entry.schema.description },
-          name: resolver.resolveDataName(node),
+          name: resolver.resolveBodyName(node),
           keysToOmit: entry.keysToOmit,
           direction: 'input',
         })
       }
       return buildContentTypeVariants(
         requestBodyContent,
-        resolver.resolveDataName(node),
+        resolver.resolveBodyName(node),
         (schema) => ({
           ...schema,
           description: node.requestBody!.description ?? schema.description,

--- a/packages/plugin-zod/src/resolvers/resolverZod.ts
+++ b/packages/plugin-zod/src/resolvers/resolverZod.ts
@@ -40,17 +40,14 @@ export const resolverZod = defineResolver<PluginZod>(() => {
     resolveTypeName(name) {
       return ensureValidVarName(pascalCase(name, { suffix: 'type' }))
     },
-    resolvePathName(name, type) {
-      return this.default(name, type)
-    },
     resolveParamName(node, param) {
       return this.resolveSchemaName(`${node.operationId} ${param.in} ${param.name}`)
     },
     resolveResponseStatusName(node, statusCode) {
       return this.resolveSchemaName(`${node.operationId} Status ${statusCode}`)
     },
-    resolveDataName(node) {
-      return this.resolveSchemaName(`${node.operationId} Data`)
+    resolveBodyName(node) {
+      return this.resolveSchemaName(`${node.operationId} Body`)
     },
     resolveResponsesName(node) {
       return this.resolveSchemaName(`${node.operationId} Responses`)
@@ -61,13 +58,13 @@ export const resolverZod = defineResolver<PluginZod>(() => {
     resolveErrorName(node) {
       return this.resolveSchemaName(`${node.operationId} Error`)
     },
-    resolvePathParamsName(node, param) {
+    resolvePathName(node, param) {
       return this.resolveParamName(node, param)
     },
-    resolveQueryParamsName(node, param) {
+    resolveQueryName(node, param) {
       return this.resolveParamName(node, param)
     },
-    resolveHeaderParamsName(node, param) {
+    resolveHeadersName(node, param) {
       return this.resolveParamName(node, param)
     },
   }

--- a/packages/plugin-zod/src/types.ts
+++ b/packages/plugin-zod/src/types.ts
@@ -42,10 +42,6 @@ export type ResolverZod = Resolver &
      */
     resolveTypeName(this: ResolverZod, name: string): string
     /**
-     * Resolves the output file name for a schema.
-     */
-    resolvePathName(this: ResolverZod, name: string, type?: 'file' | 'function' | 'type' | 'const'): string
-    /**
      * Resolves the name for an operation response by status code.
      *
      * @example Response status names
@@ -78,23 +74,23 @@ export type ResolverZod = Resolver &
      * Resolves the name for an operation's grouped path parameters type.
      *
      * @example Path parameters names
-     * `resolver.resolvePathParamsName(node, param) // → 'deletePetPathPetIdSchema'`
+     * `resolver.resolvePathName(node, param) // → 'deletePetPathPetIdSchema'`
      */
-    resolvePathParamsName(this: ResolverZod, node: ast.OperationNode, param: ast.ParameterNode): string
+    resolvePathName(this: ResolverZod, node: ast.OperationNode, param: ast.ParameterNode): string
     /**
      * Resolves the name for an operation's grouped query parameters type.
      *
      * @example Query parameters names
-     * `resolver.resolveQueryParamsName(node, param) // → 'findPetsByStatusQueryStatusSchema'`
+     * `resolver.resolveQueryName(node, param) // → 'findPetsByStatusQueryStatusSchema'`
      */
-    resolveQueryParamsName(this: ResolverZod, node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveQueryName(this: ResolverZod, node: ast.OperationNode, param: ast.ParameterNode): string
     /**
      * Resolves the name for an operation's grouped header parameters type.
      *
      * @example Header parameters names
-     * `resolver.resolveHeaderParamsName(node, param) // → 'deletePetHeaderApiKeySchema'`
+     * `resolver.resolveHeadersName(node, param) // → 'deletePetHeaderApiKeySchema'`
      */
-    resolveHeaderParamsName(this: ResolverZod, node: ast.OperationNode, param: ast.ParameterNode): string
+    resolveHeadersName(this: ResolverZod, node: ast.OperationNode, param: ast.ParameterNode): string
   }
 
 /**

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/CreateConfigV20250.ts
@@ -14,13 +14,13 @@ export type CreateConfigV20250Status201 = Config;
 /**
  * @type object
 */
-export type CreateConfigV20250Data = ConfigCreate;
+export type CreateConfigV20250Body = ConfigCreate;
 
 /**
  * @type object
 */
 export type CreateConfigV20250RequestConfig = {
-    body: CreateConfigV20250Data;
+    body: CreateConfigV20250Body;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/CreateOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/CreateOrder.ts
@@ -14,7 +14,7 @@ export type CreateOrderStatus201 = OrderSchema;
  * @description Order request body
  * @type object | undefined
 */
-export type CreateOrderData = {
+export type CreateOrderBody = {
     /**
      * @type string | undefined
     */
@@ -29,7 +29,7 @@ export type CreateOrderData = {
  * @type object
 */
 export type CreateOrderRequestConfig = {
-    body: CreateOrderData;
+    body: CreateOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/main/issue2619/zod/createReturnTypeASchema.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2619/zod/createReturnTypeASchema.ts
@@ -10,4 +10,4 @@ export const createReturnTypeAStatus200Schema = resultSchema
 
 export const createReturnTypeAResponseSchema = createReturnTypeAStatus200Schema
 
-export const createReturnTypeADataSchema = typeARequestSchema
+export const createReturnTypeABodySchema = typeARequestSchema

--- a/tests/3.0.x/__snapshots__/main/issue2619/zod/createReturnTypeBSchema.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2619/zod/createReturnTypeBSchema.ts
@@ -10,4 +10,4 @@ export const createReturnTypeBStatus200Schema = resultSchema
 
 export const createReturnTypeBResponseSchema = createReturnTypeBStatus200Schema
 
-export const createReturnTypeBDataSchema = typeBRequestSchema
+export const createReturnTypeBBodySchema = typeBRequestSchema

--- a/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/CreateConfigV20250.ts
@@ -14,13 +14,13 @@ export type CreateConfigV20250Status201 = Config;
 /**
  * @type object
 */
-export type CreateConfigV20250Data = ConfigCreate;
+export type CreateConfigV20250Body = ConfigCreate;
 
 /**
  * @type object
 */
 export type CreateConfigV20250RequestConfig = {
-    body: CreateConfigV20250Data;
+    body: CreateConfigV20250Body;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/main/simple/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/main/simple/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/UpdatePet.ts
@@ -34,13 +34,13 @@ export type UpdatePetStatus200 = Pet;
 /**
  * @type object
 */
-export type UpdatePetData = PetUpdate;
+export type UpdatePetBody = PetUpdate;
 
 /**
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    body: UpdatePetData;
+    body: UpdatePetBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../../types/AddPet.ts'
 import { createAddPetRequest } from '../createAddPetRequest.ts'
 import { createPet } from '../createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/pet/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/store/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/faker/store/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../../types/PlaceOrder.ts'
 import { createOrder } from '../createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerDE as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerDE as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/createUpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/faker/createUpdatePet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UpdatePetData, UpdatePetResponse, UpdatePetStatus200 } from '../types/UpdatePet.ts'
+import type { UpdatePetBody, UpdatePetResponse, UpdatePetStatus200 } from '../types/UpdatePet.ts'
 import { createPet } from './createPet.ts'
 import { createPetUpdate } from './createPetUpdate.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -31,8 +31,8 @@ export function createUpdatePetStatus200(data?: Partial<UpdatePetStatus200>): Up
   return createPet(data) as UpdatePetStatus200
 }
 
-export function createUpdatePetData(data?: Partial<UpdatePetData>): UpdatePetData {
-  return createPetUpdate(data) as UpdatePetData
+export function createUpdatePetBody(data?: Partial<UpdatePetBody>): UpdatePetBody {
+  return createPetUpdate(data) as UpdatePetBody
 }
 
 export function createUpdatePetResponse(data?: Partial<UpdatePetResponse>): UpdatePetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/UpdatePet.ts
@@ -34,13 +34,13 @@ export type UpdatePetStatus200 = Pet;
 /**
  * @type object
 */
-export type UpdatePetData = PetUpdate;
+export type UpdatePetBody = PetUpdate;
 
 /**
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    body: UpdatePetData;
+    body: UpdatePetBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -47,37 +47,37 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
   faker.seed([42])
 
-  return createAddPetRequest(data) as AddPetJsonData
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
   faker.seed([42])
 
-  return createPet(data) as AddPetXmlData
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
   faker.seed([42])
 
-  return createPet(data) as AddPetFormUrlEncodedData
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
   faker.seed([42])
 
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -25,28 +25,28 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
   faker.seed([42])
 
-  return createOrder(data) as PlaceOrderJsonData
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
   faker.seed([42])
 
-  return createOrder(data) as PlaceOrderXmlData
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
   faker.seed([42])
 
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
   faker.seed([42])
 
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/faker/createUploadFile.ts
@@ -28,7 +28,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   faker.seed([42])
 
   return data ?? faker.image.url() as unknown as Blob

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/UpdatePet.ts
@@ -34,13 +34,13 @@ export type UpdatePetStatus200 = Pet;
 /**
  * @type object
 */
-export type UpdatePetData = PetUpdate;
+export type UpdatePetBody = PetUpdate;
 
 /**
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    body: UpdatePetData;
+    body: UpdatePetBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/server.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/mcp/server.ts
@@ -11,8 +11,8 @@ import { uploadFileHandler } from './uploadFile.ts'
 import { findPetsByStatusQueryStatusSchema, findPetsByStatusStatus200Schema } from '../zod/findPetsByStatusSchema.ts'
 import { getInventoryStatus200Schema } from '../zod/getInventorySchema.ts'
 import { getPetByIdPathPetIdSchema, getPetByIdStatus200Schema } from '../zod/getPetByIdSchema.ts'
-import { placeOrderDataSchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
-import { uploadFileDataSchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
+import { placeOrderBodySchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
+import { uploadFileBodySchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { z } from 'zod'
@@ -47,7 +47,7 @@ export function getServer() {
     title: "uploads an image",
     description: "Make a POST request to /pet/{petId}/uploadImage",
     outputSchema: { data: uploadFileStatus200Schema },
-    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileDataSchema },
+    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileBodySchema },
   }, async ({ path, query, body }, request) => {
     return uploadFileHandler({ path, query, body }, request)
   })
@@ -66,7 +66,7 @@ export function getServer() {
     title: "Place an order for a pet",
     description: "Place a new order in the store",
     outputSchema: { data: placeOrderStatus200Schema },
-    inputSchema: { body: placeOrderDataSchema },
+    inputSchema: { body: placeOrderBodySchema },
   }, async ({ body }, request) => {
     return placeOrderHandler({ body }, request)
   })

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/server.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/mcp/server.ts
@@ -10,13 +10,13 @@ import { getPetByIdHandler } from './pet/getPetById.ts'
 import { uploadFileHandler } from './pet/uploadFile.ts'
 import { getInventoryHandler } from './store/getInventory.ts'
 import { placeOrderHandler } from './store/placeOrder.ts'
-import { addPetDataSchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
+import { addPetBodySchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
 import { deletePetHeaderApiKeySchema, deletePetPathPetIdSchema } from '../zod/deletePetSchema.ts'
 import { findPetsByStatusQueryStatusSchema, findPetsByStatusStatus200Schema } from '../zod/findPetsByStatusSchema.ts'
 import { getInventoryStatus200Schema } from '../zod/getInventorySchema.ts'
 import { getPetByIdPathPetIdSchema, getPetByIdStatus200Schema } from '../zod/getPetByIdSchema.ts'
-import { placeOrderDataSchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
-import { uploadFileDataSchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
+import { placeOrderBodySchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
+import { uploadFileBodySchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { z } from 'zod'
@@ -31,7 +31,7 @@ export function getServer() {
     title: "Add a new pet to the store",
     description: "Add a new pet to the store",
     outputSchema: { data: addPetStatus200Schema },
-    inputSchema: { body: addPetDataSchema },
+    inputSchema: { body: addPetBodySchema },
   }, async ({ body }, request) => {
     return addPetHandler({ body }, request)
   })
@@ -70,7 +70,7 @@ export function getServer() {
     title: "uploads an image",
     description: "Make a POST request to /pet/{petId}/uploadImage",
     outputSchema: { data: uploadFileStatus200Schema },
-    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileDataSchema },
+    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileBodySchema },
   }, async ({ path, query, body }, request) => {
     return uploadFileHandler({ path, query, body }, request)
   })
@@ -89,7 +89,7 @@ export function getServer() {
     title: "Place an order for a pet",
     description: "Place a new order in the store",
     outputSchema: { data: placeOrderStatus200Schema },
-    inputSchema: { body: placeOrderDataSchema },
+    inputSchema: { body: placeOrderBodySchema },
   }, async ({ body }, request) => {
     return placeOrderHandler({ body }, request)
   })

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/server.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/mcp/server.ts
@@ -8,11 +8,11 @@ import { deletePetHandler } from './deletePet.ts'
 import { findPetsByStatusHandler } from './findPetsByStatus.ts'
 import { getPetByIdHandler } from './getPetById.ts'
 import { uploadFileHandler } from './uploadFile.ts'
-import { addPetDataSchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
+import { addPetBodySchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
 import { deletePetHeaderApiKeySchema, deletePetPathPetIdSchema } from '../zod/deletePetSchema.ts'
 import { findPetsByStatusQueryStatusSchema, findPetsByStatusStatus200Schema } from '../zod/findPetsByStatusSchema.ts'
 import { getPetByIdPathPetIdSchema, getPetByIdStatus200Schema } from '../zod/getPetByIdSchema.ts'
-import { uploadFileDataSchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
+import { uploadFileBodySchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { z } from 'zod'
@@ -27,7 +27,7 @@ export function getServer() {
     title: "Add a new pet to the store",
     description: "Add a new pet to the store",
     outputSchema: { data: addPetStatus200Schema },
-    inputSchema: { body: addPetDataSchema },
+    inputSchema: { body: addPetBodySchema },
   }, async ({ body }, request) => {
     return addPetHandler({ body }, request)
   })
@@ -66,7 +66,7 @@ export function getServer() {
     title: "uploads an image",
     description: "Make a POST request to /pet/{petId}/uploadImage",
     outputSchema: { data: uploadFileStatus200Schema },
-    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileDataSchema },
+    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileBodySchema },
   }, async ({ path, query, body }, request) => {
     return uploadFileHandler({ path, query, body }, request)
   })

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/mcp/server.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/mcp/server.ts
@@ -4,7 +4,7 @@
 */
 
 import { updatePetHandler } from './updatePet.ts'
-import { updatePetDataSchema, updatePetHeaderXRequestIDSchema, updatePetPathPetIdSchema, updatePetQueryIncludeDeletedSchema, updatePetQueryRequestSourceSchema, updatePetStatus200Schema } from '../zod/updatePetSchema.ts'
+import { updatePetBodySchema, updatePetHeaderXRequestIDSchema, updatePetPathPetIdSchema, updatePetQueryIncludeDeletedSchema, updatePetQueryRequestSourceSchema, updatePetStatus200Schema } from '../zod/updatePetSchema.ts'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { z } from 'zod'
@@ -18,7 +18,7 @@ export function getServer() {
   server.registerTool("updatePet", {
     description: "Make a POST request to /pets/{pet_id}",
     outputSchema: { data: updatePetStatus200Schema },
-    inputSchema: { path: z.object({ "petId": updatePetPathPetIdSchema }), query: z.object({ "includeDeleted": updatePetQueryIncludeDeletedSchema, "requestSource": updatePetQueryRequestSourceSchema }), headers: z.object({ "xRequestID": updatePetHeaderXRequestIDSchema }), body: updatePetDataSchema },
+    inputSchema: { path: z.object({ "petId": updatePetPathPetIdSchema }), query: z.object({ "includeDeleted": updatePetQueryIncludeDeletedSchema, "requestSource": updatePetQueryRequestSourceSchema }), headers: z.object({ "xRequestID": updatePetHeaderXRequestIDSchema }), body: updatePetBodySchema },
   }, async ({ path, query, headers, body }, request) => {
     return updatePetHandler({ path, query, headers, body }, request)
   })

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/UpdatePet.ts
@@ -34,13 +34,13 @@ export type UpdatePetStatus200 = Pet;
 /**
  * @type object
 */
-export type UpdatePetData = PetUpdate;
+export type UpdatePetBody = PetUpdate;
 
 /**
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    body: UpdatePetData;
+    body: UpdatePetBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/zod/updatePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/zod/updatePetSchema.ts
@@ -19,4 +19,4 @@ export const updatePetStatus200Schema = petSchema
 
 export const updatePetResponseSchema = updatePetStatus200Schema
 
-export const updatePetDataSchema = petUpdateSchema
+export const updatePetBodySchema = petUpdateSchema

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/server.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/mcp/server.ts
@@ -10,13 +10,13 @@ import { getInventoryHandler } from './getInventory.ts'
 import { getPetByIdHandler } from './getPetById.ts'
 import { placeOrderHandler } from './placeOrder.ts'
 import { uploadFileHandler } from './uploadFile.ts'
-import { addPetDataSchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
+import { addPetBodySchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
 import { deletePetHeaderApiKeySchema, deletePetPathPetIdSchema } from '../zod/deletePetSchema.ts'
 import { findPetsByStatusQueryStatusSchema, findPetsByStatusStatus200Schema } from '../zod/findPetsByStatusSchema.ts'
 import { getInventoryStatus200Schema } from '../zod/getInventorySchema.ts'
 import { getPetByIdPathPetIdSchema, getPetByIdStatus200Schema } from '../zod/getPetByIdSchema.ts'
-import { placeOrderDataSchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
-import { uploadFileDataSchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
+import { placeOrderBodySchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
+import { uploadFileBodySchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { z } from 'zod'
@@ -31,7 +31,7 @@ export function getServer() {
     title: "Add a new pet to the store",
     description: "Add a new pet to the store",
     outputSchema: { data: addPetStatus200Schema },
-    inputSchema: { body: addPetDataSchema },
+    inputSchema: { body: addPetBodySchema },
   }, async ({ body }, request) => {
     return addPetHandler({ body }, request)
   })
@@ -70,7 +70,7 @@ export function getServer() {
     title: "uploads an image",
     description: "Make a POST request to /pet/{petId}/uploadImage",
     outputSchema: { data: uploadFileStatus200Schema },
-    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileDataSchema },
+    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileBodySchema },
   }, async ({ path, query, body }, request) => {
     return uploadFileHandler({ path, query, body }, request)
   })
@@ -89,7 +89,7 @@ export function getServer() {
     title: "Place an order for a pet",
     description: "Place a new order in the store",
     outputSchema: { data: placeOrderStatus200Schema },
-    inputSchema: { body: placeOrderDataSchema },
+    inputSchema: { body: placeOrderBodySchema },
   }, async ({ body }, request) => {
     return placeOrderHandler({ body }, request)
   })

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/mcp/server.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/mcp/server.ts
@@ -10,13 +10,13 @@ import { getInventoryHandler } from './getInventory.ts'
 import { getPetByIdHandler } from './getPetById.ts'
 import { placeOrderHandler } from './placeOrder.ts'
 import { uploadFileHandler } from './uploadFile.ts'
-import { addPetDataSchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
+import { addPetBodySchema, addPetStatus200Schema } from '../zod/addPetSchema.ts'
 import { deletePetHeaderApiKeySchema, deletePetPathPetIdSchema } from '../zod/deletePetSchema.ts'
 import { findPetsByStatusQueryStatusSchema, findPetsByStatusStatus200Schema } from '../zod/findPetsByStatusSchema.ts'
 import { getInventoryStatus200Schema } from '../zod/getInventorySchema.ts'
 import { getPetByIdPathPetIdSchema, getPetByIdStatus200Schema } from '../zod/getPetByIdSchema.ts'
-import { placeOrderDataSchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
-import { uploadFileDataSchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
+import { placeOrderBodySchema, placeOrderStatus200Schema } from '../zod/placeOrderSchema.ts'
+import { uploadFileBodySchema, uploadFilePathPetIdSchema, uploadFileQueryAdditionalMetadataSchema, uploadFileStatus200Schema } from '../zod/uploadFileSchema.ts'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio'
 import { z } from 'zod'
@@ -31,7 +31,7 @@ export function getServer() {
     title: "Add a new pet to the store",
     description: "Add a new pet to the store",
     outputSchema: { data: addPetStatus200Schema },
-    inputSchema: { body: addPetDataSchema },
+    inputSchema: { body: addPetBodySchema },
   }, async ({ body }, request) => {
     return addPetHandler({ body }, request)
   })
@@ -70,7 +70,7 @@ export function getServer() {
     title: "uploads an image",
     description: "Make a POST request to /pet/{petId}/uploadImage",
     outputSchema: { data: uploadFileStatus200Schema },
-    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileDataSchema },
+    inputSchema: { path: z.object({ "petId": uploadFilePathPetIdSchema }), query: z.object({ "additionalMetadata": uploadFileQueryAdditionalMetadataSchema }), body: uploadFileBodySchema },
   }, async ({ path, query, body }, request) => {
     return uploadFileHandler({ path, query, body }, request)
   })
@@ -89,7 +89,7 @@ export function getServer() {
     title: "Place an order for a pet",
     description: "Place a new order in the store",
     outputSchema: { data: placeOrderStatus200Schema },
-    inputSchema: { body: placeOrderDataSchema },
+    inputSchema: { body: placeOrderBodySchema },
   }, async ({ body }, request) => {
     return placeOrderHandler({ body }, request)
   })

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/addPetHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405, AddPetData } from '../types/AddPet.ts'
+import type { AddPetResponse, AddPetStatus405, AddPetBody } from '../types/AddPet.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
-  return http.post<Record<string, string>, AddPetData>(`http://localhost:3000/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetBody>) {
+  return http.post<Record<string, string>, AddPetBody>(`http://localhost:3000/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/placeOrderHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderBody } from '../types/PlaceOrder.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
-  return http.post<Record<string, string>, PlaceOrderData>(`http://localhost:3000/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderBody>) {
+  return http.post<Record<string, string>, PlaceOrderBody>(`http://localhost:3000/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/msw/uploadFileHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse, UploadFileData } from '../types/UploadFile.ts'
+import type { UploadFileResponse, UploadFileBody } from '../types/UploadFile.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
-  return http.post<Record<string, string>, UploadFileData>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileBody>) {
+  return http.post<Record<string, string>, UploadFileBody>(`http://localhost:3000/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/placeOrderHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderBody } from '../types/PlaceOrder.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
-  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderBody>) {
+  return http.post<Record<string, string>, PlaceOrderBody>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/msw/uploadFileHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse, UploadFileData } from '../types/UploadFile.ts'
+import type { UploadFileResponse, UploadFileBody } from '../types/UploadFile.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
-  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileBody>) {
+  return http.post<Record<string, string>, UploadFileBody>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/addPetHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405, AddPetData } from '../../types/AddPet.ts'
+import type { AddPetResponse, AddPetStatus405, AddPetBody } from '../../types/AddPet.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
-  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetBody>) {
+  return http.post<Record<string, string>, AddPetBody>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/pet/uploadFileHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse, UploadFileData } from '../../types/UploadFile.ts'
+import type { UploadFileResponse, UploadFileBody } from '../../types/UploadFile.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
-  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileBody>) {
+  return http.post<Record<string, string>, UploadFileBody>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/store/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/msw/store/placeOrderHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from '../../types/PlaceOrder.ts'
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderBody } from '../../types/PlaceOrder.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
-  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderBody>) {
+  return http.post<Record<string, string>, PlaceOrderBody>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/addPetHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405, AddPetData } from '../types/AddPet.ts'
+import type { AddPetResponse, AddPetStatus405, AddPetBody } from '../types/AddPet.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
-  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetBody>) {
+  return http.post<Record<string, string>, AddPetBody>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/placeOrderHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderBody } from '../types/PlaceOrder.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
-  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderBody>) {
+  return http.post<Record<string, string>, PlaceOrderBody>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/msw/uploadFileHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse, UploadFileData } from '../types/UploadFile.ts'
+import type { UploadFileResponse, UploadFileBody } from '../types/UploadFile.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
-  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileBody>) {
+  return http.post<Record<string, string>, UploadFileBody>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/addPetHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405, AddPetData } from '../types/AddPet.ts'
+import type { AddPetResponse, AddPetStatus405, AddPetBody } from '../types/AddPet.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
-  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetBody>) {
+  return http.post<Record<string, string>, AddPetBody>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/msw/uploadFileHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse, UploadFileData } from '../types/UploadFile.ts'
+import type { UploadFileResponse, UploadFileBody } from '../types/UploadFile.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
-  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileBody>) {
+  return http.post<Record<string, string>, UploadFileBody>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createAddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createAddPet.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetData, AddPetFormUrlEncodedData, AddPetJsonData, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405, AddPetXmlData } from '../types/AddPet.ts'
+import type { AddPetBody, AddPetBodyFormUrlEncoded, AddPetBodyJson, AddPetBodyXml, AddPetResponse, AddPetStatus200, AddPetStatus200Json, AddPetStatus200Xml, AddPetStatus405 } from '../types/AddPet.ts'
 import { createAddPetRequest } from './createAddPetRequest.ts'
 import { createPet } from './createPet.ts'
 import { fakerEN as faker } from '@faker-js/faker'
@@ -39,29 +39,29 @@ export function createAddPetStatus405() {
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetJsonData(data?: Partial<AddPetJsonData>): AddPetJsonData {
-  return createAddPetRequest(data) as AddPetJsonData
+export function createAddPetBodyJson(data?: Partial<AddPetBodyJson>): AddPetBodyJson {
+  return createAddPetRequest(data) as AddPetBodyJson
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetXmlData(data?: Partial<AddPetXmlData>): AddPetXmlData {
-  return createPet(data) as AddPetXmlData
+export function createAddPetBodyXml(data?: Partial<AddPetBodyXml>): AddPetBodyXml {
+  return createPet(data) as AddPetBodyXml
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetFormUrlEncodedData(data?: Partial<AddPetFormUrlEncodedData>): AddPetFormUrlEncodedData {
-  return createPet(data) as AddPetFormUrlEncodedData
+export function createAddPetBodyFormUrlEncoded(data?: Partial<AddPetBodyFormUrlEncoded>): AddPetBodyFormUrlEncoded {
+  return createPet(data) as AddPetBodyFormUrlEncoded
 }
 
 /**
  * @description Create a new pet in the store
  */
-export function createAddPetData(_data?: AddPetData): AddPetData {
-  return faker.helpers.arrayElement([createAddPetJsonData(), createAddPetXmlData(), createAddPetFormUrlEncodedData()])
+export function createAddPetBody(_data?: AddPetBody): AddPetBody {
+  return faker.helpers.arrayElement([createAddPetBodyJson(), createAddPetBodyXml(), createAddPetBodyFormUrlEncoded()])
 }
 
 export function createAddPetResponse(_data?: AddPetResponse): AddPetResponse {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createPlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createPlaceOrder.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderData, PlaceOrderFormUrlEncodedData, PlaceOrderJsonData, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405, PlaceOrderXmlData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderBody, PlaceOrderBodyFormUrlEncoded, PlaceOrderBodyJson, PlaceOrderBodyXml, PlaceOrderResponse, PlaceOrderStatus200, PlaceOrderStatus405 } from '../types/PlaceOrder.ts'
 import { createOrder } from './createOrder.ts'
 import { fakerEN as faker } from '@faker-js/faker'
 
@@ -21,20 +21,20 @@ export function createPlaceOrderStatus405() {
   return undefined
 }
 
-export function createPlaceOrderJsonData(data?: Partial<PlaceOrderJsonData>): PlaceOrderJsonData {
-  return createOrder(data) as PlaceOrderJsonData
+export function createPlaceOrderBodyJson(data?: Partial<PlaceOrderBodyJson>): PlaceOrderBodyJson {
+  return createOrder(data) as PlaceOrderBodyJson
 }
 
-export function createPlaceOrderXmlData(data?: Partial<PlaceOrderXmlData>): PlaceOrderXmlData {
-  return createOrder(data) as PlaceOrderXmlData
+export function createPlaceOrderBodyXml(data?: Partial<PlaceOrderBodyXml>): PlaceOrderBodyXml {
+  return createOrder(data) as PlaceOrderBodyXml
 }
 
-export function createPlaceOrderFormUrlEncodedData(data?: Partial<PlaceOrderFormUrlEncodedData>): PlaceOrderFormUrlEncodedData {
-  return createOrder(data) as PlaceOrderFormUrlEncodedData
+export function createPlaceOrderBodyFormUrlEncoded(data?: Partial<PlaceOrderBodyFormUrlEncoded>): PlaceOrderBodyFormUrlEncoded {
+  return createOrder(data) as PlaceOrderBodyFormUrlEncoded
 }
 
-export function createPlaceOrderData(_data?: PlaceOrderData): PlaceOrderData {
-  return faker.helpers.arrayElement([createPlaceOrderJsonData(), createPlaceOrderXmlData(), createPlaceOrderFormUrlEncodedData()])
+export function createPlaceOrderBody(_data?: PlaceOrderBody): PlaceOrderBody {
+  return faker.helpers.arrayElement([createPlaceOrderBodyJson(), createPlaceOrderBodyXml(), createPlaceOrderBodyFormUrlEncoded()])
 }
 
 export function createPlaceOrderResponse(_data?: PlaceOrderResponse): PlaceOrderResponse {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/faker/createUploadFile.ts
@@ -22,7 +22,7 @@ export function createUploadFileStatus200(data?: Partial<UploadFileStatus200>): 
   return createApiResponse(data) as UploadFileStatus200
 }
 
-export function createUploadFileData(data?: Blob): Blob {
+export function createUploadFileBody(data?: Blob): Blob {
   return data ?? faker.image.url() as unknown as Blob
 }
 

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/addPetHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405, AddPetData } from '../types/AddPet.ts'
+import type { AddPetResponse, AddPetStatus405, AddPetBody } from '../types/AddPet.ts'
 import type { HttpResponseResolver } from 'msw'
 import { createAddPetResponse } from '../faker/createAddPet.ts'
 import { http } from 'msw'
@@ -24,8 +24,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
-  return http.post<Record<string, string>, AddPetData>('/pet', function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetBody>) {
+  return http.post<Record<string, string>, AddPetBody>('/pet', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || createAddPetResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/placeOrderHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderBody } from '../types/PlaceOrder.ts'
 import type { HttpResponseResolver } from 'msw'
 import { createPlaceOrderResponse } from '../faker/createPlaceOrder.ts'
 import { http } from 'msw'
@@ -24,8 +24,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
-  return http.post<Record<string, string>, PlaceOrderData>('/store/order', function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderBody>) {
+  return http.post<Record<string, string>, PlaceOrderBody>('/store/order', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || createPlaceOrderResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/msw/uploadFileHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse, UploadFileData } from '../types/UploadFile.ts'
+import type { UploadFileResponse, UploadFileBody } from '../types/UploadFile.ts'
 import type { HttpResponseResolver } from 'msw'
 import { createUploadFileResponse } from '../faker/createUploadFile.ts'
 import { http } from 'msw'
@@ -17,8 +17,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
-  return http.post<Record<string, string>, UploadFileData>('/pet/:petId/uploadImage', function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileBody>) {
+  return http.post<Record<string, string>, UploadFileBody>('/pet/:petId/uploadImage', function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data || createUploadFileResponse(data)), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/addPetHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/addPetHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { AddPetResponse, AddPetStatus405, AddPetData } from '../types/AddPet.ts'
+import type { AddPetResponse, AddPetStatus405, AddPetBody } from '../types/AddPet.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function addPetHandlerResponse405(data?: AddPetStatus405) {
   })
 }
 
-export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetData>) {
-  return http.post<Record<string, string>, AddPetData>(`/pet`, function handler(info) {
+export function addPetHandler(data?: AddPetResponse | HttpResponseResolver<Record<string, string>, AddPetBody>) {
+  return http.post<Record<string, string>, AddPetBody>(`/pet`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/placeOrderHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/placeOrderHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderData } from '../types/PlaceOrder.ts'
+import type { PlaceOrderResponse, PlaceOrderStatus405, PlaceOrderBody } from '../types/PlaceOrder.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -23,8 +23,8 @@ export function placeOrderHandlerResponse405(data?: PlaceOrderStatus405) {
   })
 }
 
-export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderData>) {
-  return http.post<Record<string, string>, PlaceOrderData>(`/store/order`, function handler(info) {
+export function placeOrderHandler(data?: PlaceOrderResponse | HttpResponseResolver<Record<string, string>, PlaceOrderBody>) {
+  return http.post<Record<string, string>, PlaceOrderBody>(`/store/order`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/uploadFileHandler.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/msw/uploadFileHandler.ts
@@ -3,7 +3,7 @@
 * Do not edit manually.
 */
 
-import type { UploadFileResponse, UploadFileData } from '../types/UploadFile.ts'
+import type { UploadFileResponse, UploadFileBody } from '../types/UploadFile.ts'
 import type { HttpResponseResolver } from 'msw'
 import { http } from 'msw'
 
@@ -16,8 +16,8 @@ export function uploadFileHandlerResponse200(data: UploadFileResponse) {
   })
 }
 
-export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileData>) {
-  return http.post<Record<string, string>, UploadFileData>(`/pet/:petId/uploadImage`, function handler(info) {
+export function uploadFileHandler(data?: UploadFileResponse | HttpResponseResolver<Record<string, string>, UploadFileBody>) {
+  return http.post<Record<string, string>, UploadFileBody>(`/pet/:petId/uploadImage`, function handler(info) {
       if(typeof data === 'function') return data(info)
 
       return new Response(JSON.stringify(data), {

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/UpdatePet.ts
@@ -34,13 +34,13 @@ export type UpdatePetStatus200 = Pet;
 /**
  * @type object
 */
-export type UpdatePetData = PetUpdate;
+export type UpdatePetBody = PetUpdate;
 
 /**
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    body: UpdatePetData;
+    body: UpdatePetBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/UpdatePet.ts
@@ -34,13 +34,13 @@ export type UpdatePetStatus200 = Pet;
 /**
  * @type object
 */
-export type UpdatePetData = PetUpdate;
+export type UpdatePetBody = PetUpdate;
 
 /**
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    body: UpdatePetData;
+    body: UpdatePetBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/CreateConfigV20250.ts
@@ -14,13 +14,13 @@ export type CreateConfigV20250Status201 = Config;
 /**
  * @type object
 */
-export type CreateConfigV20250Data = ConfigCreate;
+export type CreateConfigV20250Body = ConfigCreate;
 
 /**
  * @type object
 */
 export type CreateConfigV20250RequestConfig = {
-    body: CreateConfigV20250Data;
+    body: CreateConfigV20250Body;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/UpdatePet.ts
@@ -34,13 +34,13 @@ export type UpdatePetStatus200 = Pet;
 /**
  * @type object
 */
-export type UpdatePetData = PetUpdate;
+export type UpdatePetBody = PetUpdate;
 
 /**
  * @type object
 */
 export type UpdatePetRequestConfig = {
-    body: UpdatePetData;
+    body: UpdatePetBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPet.ts
@@ -27,27 +27,27 @@ export type AddPetStatus405 = any;
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetJsonData = AddPetRequest;
+export type AddPetBodyJson = AddPetRequest;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetXmlData = Pet;
+export type AddPetBodyXml = Pet;
 
 /**
  * @description Create a new pet in the store
  * @type object
 */
-export type AddPetFormUrlEncodedData = Pet;
+export type AddPetBodyFormUrlEncoded = Pet;
 
-export type AddPetData = (AddPetJsonData | AddPetXmlData | AddPetFormUrlEncodedData);
+export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type AddPetRequestConfig = {
-    body: AddPetData;
+    body: AddPetBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/PlaceOrder.ts
@@ -18,25 +18,25 @@ export type PlaceOrderStatus405 = any;
 /**
  * @type object | undefined
 */
-export type PlaceOrderJsonData = Order | undefined;
+export type PlaceOrderBodyJson = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderXmlData = Order | undefined;
+export type PlaceOrderBodyXml = Order | undefined;
 
 /**
  * @type object | undefined
 */
-export type PlaceOrderFormUrlEncodedData = Order | undefined;
+export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
-export type PlaceOrderData = (PlaceOrderJsonData | PlaceOrderXmlData | PlaceOrderFormUrlEncodedData);
+export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
 /**
  * @type object
 */
 export type PlaceOrderRequestConfig = {
-    body: PlaceOrderData;
+    body: PlaceOrderBody;
     path?: never;
     query?: never;
     headers?: never;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
@@ -27,13 +27,13 @@ export type UploadFileStatus200 = ApiResponse;
 /**
  * @type string | undefined
 */
-export type UploadFileData = Blob | undefined;
+export type UploadFileBody = Blob | undefined;
 
 /**
  * @type object
 */
 export type UploadFileRequestConfig = {
-    body: UploadFileData;
+    body: UploadFileBody;
     /**
      * @type object
     */

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/coercion/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderInputSchema.optional()
+export const placeOrderBodySchemaJson = orderInputSchema.optional()
 
-export const placeOrderDataSchemaXml = orderInputSchema.optional()
+export const placeOrderBodySchemaXml = orderInputSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderInputSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderInputSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/dateTypeDate/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/excludeByOperationId/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/pet/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/store/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/groupByTag/zod/store/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/includeByTag/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/addPetSchema.ts
@@ -31,18 +31,18 @@ export const addPetErrorSchema = addPetStatus405Schema
 
 export type AddPetErrorSchemaType = z.infer<typeof addPetErrorSchema>
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export type AddPetDataSchemaJsonType = z.infer<typeof addPetDataSchemaJson>
+export type AddPetBodySchemaJsonType = z.infer<typeof addPetBodySchemaJson>
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export type AddPetDataSchemaXmlType = z.infer<typeof addPetDataSchemaXml>
+export type AddPetBodySchemaXmlType = z.infer<typeof addPetBodySchemaXml>
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export type AddPetDataSchemaFormUrlEncodedType = z.infer<typeof addPetDataSchemaFormUrlEncoded>
+export type AddPetBodySchemaFormUrlEncodedType = z.infer<typeof addPetBodySchemaFormUrlEncoded>
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])
 
-export type AddPetDataSchemaType = z.infer<typeof addPetDataSchema>
+export type AddPetBodySchemaType = z.infer<typeof addPetBodySchema>

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/placeOrderSchema.ts
@@ -22,18 +22,18 @@ export const placeOrderErrorSchema = placeOrderStatus405Schema
 
 export type PlaceOrderErrorSchemaType = z.infer<typeof placeOrderErrorSchema>
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export type PlaceOrderDataSchemaJsonType = z.infer<typeof placeOrderDataSchemaJson>
+export type PlaceOrderBodySchemaJsonType = z.infer<typeof placeOrderBodySchemaJson>
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export type PlaceOrderDataSchemaXmlType = z.infer<typeof placeOrderDataSchemaXml>
+export type PlaceOrderBodySchemaXmlType = z.infer<typeof placeOrderBodySchemaXml>
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export type PlaceOrderDataSchemaFormUrlEncodedType = z.infer<typeof placeOrderDataSchemaFormUrlEncoded>
+export type PlaceOrderBodySchemaFormUrlEncodedType = z.infer<typeof placeOrderBodySchemaFormUrlEncoded>
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])
 
-export type PlaceOrderDataSchemaType = z.infer<typeof placeOrderDataSchema>
+export type PlaceOrderBodySchemaType = z.infer<typeof placeOrderBodySchema>

--- a/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/inferred/zod/uploadFileSchema.ts
@@ -22,6 +22,6 @@ export const uploadFileResponseSchema = uploadFileStatus200Schema
 
 export type UploadFileResponseSchemaType = z.infer<typeof uploadFileResponseSchema>
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()
 
-export type UploadFileDataSchemaType = z.infer<typeof uploadFileDataSchema>
+export type UploadFileBodySchemaType = z.infer<typeof uploadFileBodySchema>

--- a/tests/3.0.x/__snapshots__/pluginZod/paramsCasing/zod/updatePetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/paramsCasing/zod/updatePetSchema.ts
@@ -19,4 +19,4 @@ export const updatePetStatus200Schema = petSchema
 
 export const updatePetResponseSchema = updatePetStatus200Schema
 
-export const updatePetDataSchema = petUpdateSchema
+export const updatePetBodySchema = petUpdateSchema

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/addPetSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/addPetSchema.ts
@@ -19,10 +19,10 @@ export const addPetResponseSchema = addPetStatus200Schema
 
 export const addPetErrorSchema = addPetStatus405Schema
 
-export const addPetDataSchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaJson = addPetRequestSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaXml = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaXml = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
+export const addPetBodySchemaFormUrlEncoded = petSchema.describe('Create a new pet in the store')
 
-export const addPetDataSchema = z.union([addPetDataSchemaJson, addPetDataSchemaXml, addPetDataSchemaFormUrlEncoded])
+export const addPetBodySchema = z.union([addPetBodySchemaJson, addPetBodySchemaXml, addPetBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/placeOrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/placeOrderSchema.ts
@@ -14,10 +14,10 @@ export const placeOrderResponseSchema = placeOrderStatus200Schema
 
 export const placeOrderErrorSchema = placeOrderStatus405Schema
 
-export const placeOrderDataSchemaJson = orderSchema.optional()
+export const placeOrderBodySchemaJson = orderSchema.optional()
 
-export const placeOrderDataSchemaXml = orderSchema.optional()
+export const placeOrderBodySchemaXml = orderSchema.optional()
 
-export const placeOrderDataSchemaFormUrlEncoded = orderSchema.optional()
+export const placeOrderBodySchemaFormUrlEncoded = orderSchema.optional()
 
-export const placeOrderDataSchema = z.union([placeOrderDataSchemaJson, placeOrderDataSchemaXml, placeOrderDataSchemaFormUrlEncoded])
+export const placeOrderBodySchema = z.union([placeOrderBodySchemaJson, placeOrderBodySchemaXml, placeOrderBodySchemaFormUrlEncoded])

--- a/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/uploadFileSchema.ts
+++ b/tests/3.0.x/__snapshots__/pluginZod/petStore/zod/uploadFileSchema.ts
@@ -14,4 +14,4 @@ export const uploadFileStatus200Schema = apiResponseSchema
 
 export const uploadFileResponseSchema = uploadFileStatus200Schema
 
-export const uploadFileDataSchema = z.instanceof(File).optional()
+export const uploadFileBodySchema = z.instanceof(File).optional()


### PR DESCRIPTION
## 🎯 Changes

Simplifies the resolver naming API across all plugins.

**Remove the redundant `resolvePathName`.** On every plugin resolver it was an exact duplicate of the built-in `default(name, type)` (most literally `return this.default(name, type)`), with a single real caller. It is dropped, and that caller (`plugin-msw`) now calls `default` directly. A straight rename to `resolvePath` was not possible — `resolvePath(params, context)` is already a reserved built-in on the core `Resolver` type (the file-path resolver).

**Align the request-part resolvers to the generated object vocabulary.** Generated code already emits `body` / `path` / `query` / `headers` keys on `RequestConfig`, but the resolver methods used a different vocabulary. They now match:

| Before | After |
| --- | --- |
| `resolveDataName` | `resolveBodyName` |
| `resolvePathParamsName` | `resolvePathName` |
| `resolveQueryParamsName` | `resolveQueryName` |
| `resolveHeaderParamsName` | `resolveHeadersName` |

**Change the request body type suffix `Data` → `Body`** in generated output: `CreatePetData` → `CreatePetBody`, and the Zod schema `createPetDataSchema` → `createPetBodySchema`. This is a breaking change to generated code, made now during the v5 beta.

Note that the `resolvePathName` identifier is reused: the old file-name method of that name is gone, and it now names the grouped path-parameters resolver `resolvePathName(node, param)`.

Snapshots and the affected unit tests are updated. A changeset bumps all 11 published plugins as `minor`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169LQqGKevmGh9MGBouwRXE)_