### PR TITLE
fix: sync oxlint test-file override with kubb and platform

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -46,11 +46,13 @@ export default defineConfig({
       },
     },
     {
-      // Test fixtures build partial mock objects (`{ ... } as GeneratorContext`) that a
-      // type annotation or `satisfies` cannot express, so the assertion is intentional there.
+      // Test fixtures build partial or intentionally-invalid mock objects (`{ ... } as GeneratorContext`,
+      // `undefined as any`) that a type annotation or `satisfies` cannot express, so assertions and
+      // `any` are intentional there. The source rules stay strict.
       files: ['**/*.test.ts', '**/*.test.tsx'],
       rules: {
         'typescript/consistent-type-assertions': 'off',
+        'typescript/no-explicit-any': 'off',
       },
     },
   ],


### PR DESCRIPTION
## 🎯 Changes

Syncs `oxlint.config.ts` with kubb-labs/kubb and kubb-labs/platform, whose oxfmt options already matched but whose oxlint test-file override had drifted.

The `**/*.test.ts` / `**/*.test.tsx` override here only turned off `typescript/consistent-type-assertions`. In kubb and platform it also turns off `typescript/no-explicit-any`, since test fixtures build partial or intentionally-invalid mock objects that need both. This brings the override, and its comment, in line across the three repos. No lint failures result from this change; `pnpm lint` stays green.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NrE2g78FcfWhPUb9CE14bs)_