### PR TITLE
chore: align every plugin at 5.0.0-beta.94

### DIFF
--- a/packages/plugin-faker/package.json
+++ b/packages/plugin-faker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-faker",
-  "version": "5.0.0-beta.87",
+  "version": "5.0.0-beta.94",
   "description": "Generate Faker.js mock data factories with Kubb. Produces realistic seed data and fixtures for development and testing.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-msw/package.json
+++ b/packages/plugin-msw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-msw",
-  "version": "5.0.0-beta.87",
+  "version": "5.0.0-beta.94",
   "description": "Generate Mock Service Worker (MSW) request handlers with Kubb. Intercept HTTP requests in the browser or Node.js for frontend development and testing.",
   "keywords": [
     "api-mocking",

--- a/packages/plugin-redoc/package.json
+++ b/packages/plugin-redoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-redoc",
-  "version": "5.0.0-beta.86",
+  "version": "5.0.0-beta.94",
   "description": "Generate a ReDoc API reference page with Kubb. Produces a standalone HTML file you can host without a build step.",
   "keywords": [
     "api-docs",

--- a/packages/plugin-ts/package.json
+++ b/packages/plugin-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-ts",
-  "version": "5.0.0-beta.87",
+  "version": "5.0.0-beta.94",
   "description": "Generate TypeScript types, interfaces, and enums with Kubb. The base plugin other Kubb plugins build on for type safety.",
   "keywords": [
     "code-generation",

--- a/packages/plugin-zod/package.json
+++ b/packages/plugin-zod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-zod",
-  "version": "5.0.0-beta.87",
+  "version": "5.0.0-beta.94",
   "description": "Generate Zod validation schemas with Kubb for runtime data parsing and type safety. Pairs with @kubb/plugin-ts for end-to-end type coverage.",
   "keywords": [
     "code-generation",


### PR DESCRIPTION
## 🎯 Changes

`plugin-ts`, `plugin-zod`, `plugin-msw`, `plugin-faker`, and `plugin-redoc` missed the beta.94 release train, leaving the published plugins split across beta.86, beta.87, and beta.94. This bumps their `version` fields to `5.0.0-beta.94` so the next publish run puts every plugin on the same version — `changeset publish` releases any local version missing from npm and tags it `beta` via pre-mode.

Once published, consumers (kubb.dev platform, `kubb init`) can pin a single `5.0.0-beta.94` across all plugins.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md). (Version bump only — no changeset needed; the versions themselves are the release.)
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWG738SfNK2KNk5E9JdNbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWG738SfNK2KNk5E9JdNbS)_