### PR TITLE
refactor(resolvers): share naming templates via internal resolver bases

### DIFF
--- a/.changeset/export-default-resolvers.md
+++ b/.changeset/export-default-resolvers.md
@@ -1,0 +1,8 @@
+---
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-msw": patch
+---
+
+Export the default resolver (`resolverReactQuery`, `resolverVueQuery`, `resolverSwr`, `resolverMsw`) and its type from the package index, matching plugin-ts, plugin-zod, plugin-faker, plugin-mcp, and plugin-cypress. Import it to reference the exact names a plugin generates or to build a custom resolver on top of the defaults.

--- a/.changeset/shared-resolver-bases.md
+++ b/.changeset/shared-resolver-bases.md
@@ -1,0 +1,10 @@
+---
+"@kubb/plugin-ts": patch
+"@kubb/plugin-zod": patch
+"@kubb/plugin-faker": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-vue-query": patch
+---
+
+Share the resolver naming templates through internal helpers instead of repeating them per plugin. The `param`, `response`, and `file.baseName` templates used by plugin-ts, plugin-zod, and plugin-faker now come from one implementation, and the query/mutation naming used by plugin-react-query, plugin-swr, and plugin-vue-query comes from a shared TanStack Query base. Generated output is unchanged.

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -41,5 +41,13 @@ export {
   type ResolveOperationTypeNameOptions,
 } from './operation.ts'
 export { getOasAdapter } from './adapter.ts'
+export {
+  createCasedFile,
+  createOperationParamResolver,
+  createOperationResponseResolver,
+  operationParamName,
+  type OperationParamResolver,
+  type OperationResponseResolver,
+} from './resolver.ts'
 export { createGroupConfig } from './group.ts'
 export { buildParamsMapping, buildParamsRemapExpression, buildTransformedParamsMapping, caseParams } from './params.ts'

--- a/internals/shared/src/resolver.test.ts
+++ b/internals/shared/src/resolver.test.ts
@@ -1,0 +1,47 @@
+import { camelCase, pascalCase } from '@internals/utils'
+import type { Resolver } from 'kubb/kit'
+import { ast } from 'kubb/kit'
+import { describe, expect, test } from 'vitest'
+import { createCasedFile, createOperationParamResolver, createOperationResponseResolver, operationParamName } from './resolver.ts'
+
+const resolver = { name: (name: string) => pascalCase(name) } as unknown as Resolver
+const node = ast.factory.createOperation({ operationId: 'listPets', method: 'GET', path: '/pets' })
+
+describe('createOperationParamResolver', () => {
+  const param = createOperationParamResolver()
+
+  test('name uses the <operationId> <in> <name> template', () => {
+    const parameter = ast.factory.createParameter({ name: 'pet-id', in: 'path', schema: ast.factory.createSchema({ type: 'string' }) })
+    expect(param.name.call(resolver, node, parameter)).toBe('ListPetsPathPetId')
+    expect(operationParamName.call(resolver, node, parameter)).toBe('ListPetsPathPetId')
+  })
+
+  test('path/query/headers use the grouped templates', () => {
+    expect(param.path.call(resolver, node)).toBe('ListPetsPath')
+    expect(param.query.call(resolver, node)).toBe('ListPetsQuery')
+    expect(param.headers.call(resolver, node)).toBe('ListPetsHeaders')
+  })
+})
+
+describe('createOperationResponseResolver', () => {
+  const response = createOperationResponseResolver()
+
+  test('status/body/responses/response use the grouped templates', () => {
+    expect(response.status.call(resolver, node, '200')).toBe('ListPetsStatus200')
+    expect(response.body.call(resolver, node)).toBe('ListPetsBody')
+    expect(response.responses.call(resolver, node)).toBe('ListPetsResponses')
+    expect(response.response.call(resolver, node)).toBe('ListPetsResponse')
+  })
+})
+
+describe('createCasedFile', () => {
+  test('baseName cases the final segment and appends the extension', () => {
+    const file = createCasedFile(pascalCase)
+    expect(file.baseName?.({ name: 'pet.petId', extname: '.ts' })).toBe('pet/PetId.ts')
+  })
+
+  test('baseName supports prefixed and suffixed casing', () => {
+    const file = createCasedFile((part) => camelCase(part, { suffix: 'schema' }))
+    expect(file.baseName?.({ name: 'tag.tag', extname: '.ts' })).toBe('tag/tagSchema.ts')
+  })
+})

--- a/internals/shared/src/resolver.ts
+++ b/internals/shared/src/resolver.ts
@@ -1,0 +1,105 @@
+import { toFilePath } from '@internals/utils'
+import type { ast, Resolver, ResolverFile } from 'kubb/kit'
+
+/**
+ * The `param` namespace shared by the schema-producing plugins (ts, zod, faker):
+ * per-parameter names plus the grouped `Path`/`Query`/`Headers` names, all routed
+ * through the plugin's top-level `name` casing.
+ */
+export type OperationParamResolver = {
+  name(this: Resolver, node: ast.OperationNode, param: ast.ParameterNode): string
+  path(this: Resolver, node: ast.OperationNode): string
+  query(this: Resolver, node: ast.OperationNode): string
+  headers(this: Resolver, node: ast.OperationNode): string
+}
+
+/**
+ * The `response` namespace shared by the schema-producing plugins: per-status,
+ * body, and combined response names, all routed through the plugin's top-level
+ * `name` casing.
+ */
+export type OperationResponseResolver = {
+  status(this: Resolver, node: ast.OperationNode, statusCode: ast.StatusCode): string
+  body(this: Resolver, node: ast.OperationNode): string
+  responses(this: Resolver, node: ast.OperationNode): string
+  response(this: Resolver, node: ast.OperationNode): string
+}
+
+/**
+ * Resolves a single operation parameter name with the
+ * `<operationId> <in> <name>` template.
+ *
+ * @example
+ * `operationParamName.call(resolver, node, param) // → 'DeletePetPathPetId'`
+ */
+export function operationParamName(this: Resolver, node: ast.OperationNode, param: ast.ParameterNode): string {
+  return this.name(`${node.operationId} ${param.in} ${param.name}`)
+}
+
+/**
+ * Builds the shared `param` namespace. Spread the result into `createResolver`
+ * and override individual methods next to it when a plugin deviates.
+ *
+ * @example
+ * ```ts
+ * createResolver<PluginTs>({ param: createOperationParamResolver(), ... })
+ * ```
+ */
+export function createOperationParamResolver(): OperationParamResolver {
+  return {
+    name: operationParamName,
+    path(node) {
+      return this.name(`${node.operationId} Path`)
+    },
+    query(node) {
+      return this.name(`${node.operationId} Query`)
+    },
+    headers(node) {
+      return this.name(`${node.operationId} Headers`)
+    },
+  }
+}
+
+/**
+ * Builds the shared `response` namespace. Spread the result into
+ * `createResolver` and add plugin-specific methods (`options`, `error`) next
+ * to it.
+ *
+ * @example
+ * ```ts
+ * createResolver<PluginTs>({ response: { ...createOperationResponseResolver(), options(node) {...} }, ... })
+ * ```
+ */
+export function createOperationResponseResolver(): OperationResponseResolver {
+  return {
+    status(node, statusCode) {
+      return this.name(`${node.operationId} Status ${statusCode}`)
+    },
+    body(node) {
+      return this.name(`${node.operationId} Body`)
+    },
+    responses(node) {
+      return this.name(`${node.operationId} Responses`)
+    },
+    response(node) {
+      return this.name(`${node.operationId} Response`)
+    },
+  }
+}
+
+/**
+ * Builds a resolver `file` override whose base name runs every path segment
+ * through `toFilePath`, casing the final segment with `caseLast`.
+ *
+ * @example
+ * ```ts
+ * createResolver<PluginTs>({ file: createCasedFile(pascalCase), ... })
+ * ```
+ */
+export function createCasedFile(caseLast: (part: string) => string): ResolverFile {
+  return {
+    baseName({ name, extname }) {
+      return `${toFilePath(name, caseLast)}${extname}`
+    },
+  }
+}

--- a/internals/tanstack-query/src/index.ts
+++ b/internals/tanstack-query/src/index.ts
@@ -1,4 +1,5 @@
 export { MutationKey, mutationKeyTransformer } from './components/MutationKey.tsx'
+export { createMutationResolver, createQueryResolver, type MutationResolver, type QueryResolver, type QueryVariant } from './resolver.ts'
 export { QueryKey, queryKeyTransformer } from './components/QueryKey.tsx'
 export type { ParamsCasing, ParamsType, PathParamsType, Transformer } from './types.ts'
 export {

--- a/internals/tanstack-query/src/resolver.ts
+++ b/internals/tanstack-query/src/resolver.ts
@@ -1,0 +1,84 @@
+import { capitalize } from '@internals/utils'
+import type { ast, Resolver } from 'kubb/kit'
+
+/**
+ * The naming variant of a query namespace: the plain query, or the
+ * `Suspense`/`Infinite`/`SuspenseInfinite` flavors that suffix every
+ * generated identifier.
+ */
+export type QueryVariant = '' | 'Suspense' | 'Infinite' | 'SuspenseInfinite'
+
+/**
+ * The query namespace shared by the TanStack Query flavored plugins
+ * (react-query, vue-query, swr): hook, options, key, key type, and inline
+ * client names.
+ */
+export type QueryResolver = {
+  name(this: Resolver, node: ast.OperationNode): string
+  optionsName(this: Resolver, node: ast.OperationNode): string
+  keyName(this: Resolver, node: ast.OperationNode): string
+  keyTypeName(this: Resolver, node: ast.OperationNode): string
+  clientName(this: Resolver, node: ast.OperationNode): string
+}
+
+/**
+ * The mutation namespace shared by the TanStack Query flavored plugins:
+ * hook and mutation key names.
+ */
+export type MutationResolver = {
+  name(this: Resolver, node: ast.OperationNode): string
+  keyName(this: Resolver, node: ast.OperationNode): string
+}
+
+/**
+ * Builds the shared query namespace for a variant. Spread the result into
+ * `createResolver` once per variant the plugin supports.
+ *
+ * @example
+ * ```ts
+ * createResolver<PluginReactQuery>({
+ *   query: createQueryResolver(),
+ *   suspenseQuery: createQueryResolver('Suspense'),
+ * })
+ * ```
+ */
+export function createQueryResolver(variant: QueryVariant = ''): QueryResolver {
+  return {
+    name(node) {
+      return `use${capitalize(this.name(node.operationId))}${variant}`
+    },
+    optionsName(node) {
+      return `${this.name(node.operationId)}${variant}QueryOptions`
+    },
+    keyName(node) {
+      return `${this.name(node.operationId)}${variant}QueryKey`
+    },
+    keyTypeName(node) {
+      return `${capitalize(this.name(node.operationId))}${variant}QueryKey`
+    },
+    clientName(node) {
+      return `${this.name(node.operationId)}${variant}`
+    },
+  }
+}
+
+/**
+ * Builds the shared mutation namespace. Spread the result into
+ * `createResolver` and add plugin-specific methods (`optionsName`,
+ * `typeName`, `argTypeName`) next to it.
+ *
+ * @example
+ * ```ts
+ * createResolver<PluginSwr>({ mutation: { ...createMutationResolver(), argTypeName(node) {...} } })
+ * ```
+ */
+export function createMutationResolver(): MutationResolver {
+  return {
+    name(node) {
+      return `use${capitalize(this.name(node.operationId))}`
+    },
+    keyName(node) {
+      return `${this.name(node.operationId)}MutationKey`
+    },
+  }
+}

--- a/internals/utils/src/casing.test.ts
+++ b/internals/utils/src/casing.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, test } from 'vitest'
-import { camelCase, pascalCase, screamingSnakeCase, snakeCase } from './casing.ts'
+import { camelCase, capitalize, pascalCase, screamingSnakeCase, snakeCase } from './casing.ts'
 
 describe('casing', () => {
+  test.each([
+    ['getPetById', 'GetPetById'],
+    ['hello-world', 'Hello-world'],
+    ['HTML', 'HTML'],
+    ['a', 'A'],
+    ['', ''],
+  ])('capitalize(%s) -> %s', (input, expected) => {
+    expect(capitalize(input)).toBe(expected)
+  })
+
   test('camelCase', () => {
     expect(camelCase('pet pet')).toBe('petPet')
     expect(camelCase('is HTML test')).toBe('isHTMLTest')

--- a/internals/utils/src/casing.ts
+++ b/internals/utils/src/casing.ts
@@ -60,6 +60,17 @@ export function pascalCase(text: string, { prefix = '', suffix = '' }: Options =
 }
 
 /**
+ * Uppercases only the first character of `text`, leaving the rest untouched.
+ * Unlike {@link pascalCase} it never re-splits word boundaries or strips characters.
+ *
+ * @example
+ * `capitalize('getPetById') // 'GetPetById'`
+ */
+export function capitalize(text: string): string {
+  return `${text.charAt(0).toUpperCase()}${text.slice(1)}`
+}
+
+/**
  * Converts `text` to snake_case.
  *
  * @example From camelCase

--- a/internals/utils/src/index.ts
+++ b/internals/utils/src/index.ts
@@ -1,4 +1,4 @@
-export { camelCase, pascalCase, screamingSnakeCase, snakeCase } from './casing.ts'
+export { camelCase, capitalize, pascalCase, screamingSnakeCase, snakeCase } from './casing.ts'
 export { buildJSDoc, buildList, buildObject, lazyGetter, objectKey } from './codegen.ts'
 export { getRelativePath, toFilePath } from './fs.ts'
 export { aliasConflictingImports, filterUsedImports, rewriteAliasedImports, type ImportEntry, type ImportName } from './imports.ts'

--- a/packages/plugin-faker/src/resolvers/resolverFaker.ts
+++ b/packages/plugin-faker/src/resolvers/resolverFaker.ts
@@ -1,4 +1,5 @@
-import { camelCase, ensureValidVarName, toFilePath } from '@internals/utils'
+import { createCasedFile, createOperationParamResolver, createOperationResponseResolver } from '@internals/shared'
+import { camelCase, ensureValidVarName } from '@internals/utils'
 import { createResolver } from 'kubb/kit'
 import type { PluginFaker } from '../types.ts'
 
@@ -19,37 +20,7 @@ export const resolverFaker = createResolver<PluginFaker>({
   name(name) {
     return ensureValidVarName(camelCase(name, { prefix: 'create' }))
   },
-  file: {
-    baseName({ name, extname }) {
-      return `${toFilePath(name, (part) => camelCase(part, { prefix: 'create' }))}${extname}`
-    },
-  },
-  param: {
-    name(node, param) {
-      return this.name(`${node.operationId} ${param.in} ${param.name}`)
-    },
-    path(node) {
-      return this.name(`${node.operationId} Path`)
-    },
-    query(node) {
-      return this.name(`${node.operationId} Query`)
-    },
-    headers(node) {
-      return this.name(`${node.operationId} Headers`)
-    },
-  },
-  response: {
-    status(node, statusCode) {
-      return this.name(`${node.operationId} Status ${statusCode}`)
-    },
-    body(node) {
-      return this.name(`${node.operationId} Body`)
-    },
-    response(node) {
-      return this.name(`${node.operationId} Response`)
-    },
-    responses(node) {
-      return this.name(`${node.operationId} Responses`)
-    },
-  },
+  file: createCasedFile((part) => camelCase(part, { prefix: 'create' })),
+  param: createOperationParamResolver(),
+  response: createOperationResponseResolver(),
 })

--- a/packages/plugin-msw/src/index.ts
+++ b/packages/plugin-msw/src/index.ts
@@ -1,2 +1,3 @@
 export { default, pluginMsw, pluginMswName } from './plugin.ts'
-export type { PluginMsw } from './types.ts'
+export { resolverMsw } from './resolvers/resolverMsw.ts'
+export type { PluginMsw, ResolverMsw } from './types.ts'

--- a/packages/plugin-react-query/src/index.ts
+++ b/packages/plugin-react-query/src/index.ts
@@ -1,2 +1,3 @@
 export { default, pluginReactQuery, pluginReactQueryName } from './plugin.ts'
-export type { PluginReactQuery } from './types.ts'
+export { resolverReactQuery } from './resolvers/resolverReactQuery.ts'
+export type { PluginReactQuery, ResolverReactQuery } from './types.ts'

--- a/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
+++ b/packages/plugin-react-query/src/resolvers/resolverReactQuery.ts
@@ -1,9 +1,7 @@
+import { createMutationResolver, createQueryResolver } from '@internals/tanstack-query'
+import { capitalize } from '@internals/utils'
 import { createResolver } from 'kubb/kit'
 import type { PluginReactQuery } from '../types.ts'
-
-function capitalize(name: string): string {
-  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`
-}
 
 /**
  * Default resolver used by `@kubb/plugin-react-query`. Decides the names and
@@ -26,83 +24,14 @@ function capitalize(name: string): string {
  */
 export const resolverReactQuery = createResolver<PluginReactQuery>({
   pluginName: 'plugin-react-query',
-  query: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}`
-    },
-    optionsName(node) {
-      return `${this.name(node.operationId)}QueryOptions`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}QueryKey`
-    },
-    keyTypeName(node) {
-      return `${capitalize(this.name(node.operationId))}QueryKey`
-    },
-    clientName(node) {
-      return this.name(node.operationId)
-    },
-  },
-  suspenseQuery: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}Suspense`
-    },
-    optionsName(node) {
-      return `${this.name(node.operationId)}SuspenseQueryOptions`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}SuspenseQueryKey`
-    },
-    keyTypeName(node) {
-      return `${capitalize(this.name(node.operationId))}SuspenseQueryKey`
-    },
-    clientName(node) {
-      return `${this.name(node.operationId)}Suspense`
-    },
-  },
-  infiniteQuery: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}Infinite`
-    },
-    optionsName(node) {
-      return `${this.name(node.operationId)}InfiniteQueryOptions`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}InfiniteQueryKey`
-    },
-    keyTypeName(node) {
-      return `${capitalize(this.name(node.operationId))}InfiniteQueryKey`
-    },
-    clientName(node) {
-      return `${this.name(node.operationId)}Infinite`
-    },
-  },
-  suspenseInfiniteQuery: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}SuspenseInfinite`
-    },
-    optionsName(node) {
-      return `${this.name(node.operationId)}SuspenseInfiniteQueryOptions`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}SuspenseInfiniteQueryKey`
-    },
-    keyTypeName(node) {
-      return `${capitalize(this.name(node.operationId))}SuspenseInfiniteQueryKey`
-    },
-    clientName(node) {
-      return `${this.name(node.operationId)}SuspenseInfinite`
-    },
-  },
+  query: createQueryResolver(),
+  suspenseQuery: createQueryResolver('Suspense'),
+  infiniteQuery: createQueryResolver('Infinite'),
+  suspenseInfiniteQuery: createQueryResolver('SuspenseInfinite'),
   mutation: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}`
-    },
+    ...createMutationResolver(),
     optionsName(node) {
       return `${this.name(node.operationId)}MutationOptions`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}MutationKey`
     },
     typeName(node) {
       return capitalize(this.name(node.operationId))

--- a/packages/plugin-swr/package.json
+++ b/packages/plugin-swr/package.json
@@ -73,6 +73,7 @@
     "@internals/client": "workspace:*",
     "@internals/shared": "workspace:*",
     "@internals/tanstack-query": "workspace:*",
+    "@internals/utils": "workspace:*",
     "kubb": "catalog:"
   },
   "peerDependencies": {

--- a/packages/plugin-swr/src/index.ts
+++ b/packages/plugin-swr/src/index.ts
@@ -1,2 +1,3 @@
 export { default, pluginSwr, pluginSwrName } from './plugin.ts'
-export type { PluginSwr, Transformer } from './types.ts'
+export { resolverSwr } from './resolvers/resolverSwr.ts'
+export type { PluginSwr, ResolverSwr, Transformer } from './types.ts'

--- a/packages/plugin-swr/src/resolvers/resolverSwr.ts
+++ b/packages/plugin-swr/src/resolvers/resolverSwr.ts
@@ -1,9 +1,7 @@
+import { createMutationResolver, createQueryResolver } from '@internals/tanstack-query'
+import { capitalize } from '@internals/utils'
 import { createResolver } from 'kubb/kit'
 import type { PluginSwr } from '../types.ts'
-
-function capitalize(name: string): string {
-  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`
-}
 
 /**
  * Default resolver used by `@kubb/plugin-swr`. Decides the names and file paths for every generated
@@ -23,30 +21,9 @@ function capitalize(name: string): string {
  */
 export const resolverSwr = createResolver<PluginSwr>({
   pluginName: 'plugin-swr',
-  query: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}`
-    },
-    optionsName(node) {
-      return `${this.name(node.operationId)}QueryOptions`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}QueryKey`
-    },
-    keyTypeName(node) {
-      return `${capitalize(this.name(node.operationId))}QueryKey`
-    },
-    clientName(node) {
-      return this.name(node.operationId)
-    },
-  },
+  query: createQueryResolver(),
   mutation: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}MutationKey`
-    },
+    ...createMutationResolver(),
     keyTypeName(node) {
       return `${capitalize(this.name(node.operationId))}MutationKey`
     },

--- a/packages/plugin-ts/src/resolvers/resolverTs.ts
+++ b/packages/plugin-ts/src/resolvers/resolverTs.ts
@@ -1,4 +1,5 @@
-import { ensureValidVarName, pascalCase, toFilePath } from '@internals/utils'
+import { createCasedFile, createOperationParamResolver, createOperationResponseResolver } from '@internals/shared'
+import { ensureValidVarName, pascalCase } from '@internals/utils'
 import { createResolver } from 'kubb/kit'
 import type { PluginTs } from '../types.ts'
 
@@ -26,40 +27,12 @@ export const resolverTs = createResolver<PluginTs>({
   name(name) {
     return ensureValidVarName(pascalCase(name))
   },
-  file: {
-    baseName({ name, extname }) {
-      return `${toFilePath(name, pascalCase)}${extname}`
-    },
-  },
-  param: {
-    name(node, param) {
-      return this.name(`${node.operationId} ${param.in} ${param.name}`)
-    },
-    path(node) {
-      return this.name(`${node.operationId} Path`)
-    },
-    query(node) {
-      return this.name(`${node.operationId} Query`)
-    },
-    headers(node) {
-      return this.name(`${node.operationId} Headers`)
-    },
-  },
+  file: createCasedFile(pascalCase),
+  param: createOperationParamResolver(),
   response: {
-    status(node, statusCode) {
-      return this.name(`${node.operationId} Status ${statusCode}`)
-    },
+    ...createOperationResponseResolver(),
     options(node) {
       return this.name(`${node.operationId} Options`)
-    },
-    responses(node) {
-      return this.name(`${node.operationId} Responses`)
-    },
-    response(node) {
-      return this.name(`${node.operationId} Response`)
-    },
-    body(node) {
-      return this.name(`${node.operationId} Body`)
     },
   },
   enum: {

--- a/packages/plugin-vue-query/src/index.ts
+++ b/packages/plugin-vue-query/src/index.ts
@@ -1,2 +1,3 @@
 export { default, pluginVueQuery, pluginVueQueryName } from './plugin.ts'
-export type { PluginVueQuery } from './types.ts'
+export { resolverVueQuery } from './resolvers/resolverVueQuery.ts'
+export type { PluginVueQuery, ResolverVueQuery } from './types.ts'

--- a/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
+++ b/packages/plugin-vue-query/src/resolvers/resolverVueQuery.ts
@@ -1,9 +1,7 @@
+import { createMutationResolver, createQueryResolver } from '@internals/tanstack-query'
+import { capitalize } from '@internals/utils'
 import { createResolver } from 'kubb/kit'
 import type { PluginVueQuery } from '../types.ts'
-
-function capitalize(name: string): string {
-  return `${name.charAt(0).toUpperCase()}${name.slice(1)}`
-}
 
 /**
  * Default resolver used by `@kubb/plugin-vue-query`. Decides the names and
@@ -25,47 +23,10 @@ function capitalize(name: string): string {
  */
 export const resolverVueQuery = createResolver<PluginVueQuery>({
   pluginName: 'plugin-vue-query',
-  query: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}QueryKey`
-    },
-    keyTypeName(node) {
-      return `${capitalize(this.name(node.operationId))}QueryKey`
-    },
-    optionsName(node) {
-      return `${this.name(node.operationId)}QueryOptions`
-    },
-    clientName(node) {
-      return this.name(node.operationId)
-    },
-  },
-  infiniteQuery: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}Infinite`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}InfiniteQueryKey`
-    },
-    keyTypeName(node) {
-      return `${capitalize(this.name(node.operationId))}InfiniteQueryKey`
-    },
-    optionsName(node) {
-      return `${this.name(node.operationId)}InfiniteQueryOptions`
-    },
-    clientName(node) {
-      return `${this.name(node.operationId)}Infinite`
-    },
-  },
+  query: createQueryResolver(),
+  infiniteQuery: createQueryResolver('Infinite'),
   mutation: {
-    name(node) {
-      return `use${capitalize(this.name(node.operationId))}`
-    },
-    keyName(node) {
-      return `${this.name(node.operationId)}MutationKey`
-    },
+    ...createMutationResolver(),
     typeName(node) {
       return capitalize(this.name(node.operationId))
     },

--- a/packages/plugin-zod/src/resolvers/resolverZod.ts
+++ b/packages/plugin-zod/src/resolvers/resolverZod.ts
@@ -1,4 +1,5 @@
-import { camelCase, ensureValidVarName, pascalCase, toFilePath } from '@internals/utils'
+import { createCasedFile, createOperationResponseResolver, operationParamName } from '@internals/shared'
+import { camelCase, ensureValidVarName, pascalCase } from '@internals/utils'
 import { createResolver } from 'kubb/kit'
 import type { PluginZod } from '../types.ts'
 
@@ -22,11 +23,7 @@ export const resolverZod = createResolver<PluginZod>({
   name(name) {
     return ensureValidVarName(camelCase(name, { suffix: 'schema' }))
   },
-  file: {
-    baseName({ name, extname }) {
-      return `${toFilePath(name, (part) => camelCase(part, { suffix: 'schema' }))}${extname}`
-    },
-  },
+  file: createCasedFile((part) => camelCase(part, { suffix: 'schema' })),
   schema: {
     typeName(name) {
       return ensureValidVarName(pascalCase(name, { suffix: 'schema type' }))
@@ -42,9 +39,7 @@ export const resolverZod = createResolver<PluginZod>({
     },
   },
   param: {
-    name(node, param) {
-      return this.name(`${node.operationId} ${param.in} ${param.name}`)
-    },
+    name: operationParamName,
     path(node, param) {
       return this.param.name(node, param)
     },
@@ -56,18 +51,7 @@ export const resolverZod = createResolver<PluginZod>({
     },
   },
   response: {
-    status(node, statusCode) {
-      return this.name(`${node.operationId} Status ${statusCode}`)
-    },
-    body(node) {
-      return this.name(`${node.operationId} Body`)
-    },
-    responses(node) {
-      return this.name(`${node.operationId} Responses`)
-    },
-    response(node) {
-      return this.name(`${node.operationId} Response`)
-    },
+    ...createOperationResponseResolver(),
     error(node) {
       return this.name(`${node.operationId} Error`)
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -800,6 +800,9 @@ importers:
       '@internals/tanstack-query':
         specifier: workspace:*
         version: link:../../internals/tanstack-query
+      '@internals/utils':
+        specifier: workspace:*
+        version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
         version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))


### PR DESCRIPTION
## 🎯 Changes

The resolver rollout left the same naming templates copied across plugins. This PR moves them into shared internal bases so each resolver only states what is plugin-specific, with zero change to generated output.

- `@internals/utils` gains `capitalize`, replacing the identical local helper in the react-query, swr, and vue-query resolvers.
- `@internals/tanstack-query` gains `createQueryResolver(variant)` and `createMutationResolver()`, which now back the `query`, `suspenseQuery`, `infiniteQuery`, `suspenseInfiniteQuery`, and `mutation` namespaces of plugin-react-query, plugin-swr, and plugin-vue-query.
- `@internals/shared` gains `createOperationParamResolver()`, `createOperationResponseResolver()`, `operationParamName`, and `createCasedFile(caseLast)`, which now back the `param`, `response`, and `file` namespaces of plugin-ts, plugin-zod, and plugin-faker. Plugin-specific methods (`response.options` in ts, `response.error` and the per-param `param.path/query/headers` in zod) stay local.
- plugin-react-query, plugin-vue-query, plugin-swr, and plugin-msw now export their default resolver and its type from the package index, matching plugin-ts, plugin-zod, plugin-faker, plugin-mcp, and plugin-cypress.
- plugin-swr declares its missing `@internals/utils` devDependency.

Zero behavior change: the full suite (1238 tests) passes without snapshot updates, and regenerating every example produces an empty git diff.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Hmj6RxUuXceRrDgfze9i6

---
_Generated by [Claude Code](https://claude.ai/code/session_016Hmj6RxUuXceRrDgfze9i6)_