### PR TITLE
refactor: resolve schema ref imports through resolver.imports

### DIFF
--- a/.changeset/resolver-imports.md
+++ b/.changeset/resolver-imports.md
@@ -1,0 +1,7 @@
+---
+"@kubb/plugin-ts": minor
+"@kubb/plugin-zod": minor
+"@kubb/plugin-faker": minor
+---
+
+Resolve schema ref imports through `resolver.imports` instead of the removed `adapter.getImports`. Generated output is unchanged; this release requires the matching `@kubb/core` with `resolver.imports` and an adapter that publishes `meta.nameMapping`.

--- a/.changeset/resolver-imports.md
+++ b/.changeset/resolver-imports.md
@@ -4,4 +4,4 @@
 "@kubb/plugin-faker": minor
 ---
 
-Resolve schema ref imports through `resolver.imports` and ref names through `resolveRefName` instead of the removed `adapter.getImports` and `nameMapping` printer options. Generated output is unchanged; this release requires the matching `@kubb/core` and `@kubb/adapter-oas` that ship `resolver.imports` and stamp `targetName` on collision-renamed refs.
+Resolve schema ref imports through `resolver.imports` and ref names through `resolveRefName` instead of the removed `adapter.getImports` and `nameMapping` printer options. Generated output is unchanged. This release requires the matching `@kubb/core` and `@kubb/adapter-oas` that ship `resolver.imports` and stamp `targetName` on collision-renamed refs.

--- a/.changeset/resolver-imports.md
+++ b/.changeset/resolver-imports.md
@@ -4,4 +4,4 @@
 "@kubb/plugin-faker": minor
 ---
 
-Resolve schema ref imports through `resolver.imports` instead of the removed `adapter.getImports`. Generated output is unchanged; this release requires the matching `@kubb/core` with `resolver.imports` and an adapter that publishes `meta.nameMapping`.
+Resolve schema ref imports through `resolver.imports` and ref names through `resolveRefName` instead of the removed `adapter.getImports` and `nameMapping` printer options. Generated output is unchanged; this release requires the matching `@kubb/core` and `@kubb/adapter-oas` that ship `resolver.imports` and stamp `targetName` on collision-renamed refs.

--- a/internals/shared/src/adapter.ts
+++ b/internals/shared/src/adapter.ts
@@ -3,7 +3,7 @@ import type { AdapterOas } from '@kubb/adapter-oas'
 
 /**
  * Narrows the generic `Adapter` from a generator context to the OpenAPI adapter,
- * so OAS-only options (`dateType`, `nameMapping`) and the parsed `document` are typed.
+ * so OAS-only options (`dateType`, `enums`) and the parsed `document` are typed.
  *
  * Throws when a non-OAS adapter is configured, turning a silently wrong cast into a
  * clear, actionable error at the point of use.

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -41,5 +41,6 @@ export {
   type ResolveOperationTypeNameOptions,
 } from './operation.ts'
 export { getOasAdapter } from './adapter.ts'
+export { collectRefNames } from './refs.ts'
 export { createGroupConfig } from './group.ts'
 export { buildParamsMapping, buildParamsRemapExpression, buildTransformedParamsMapping, caseParams } from './params.ts'

--- a/internals/shared/src/refs.ts
+++ b/internals/shared/src/refs.ts
@@ -1,0 +1,17 @@
+import { ast } from 'kubb/kit'
+
+/**
+ * Collects the resolved target name of every pointer-carrying ref in a schema tree, in
+ * first-occurrence order. Use this for name-only checks (e.g. redeclaration detection) where
+ * `resolver.imports` would resolve file paths that are then discarded.
+ */
+export function collectRefNames(schema: ast.SchemaNode): Array<string> {
+  return ast.collect(schema, {
+    schema: (node) => {
+      const refNode = ast.narrowSchema(node, 'ref')
+      if (!refNode?.ref) return null
+
+      return ast.resolveRefName(refNode)
+    },
+  })
+}

--- a/packages/plugin-faker/src/generators/__snapshots__/catCycle/createCat.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/catCycle/createCat.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Cat } from './types/Cat'
+import { createPet } from './createPet'
 import { faker } from '@faker-js/faker'
 
 export function createCat<TData extends Partial<Cat> = object>(data?: TData) {

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet/createCreatePet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet/createCreatePet.ts
@@ -5,6 +5,8 @@
  */
 
 import type { CreatePetBody, CreatePetResponse, CreatePetStatus201 } from './types/CreatePet'
+import { createCategory } from './createCategory'
+import { createPet } from './createPet'
 import { faker } from '@faker-js/faker'
 
 /**

--- a/packages/plugin-faker/src/generators/__snapshots__/pet/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet/createPet.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Pet } from './types/Pet'
+import { createCategory } from './createCategory'
 import { faker } from '@faker-js/faker'
 
 export function createPet<TData extends Partial<Pet> = object>(data?: TData) {

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs/createPet.ts
@@ -6,6 +6,7 @@
 
 import dayjs from 'dayjs'
 import type { Pet } from './types/Pet'
+import { createCategory } from './createCategory'
 import { faker } from '@faker-js/faker'
 
 export function createPet<TData extends Partial<Pet> = object>(data?: TData) {

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithLocale/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithLocale/createPet.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Pet } from './types/Pet'
+import { createCategory } from './createCategory'
 import { fakerDE as faker } from '@faker-js/faker'
 
 export function createPet<TData extends Partial<Pet> = object>(data?: TData) {

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMacroValues/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMacroValues/createPet.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Pet } from './types/Pet'
+import { createCategory } from './createCategory'
 import { faker } from '@faker-js/faker'
 
 export function createPet<TData extends Partial<Pet> = object>(data?: TData) {

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp/createPet.ts
@@ -6,6 +6,7 @@
 
 import RandExp from 'randexp'
 import type { Pet } from './types/Pet'
+import { createCategory } from './createCategory'
 import { faker } from '@faker-js/faker'
 
 export function createPet<TData extends Partial<Pet> = object>(data?: TData) {

--- a/packages/plugin-faker/src/generators/__snapshots__/showPetById/createShowPetById.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/showPetById/createShowPetById.ts
@@ -5,6 +5,8 @@
  */
 
 import type { ShowPetByIdPath, ShowPetByIdResponse, ShowPetByIdStatus200, ShowPetByIdStatusDefault } from './types/ShowPetById'
+import { createError } from './createError'
+import { createPet } from './createPet'
 import { faker } from '@faker-js/faker'
 
 export function createShowPetByIdPath<TData extends Partial<ShowPetByIdPath> = object>(data?: TData) {

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -68,10 +68,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       typeFilePath: meta.typeFile.path,
     })
 
-    const imports = adapter.getImports(node, (schemaName) => ({
-      name: resolver.name(schemaName),
-      path: resolver.file({ name: schemaName, extname: '.ts', root, output, group: group ?? undefined }).path,
-    }))
+    const imports = resolver.imports({ node, meta: ctx.meta, root, output, group: group ?? undefined })
     const usedImports = filterUsedImports(imports, fakerText)
 
     return (
@@ -199,12 +196,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
     } as const
 
     function resolveMockImports(schema: ast.SchemaNode) {
-      return adapter
-        .getImports(schema, (schemaName) => ({
-          name: resolver.name(schemaName),
-          path: resolver.file({ name: schemaName, extname: '.ts', root, output, group: group ?? undefined }).path,
-        }))
-        .filter((entry) => entry.path !== meta.file.path)
+      return resolver.imports({ node: schema, meta: ctx.meta, root, output, group: group ?? undefined }).filter((entry) => entry.path !== meta.file.path)
     }
 
     function renderEntry({

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -1,4 +1,4 @@
-import { caseParams, getOasAdapter, getOperationParameters, getPerContentTypeName, resolveContentTypeVariants } from '@internals/shared'
+import { caseParams, getOperationParameters, getPerContentTypeName, resolveContentTypeVariants } from '@internals/shared'
 import { aliasConflictingImports, filterUsedImports, rewriteAliasedImports } from '@internals/utils'
 import { ast, defineGenerator } from 'kubb/kit'
 import { buildParams, pluginTsName } from '@kubb/plugin-ts'
@@ -18,7 +18,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
   name: 'faker',
   renderer: jsxRenderer,
   schema(node, ctx) {
-    const { adapter, config, resolver, root } = ctx
+    const { config, resolver, root } = ctx
     const { output, group, dateParser, regexGenerator, seed, locale, printer } = ctx.options
     const pluginTs = ctx.driver.getPlugin(pluginTsName)
 
@@ -56,7 +56,6 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       regexGenerator,
       nodes: printer?.nodes,
       cyclicSchemas,
-      nameMapping: getOasAdapter(adapter).options.nameMapping,
     })
     const fakerText = printerInstance.print(node) ?? 'undefined'
     const typeReference = resolveTypeReference({
@@ -68,7 +67,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       typeFilePath: meta.typeFile.path,
     })
 
-    const imports = resolver.imports({ node, meta: ctx.meta, root, output, group: group ?? undefined })
+    const imports = resolver.imports({ node, root, output, group: group ?? undefined })
     const usedImports = filterUsedImports(imports, fakerText)
 
     return (
@@ -99,7 +98,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
     )
   },
   operation(node, ctx) {
-    const { adapter, config, resolver, root } = ctx
+    const { config, resolver, root } = ctx
     const { output, group, dateParser, regexGenerator, seed, locale, printer } = ctx.options
     const pluginTs = ctx.driver.getPlugin(pluginTsName)
 
@@ -196,7 +195,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
     } as const
 
     function resolveMockImports(schema: ast.SchemaNode) {
-      return resolver.imports({ node: schema, meta: ctx.meta, root, output, group: group ?? undefined }).filter((entry) => entry.path !== meta.file.path)
+      return resolver.imports({ node: schema, root, output, group: group ?? undefined }).filter((entry) => entry.path !== meta.file.path)
     }
 
     function renderEntry({
@@ -225,7 +224,6 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
         regexGenerator,
         nodes: printer?.nodes,
         cyclicSchemas,
-        nameMapping: getOasAdapter(adapter).options.nameMapping,
       })
       const fakerText = printerInstance.print(schema) ?? 'undefined'
       const usedImports = filterUsedImports(resolveMockImports(schema), fakerText, skipImportNames)

--- a/packages/plugin-faker/src/printers/printerFaker.test.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.test.ts
@@ -87,11 +87,10 @@ describe('printerFaker', () => {
     expect(printerFaker({ resolver: resolverFaker }).print(node)).toMatchInlineSnapshot(`"createEpisodeBase(data)"`)
   })
 
-  test('resolves a collided ref to its renamed name via nameMapping', () => {
-    const node = ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order' })
-    const nameMapping = new Map([['#/components/schemas/Order', 'OrderSchema']])
+  test('resolves a collided ref to its renamed name via targetName', () => {
+    const node = ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order', targetName: 'OrderSchema' })
 
-    expect(printerFaker({ resolver: resolverFaker, nameMapping }).print(node)).toMatchInlineSnapshot(`"createOrderSchema(data)"`)
+    expect(printerFaker({ resolver: resolverFaker }).print(node)).toMatchInlineSnapshot(`"createOrderSchema(data)"`)
   })
 
   test('uses tuple item types for nested enum members', () => {

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -49,12 +49,6 @@ export type PrinterFakerOptions = {
    * the recursive faker call from ever executing (avoiding stack overflow).
    */
   cyclicSchemas?: ReadonlySet<string>
-  /**
-   * Maps a component `$ref` path to its collision-resolved name. When two components collide
-   * (across sections or by case), the adapter renames one of them; the `ref()` handler resolves
-   * the referenced name through this map so the emitted faker reference matches the renamed component.
-   */
-  nameMapping?: ReadonlyMap<string, string>
 }
 
 /**
@@ -288,15 +282,11 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
         return fakerKeywordMapper.time(node.representation ?? 'string', this.options.dateParser)
       },
       ref(node) {
-        // Parser-generated refs (with $ref) carry raw schema names that need resolving.
-        // Use the canonical name from the $ref path, since node.name may have been overridden
-        // (e.g. by single-member allOf flatten using the property-derived child name).
-        // Inline refs (without $ref) from faker utils already carry resolved helper names.
-        // `nameMapping` (keyed by the full $ref) carries the collision-resolved name when the
-        // referenced component was renamed; otherwise fall back to the short ref name.
-        const refName = node.ref
-          ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name ?? node.schema?.name)
-          : (node.name ?? node.schema?.name)
+        // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
+        // then the $ref path segment, since node.name may have been overridden (e.g. by
+        // single-member allOf flatten using the property-derived child name). Inline refs
+        // (without $ref) from faker utils already carry resolved helper names.
+        const refName = ast.resolveRefName(node)
 
         if (!refName) {
           throw new Error('Name not defined for ref node')

--- a/packages/plugin-ts/src/generators/typeGenerator.test.ts
+++ b/packages/plugin-ts/src/generators/typeGenerator.test.ts
@@ -120,13 +120,7 @@ describe('typeGenerator — custom resolver', () => {
         }),
       ],
     })
-    const adapter = createMockedAdapter({
-      getImports: (_node, resolve) =>
-        ['Pet', 'ErrorResponse', 'NewPet'].map((name) => {
-          const imported = resolve(name)
-          return ast.factory.createImport({ name: [imported.name], path: imported.path })
-        }),
-    })
+    const adapter = createMockedAdapter()
 
     await renderGeneratorOperation(typeGenerator, node, {
       config: testConfig,

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -42,14 +42,18 @@ export const typeGenerator = defineGenerator<PluginTs>({
     if (!node.name) {
       return
     }
-    // Build a set of schema names that are enums so the ref handler and getImports
-    // callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
+    // Build a set of schema names that are enums so the ref handler and the imports
+    // name callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
     const enumSchemaNames = new Set<string>(ctx.meta.enumNames)
 
-    const imports = adapter.getImports(node, (schemaName) => ({
-      name: resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
-      path: resolver.file({ name: schemaName, extname: '.ts', root, output, group: group ?? undefined }).path,
-    }))
+    const imports = resolver.imports({
+      node,
+      meta: ctx.meta,
+      root,
+      output,
+      group: group ?? undefined,
+      name: (schemaName) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
+    })
 
     const enumNode = ast.narrowSchema(node, ast.schemaTypes.enum)
     // An inline `const` (single-value enum the adapter did not register) renders as a literal type,
@@ -99,17 +103,21 @@ export const typeGenerator = defineGenerator<PluginTs>({
       file: resolver.file({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path, root, output, group: group ?? undefined }),
     } as const
 
-    // Build a set of schema names that are enums so the ref handler and getImports
-    // callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
+    // Build a set of schema names that are enums so the ref handler and the imports
+    // name callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
     const enumSchemaNames = new Set<string>(ctx.meta.enumNames)
 
     function renderSchemaType({ schema, name, keysToOmit }: { schema: ast.SchemaNode | null; name: string; keysToOmit?: Array<string> | null }) {
       if (!schema) return null
 
-      const imports = adapter.getImports(schema, (schemaName) => ({
-        name: resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
-        path: resolver.file({ name: schemaName, extname: '.ts', root, output, group: group ?? undefined }).path,
-      }))
+      const imports = resolver.imports({
+        node: schema,
+        meta: ctx.meta,
+        root,
+        output,
+        group: group ?? undefined,
+        name: (schemaName) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
+      })
 
       const schemaPrinter = printerTs({
         optionalType,
@@ -236,11 +244,15 @@ export const typeGenerator = defineGenerator<PluginTs>({
         responsesWithSchema.flatMap((res) =>
           (res.content ?? []).flatMap((entry) =>
             entry.schema
-              ? adapter
-                  .getImports(entry.schema, (schemaName) => ({
-                    name: resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
-                    path: '',
-                  }))
+              ? resolver
+                  .imports({
+                    node: entry.schema,
+                    meta: ctx.meta,
+                    root,
+                    output,
+                    group: group ?? undefined,
+                    name: (schemaName) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
+                  })
                   .flatMap((imp) => (Array.isArray(imp.name) ? imp.name : [imp.name]))
               : [],
           ),

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -1,4 +1,4 @@
-import { caseParams, getOperationParameters, resolveContentTypeVariants } from '@internals/shared'
+import { caseParams, collectRefNames, getOperationParameters, resolveContentTypeVariants } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Type } from '../components/Type.tsx'
@@ -45,14 +45,9 @@ export const typeGenerator = defineGenerator<PluginTs>({
     // Build a set of schema names that are enums so the ref handler and the imports
     // name callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
     const enumSchemaNames = new Set<string>(ctx.meta.enumNames)
+    const importName = (schemaName: string) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver })
 
-    const imports = resolver.imports({
-      node,
-      root,
-      output,
-      group: group ?? undefined,
-      name: (schemaName) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
-    })
+    const imports = resolver.imports({ node, root, output, group: group ?? undefined, name: importName })
 
     const enumNode = ast.narrowSchema(node, ast.schemaTypes.enum)
     // An inline `const` (single-value enum the adapter did not register) renders as a literal type,
@@ -104,17 +99,12 @@ export const typeGenerator = defineGenerator<PluginTs>({
     // Build a set of schema names that are enums so the ref handler and the imports
     // name callback can use the suffixed type name (e.g. `StatusKey`) for those refs.
     const enumSchemaNames = new Set<string>(ctx.meta.enumNames)
+    const importName = (schemaName: string) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver })
 
     function renderSchemaType({ schema, name, keysToOmit }: { schema: ast.SchemaNode | null; name: string; keysToOmit?: Array<string> | null }) {
       if (!schema) return null
 
-      const imports = resolver.imports({
-        node: schema,
-        root,
-        output,
-        group: group ?? undefined,
-        name: (schemaName) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
-      })
+      const imports = resolver.imports({ node: schema, root, output, group: group ?? undefined, name: importName })
 
       const schemaPrinter = printerTs({
         optionalType,
@@ -237,21 +227,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
 
       const responsesWithSchema = node.responses.filter(hasSchema)
       const importedNames = new Set(
-        responsesWithSchema.flatMap((res) =>
-          (res.content ?? []).flatMap((entry) =>
-            entry.schema
-              ? resolver
-                  .imports({
-                    node: entry.schema,
-                    root,
-                    output,
-                    group: group ?? undefined,
-                    name: (schemaName) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
-                  })
-                  .flatMap((imp) => (Array.isArray(imp.name) ? imp.name : [imp.name]))
-              : [],
-          ),
-        ),
+        responsesWithSchema.flatMap((res) => (res.content ?? []).flatMap((entry) => (entry.schema ? collectRefNames(entry.schema).map(importName) : []))),
       )
 
       if (importedNames.has(responseName)) {

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -1,4 +1,4 @@
-import { caseParams, getOasAdapter, getOperationParameters, resolveContentTypeVariants } from '@internals/shared'
+import { caseParams, getOperationParameters, resolveContentTypeVariants } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Type } from '../components/Type.tsx'
@@ -37,7 +37,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
   renderer: jsxRenderer,
   schema(node, ctx) {
     const { enum: enumOptions, syntaxType, optionalType, arrayType, output, group, printer } = ctx.options
-    const { adapter, config, resolver, root } = ctx
+    const { config, resolver, root } = ctx
 
     if (!node.name) {
       return
@@ -48,7 +48,6 @@ export const typeGenerator = defineGenerator<PluginTs>({
 
     const imports = resolver.imports({
       node,
-      meta: ctx.meta,
       root,
       output,
       group: group ?? undefined,
@@ -74,7 +73,6 @@ export const typeGenerator = defineGenerator<PluginTs>({
       description: node.description,
       resolver,
       enumSchemaNames,
-      nameMapping: getOasAdapter(adapter).options.nameMapping,
       nodes: printer?.nodes,
     })
 
@@ -95,7 +93,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
   },
   operation(node, ctx) {
     const { enum: enumOptions, optionalType, arrayType, syntaxType, group, output, printer } = ctx.options
-    const { adapter, config, resolver, root } = ctx
+    const { config, resolver, root } = ctx
 
     const params = caseParams(node.parameters, 'camelcase')
 
@@ -112,7 +110,6 @@ export const typeGenerator = defineGenerator<PluginTs>({
 
       const imports = resolver.imports({
         node: schema,
-        meta: ctx.meta,
         root,
         output,
         group: group ?? undefined,
@@ -129,7 +126,6 @@ export const typeGenerator = defineGenerator<PluginTs>({
         keysToOmit,
         resolver,
         enumSchemaNames,
-        nameMapping: getOasAdapter(adapter).options.nameMapping,
         nodes: printer?.nodes,
       })
 
@@ -247,7 +243,6 @@ export const typeGenerator = defineGenerator<PluginTs>({
               ? resolver
                   .imports({
                     node: entry.schema,
-                    meta: ctx.meta,
                     root,
                     output,
                     group: group ?? undefined,

--- a/packages/plugin-ts/src/printers/printerTs.test.ts
+++ b/packages/plugin-ts/src/printers/printerTs.test.ts
@@ -174,7 +174,7 @@ describe('printerTs', () => {
     })
 
     it('ref without $ref path (inline ref) uses node.name directly', async () => {
-      // Inline refs from getImports/utils don't carry a $ref path — node.name is the resolved type.
+      // Inline refs from resolver.imports/utils don't carry a $ref path — node.name is the resolved type.
       const result = printer.transform(ast.factory.createSchema({ type: 'ref', name: 'ResolvedType' }))
 
       expect(await formatTS(result)).toBe('ResolvedType')

--- a/packages/plugin-ts/src/printers/printerTs.test.ts
+++ b/packages/plugin-ts/src/printers/printerTs.test.ts
@@ -187,32 +187,13 @@ describe('printerTs', () => {
       expect(await formatTS(result)).toBe('FallbackType')
     })
 
-    it('ref resolves a collided component to its renamed name via nameMapping', async () => {
+    it('ref resolves a collided component to its renamed name via targetName', async () => {
       // When `#/components/schemas/Order` collides with `#/components/requestBodies/Order`,
-      // the adapter renames it to `OrderSchema`; the printer must emit the renamed type.
-      const mappedPrinter = printerTs({
-        resolver: resolverTs,
-        optionalType: 'questionToken',
-        arrayType: 'array',
-        enum: inlineLiteralEnum,
-        nameMapping: new Map([['#/components/schemas/Order', 'OrderSchema']]),
-      })
-      const result = mappedPrinter.transform(ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order' }))
+      // the adapter renames it to `OrderSchema` and stamps the ref; the printer must emit the
+      // renamed type.
+      const result = printer.transform(ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order', targetName: 'OrderSchema' }))
 
       expect(await formatTS(result)).toBe('OrderSchema')
-    })
-
-    it('ref ignores nameMapping for refs that were not renamed', async () => {
-      const mappedPrinter = printerTs({
-        resolver: resolverTs,
-        optionalType: 'questionToken',
-        arrayType: 'array',
-        enum: inlineLiteralEnum,
-        nameMapping: new Map([['#/components/schemas/Order', 'OrderSchema']]),
-      })
-      const result = mappedPrinter.transform(ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }))
-
-      expect(await formatTS(result)).toBe('Pet')
     })
   })
 

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -85,11 +85,6 @@ export type PrinterTsOptions = {
    */
   enumSchemaNames?: Set<string>
   /**
-   * Maps a component `$ref` path to its collision-resolved name, so a reference to a renamed
-   * component (e.g. `#/components/schemas/Order` → `OrderSchema`) emits the renamed name.
-   */
-  nameMapping?: ReadonlyMap<string, string>
-  /**
    * Custom handler map for node type overrides.
    */
   nodes?: PrinterTsNodes
@@ -160,13 +155,11 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         if (!node.name) {
           return null
         }
-        // Parser-generated refs (with $ref) carry raw schema names that need resolving.
-        // Resolve the referenced name from the $ref path — `node.name` may have been overridden
-        // (e.g. by single-member allOf flatten using the property-derived child name). When the
-        // referenced component was renamed to resolve a name collision, `nameMapping` (keyed by the
-        // full $ref) carries the renamed name; otherwise fall back to the short ref name.
-        // Inline refs (without $ref) from utils already carry resolved type names.
-        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name) : node.name
+        // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
+        // then the $ref path segment — `node.name` may have been overridden (e.g. by single-member
+        // allOf flatten using the property-derived child name). Inline refs (without $ref) from
+        // utils already carry resolved type names.
+        const refName = ast.resolveRefName(node) ?? node.name
 
         // When a Key suffix is configured, enum refs must use the suffixed name (e.g. `StatusKey`)
         // so the reference matches what the enum file actually exports.

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -159,7 +159,10 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         // then the $ref path segment — `node.name` may have been overridden (e.g. by single-member
         // allOf flatten using the property-derived child name). Inline refs (without $ref) from
         // utils already carry resolved type names.
-        const refName = ast.resolveRefName(node) ?? node.name
+        const refName = ast.resolveRefName(node)
+        if (!refName) {
+          return null
+        }
 
         // When a Key suffix is configured, enum refs must use the suffixed name (e.g. `StatusKey`)
         // so the reference matches what the enum file actually exports.

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -155,10 +155,8 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
         if (!node.name) {
           return null
         }
-        // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
-        // then the $ref path segment — `node.name` may have been overridden (e.g. by single-member
-        // allOf flatten using the property-derived child name). Inline refs (without $ref) from
-        // utils already carry resolved type names.
+        // `node.name` may have been overridden (e.g. by the single-member allOf flatten using the
+        // property-derived child name), so resolve the target through `resolveRefName` instead.
         const refName = ast.resolveRefName(node)
         if (!refName) {
           return null

--- a/packages/plugin-zod/src/generators/__snapshots__/catCycle/catSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/catCycle/catSchema.ts
@@ -5,6 +5,7 @@
  */
 
 import * as z from 'zod'
+import { petSchema } from './petSchema'
 
 export const catSchema = z.object({
   id: z.int(),

--- a/packages/plugin-zod/src/generators/__snapshots__/discriminatedUnion/paymentSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/discriminatedUnion/paymentSchema.ts
@@ -5,5 +5,7 @@
  */
 
 import * as z from 'zod'
+import { cardPaymentSchema } from './cardPaymentSchema'
+import { walletPaymentSchema } from './walletPaymentSchema'
 
 export const paymentSchema = z.discriminatedUnion('method', [cardPaymentSchema, walletPaymentSchema])

--- a/packages/plugin-zod/src/generators/__snapshots__/miniDiscriminatedUnion/paymentSchema.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/miniDiscriminatedUnion/paymentSchema.ts
@@ -5,5 +5,7 @@
  */
 
 import * as z from 'zod/mini'
+import { cardPaymentSchema } from './cardPaymentSchema'
+import { walletPaymentSchema } from './walletPaymentSchema'
 
 export const paymentSchema = z.discriminatedUnion('method', [cardPaymentSchema, walletPaymentSchema])

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -22,7 +22,6 @@ type StdPrinterParams = {
   regexType: unknown
   dateType: unknown
   cyclicSchemas: ReadonlySet<string>
-  nameMapping?: ReadonlyMap<string, string>
   nodes: unknown
 }
 
@@ -69,7 +68,6 @@ function getMiniPrinter(
     guidType: unknown
     regexType: unknown
     cyclicSchemas: ReadonlySet<string>
-    nameMapping?: ReadonlyMap<string, string>
     nodes: unknown
   },
 ) {
@@ -106,7 +104,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
     const hasCodec = !mini && containsCodec(node)
 
     const codecRefNames = new Set(hasCodec ? collectCodecRefNames(node) : [])
-    const importEntries = resolver.imports({ node, meta: ctx.meta, root, output, group: group ?? undefined })
+    const importEntries = resolver.imports({ node, root, output, group: group ?? undefined })
     const inputImportEntries = hasCodec
       ? [...codecRefNames].map((schemaName) => ({
           name: [resolver.schema.inputName(schemaName)],
@@ -128,9 +126,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
 
     const inferTypeName = inferred ? resolver.schema.typeName(node.name) : null
 
-    const nameMapping = getOasAdapter(adapter).options.nameMapping
-    const stdPrinters = mini ? null : getStdPrinters(resolver, { coercion, guidType, regexType, dateType, cyclicSchemas, nameMapping, nodes: printer?.nodes })
-    const schemaPrinter = mini ? getMiniPrinter(resolver, { guidType, regexType, cyclicSchemas, nameMapping, nodes: printer?.nodes }) : stdPrinters!.output
+    const stdPrinters = mini ? null : getStdPrinters(resolver, { coercion, guidType, regexType, dateType, cyclicSchemas, nodes: printer?.nodes })
+    const schemaPrinter = mini ? getMiniPrinter(resolver, { guidType, regexType, cyclicSchemas, nodes: printer?.nodes }) : stdPrinters!.output
 
     return (
       <File
@@ -173,7 +170,6 @@ export const zodGenerator = defineGenerator<PluginZod>({
     } as const
 
     const cyclicSchemas = new Set<string>(ctx.meta.circularNames)
-    const nameMapping = getOasAdapter(adapter).options.nameMapping
 
     function renderSchemaEntry({
       schema,
@@ -194,7 +190,6 @@ export const zodGenerator = defineGenerator<PluginZod>({
       const codecRefNames = direction === 'input' && !mini ? new Set(collectCodecRefNames(schema)) : null
       const imports = resolver.imports({
         node: schema,
-        meta: ctx.meta,
         root,
         output,
         group: group ?? undefined,
@@ -203,8 +198,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
 
       const schemaPrinter = mini
         ? keysToOmit?.length
-          ? printerZodMini({ guidType, regexType, resolver, keysToOmit, cyclicSchemas, nameMapping, nodes: printer?.nodes })
-          : getMiniPrinter(resolver, { guidType, regexType, cyclicSchemas, nameMapping, nodes: printer?.nodes })
+          ? printerZodMini({ guidType, regexType, resolver, keysToOmit, cyclicSchemas, nodes: printer?.nodes })
+          : getMiniPrinter(resolver, { guidType, regexType, cyclicSchemas, nodes: printer?.nodes })
         : keysToOmit?.length
           ? printerZod({
               coercion,
@@ -214,11 +209,10 @@ export const zodGenerator = defineGenerator<PluginZod>({
               resolver,
               keysToOmit,
               cyclicSchemas,
-              nameMapping,
               nodes: printer?.nodes,
               direction,
             })
-          : getStdPrinters(resolver, { coercion, guidType, regexType, dateType, cyclicSchemas, nameMapping, nodes: printer?.nodes })[direction]
+          : getStdPrinters(resolver, { coercion, guidType, regexType, dateType, cyclicSchemas, nodes: printer?.nodes })[direction]
 
       return (
         <>
@@ -271,7 +265,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
           (res.content ?? []).flatMap((entry) =>
             entry.schema
               ? resolver
-                  .imports({ node: entry.schema, meta: ctx.meta, root, output, group: group ?? undefined })
+                  .imports({ node: entry.schema, root, output, group: group ?? undefined })
                   .flatMap((imp) => (Array.isArray(imp.name) ? imp.name : [imp.name]))
               : [],
           ),

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -1,4 +1,4 @@
-import { caseParams, getOasAdapter, getSuccessResponses, isSuccessStatusCode, resolveContentTypeVariants } from '@internals/shared'
+import { caseParams, collectRefNames, getOasAdapter, getSuccessResponses, isSuccessStatusCode, resolveContentTypeVariants } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Zod } from '../components/Zod.tsx'
@@ -262,13 +262,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
       // redeclaration errors.
       const importedNames = new Set(
         responses.flatMap((res) =>
-          (res.content ?? []).flatMap((entry) =>
-            entry.schema
-              ? resolver
-                  .imports({ node: entry.schema, root, output, group: group ?? undefined })
-                  .flatMap((imp) => (Array.isArray(imp.name) ? imp.name : [imp.name]))
-              : [],
-          ),
+          (res.content ?? []).flatMap((entry) => (entry.schema ? collectRefNames(entry.schema).map((refName) => resolver.name(refName)) : [])),
         ),
       )
 

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -106,10 +106,7 @@ export const zodGenerator = defineGenerator<PluginZod>({
     const hasCodec = !mini && containsCodec(node)
 
     const codecRefNames = new Set(hasCodec ? collectCodecRefNames(node) : [])
-    const importEntries = adapter.getImports(node, (schemaName) => ({
-      name: resolver.name(schemaName),
-      path: resolver.file({ name: schemaName, extname: '.ts', root, output, group: group ?? undefined }).path,
-    }))
+    const importEntries = resolver.imports({ node, meta: ctx.meta, root, output, group: group ?? undefined })
     const inputImportEntries = hasCodec
       ? [...codecRefNames].map((schemaName) => ({
           name: [resolver.schema.inputName(schemaName)],
@@ -195,10 +192,14 @@ export const zodGenerator = defineGenerator<PluginZod>({
 
       // In the input direction, refs to codec components resolve to their input variant.
       const codecRefNames = direction === 'input' && !mini ? new Set(collectCodecRefNames(schema)) : null
-      const imports = adapter.getImports(schema, (schemaName) => ({
-        name: codecRefNames?.has(schemaName) ? resolver.schema.inputName(schemaName) : resolver.name(schemaName),
-        path: resolver.file({ name: schemaName, extname: '.ts', root, output, group: group ?? undefined }).path,
-      }))
+      const imports = resolver.imports({
+        node: schema,
+        meta: ctx.meta,
+        root,
+        output,
+        group: group ?? undefined,
+        name: (schemaName) => (codecRefNames?.has(schemaName) ? resolver.schema.inputName(schemaName) : resolver.name(schemaName)),
+      })
 
       const schemaPrinter = mini
         ? keysToOmit?.length
@@ -269,11 +270,8 @@ export const zodGenerator = defineGenerator<PluginZod>({
         responses.flatMap((res) =>
           (res.content ?? []).flatMap((entry) =>
             entry.schema
-              ? adapter
-                  .getImports(entry.schema, (schemaName) => ({
-                    name: resolver.name(schemaName),
-                    path: '',
-                  }))
+              ? resolver
+                  .imports({ node: entry.schema, meta: ctx.meta, root, output, group: group ?? undefined })
                   .flatMap((imp) => (Array.isArray(imp.name) ? imp.name : [imp.name]))
               : [],
           ),

--- a/packages/plugin-zod/src/printers/printerZod.test.ts
+++ b/packages/plugin-zod/src/printers/printerZod.test.ts
@@ -378,9 +378,9 @@ describe('printerZod', () => {
       expect(printer.print(node)).toBe('PhoneNumber')
     })
 
-    test('collided ref resolves to its renamed name via nameMapping', () => {
-      const p = printerZod({ nameMapping: new Map([['#/components/schemas/Order', 'OrderSchema']]) })
-      const node = ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order' })
+    test('collided ref resolves to its renamed name via targetName', () => {
+      const p = printerZod({})
+      const node = ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order', targetName: 'OrderSchema' })
 
       expect(p.print(node)).toBe('OrderSchema')
     })

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -305,8 +305,6 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
       },
       ref(node) {
         if (!node.name) return null
-        // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
-        // then the $ref path segment, then `node.name` for inline refs.
         const refName = ast.resolveRefName(node)
         if (!refName) return null
 

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -120,8 +120,7 @@ function strictOneOfMember(member: string, node: ast.SchemaNode, cyclicSchemas?:
 
     // A cyclic ref is annotated `z.ZodType`, and a nullable/optional ref is wrapped in
     // ZodNullable/ZodOptional, and neither exposes `.strict()`. Only a bare `ZodObject` ref takes it.
-    // A union member ref may carry only `node.name` (no `node.ref`), so fall back to it like `ref()`.
-    const refName = (node.ref ? ast.extractRefName(node.ref) : undefined) ?? node.name
+    const refName = ast.resolveRefName(node)
     if (refName && cyclicSchemas?.has(refName)) {
       return member
     }

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -98,12 +98,6 @@ export type PrinterZodOptions = {
    */
   direction?: 'input' | 'output'
   /**
-   * Maps a component `$ref` path to its collision-resolved name. When two components collide
-   * (across sections or by case), the adapter renames one of them; the `ref()` handler resolves
-   * the referenced name through this map so the emitted schema reference matches the renamed component.
-   */
-  nameMapping?: ReadonlyMap<string, string>
-  /**
    * Custom handler map for node type overrides.
    */
   nodes?: PrinterZodNodes
@@ -311,9 +305,9 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
       },
       ref(node) {
         if (!node.name) return null
-        // `nameMapping` (keyed by the full $ref) carries the collision-resolved name when the
-        // referenced component was renamed; otherwise fall back to the short ref name.
-        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name) : node.name
+        // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
+        // then the $ref path segment, then `node.name` for inline refs.
+        const refName = ast.resolveRefName(node) ?? node.name
 
         // In the input direction, a date-bearing component resolves to its `${name}InputSchema`
         // variant so request bodies encode `Date → string` instead of decoding.

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -307,7 +307,8 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
         if (!node.name) return null
         // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
         // then the $ref path segment, then `node.name` for inline refs.
-        const refName = ast.resolveRefName(node) ?? node.name
+        const refName = ast.resolveRefName(node)
+        if (!refName) return null
 
         // In the input direction, a date-bearing component resolves to its `${name}InputSchema`
         // variant so request bodies encode `Date → string` instead of decoding.

--- a/packages/plugin-zod/src/printers/printerZodMini.test.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.test.ts
@@ -326,9 +326,9 @@ describe('printerZodMini', () => {
       expect(printer.print(node)).toBe('PhoneNumber')
     })
 
-    test('collided ref resolves to its renamed name via nameMapping', () => {
-      const p = printerZodMini({ nameMapping: new Map([['#/components/schemas/Order', 'OrderSchema']]) })
-      const node = ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order' })
+    test('collided ref resolves to its renamed name via targetName', () => {
+      const p = printerZodMini({})
+      const node = ast.factory.createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order', targetName: 'OrderSchema' })
 
       expect(p.print(node)).toBe('OrderSchema')
     })

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -224,8 +224,6 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
 
       ref(node) {
         if (!node.name) return null
-        // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
-        // then the $ref path segment, then `node.name` for inline refs.
         const refName = ast.resolveRefName(node)
         if (!refName) return null
         const resolvedName = node.ref ? (this.options.resolver?.name(refName) ?? refName) : node.name

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -65,12 +65,6 @@ export type PrinterZodMiniOptions = {
    */
   cyclicSchemas?: ReadonlySet<string>
   /**
-   * Maps a component `$ref` path to its collision-resolved name. When two components collide
-   * (across sections or by case), the adapter renames one of them; the `ref()` handler resolves
-   * the referenced name through this map so the emitted schema reference matches the renamed component.
-   */
-  nameMapping?: ReadonlyMap<string, string>
-  /**
    * Custom handler map for node type overrides.
    */
   nodes?: PrinterZodMiniNodes
@@ -230,9 +224,9 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
 
       ref(node) {
         if (!node.name) return null
-        // `nameMapping` (keyed by the full $ref) carries the collision-resolved name when the
-        // referenced component was renamed; otherwise fall back to the short ref name.
-        const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name) : node.name
+        // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
+        // then the $ref path segment, then `node.name` for inline refs.
+        const refName = ast.resolveRefName(node) ?? node.name
         const resolvedName = node.ref ? (this.options.resolver?.name(refName) ?? refName) : node.name
 
         if (node.ref && this.options.cyclicSchemas?.has(refName)) {

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -226,7 +226,8 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
         if (!node.name) return null
         // `resolveRefName` prefers the node's `targetName` (set for collision or macro renames),
         // then the $ref path segment, then `node.name` for inline refs.
-        const refName = ast.resolveRefName(node) ?? node.name
+        const refName = ast.resolveRefName(node)
+        if (!refName) return null
         const resolvedName = node.ref ? (this.options.resolver?.name(refName) ?? refName) : node.name
 
         if (node.ref && this.options.cyclicSchemas?.has(refName)) {

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -111,7 +111,7 @@ export function containsCodec(node: ast.SchemaNode | undefined, seen: Set<string
  */
 export function collectCodecRefNames(node: ast.SchemaNode): Array<string> {
   return ast.collect<string>(node, {
-    schema: (n) => (n.type === 'ref' && n.ref && containsCodec(n) ? (ast.extractRefName(n.ref) ?? undefined) : undefined),
+    schema: (n) => (n.type === 'ref' && n.ref && containsCodec(n) ? (ast.resolveRefName(n) ?? undefined) : undefined),
   })
 }
 
@@ -136,7 +136,7 @@ export function isObjectSchemaNode(node: ast.SchemaNode, cyclicSchemas?: Readonl
   if (node.type === 'object') return true
 
   if (node.type === 'ref') {
-    const refName = (node.ref ? ast.extractRefName(node.ref) : undefined) ?? node.name
+    const refName = ast.resolveRefName(node)
     if (refName && cyclicSchemas?.has(refName)) return false
     const resolved = ast.syncSchemaRef(node)
     // An unresolved ref keeps its `ref` type; assume it resolves to an object (matches the printer's

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-beta.94
-      version: 5.0.0-beta.94
+      specifier: 5.0.0-beta.95
+      version: 5.0.0-beta.95
     '@kubb/core':
-      specifier: 5.0.0-beta.94
-      version: 5.0.0-beta.94
+      specifier: 5.0.0-beta.95
+      version: 5.0.0-beta.95
     '@kubb/parser-ts':
-      specifier: 5.0.0-beta.94
-      version: 5.0.0-beta.94
+      specifier: 5.0.0-beta.95
+      version: 5.0.0-beta.95
     '@kubb/plugin-barrel':
-      specifier: 5.0.0-beta.94
-      version: 5.0.0-beta.94
+      specifier: 5.0.0-beta.95
+      version: 5.0.0-beta.95
     '@types/node':
       specifier: ^22.20.1
       version: 22.20.1
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
     kubb:
-      specifier: 5.0.0-beta.94
-      version: 5.0.0-beta.94
+      specifier: 5.0.0-beta.95
+      version: 5.0.0-beta.95
     oxfmt:
       specifier: ^0.58.0
       version: 0.58.0
@@ -64,13 +64,13 @@ importers:
         version: 2.31.0(@types/node@22.20.1)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       '@kubb/plugin-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(@kubb/core@5.0.0-beta.94)
+        version: 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -94,7 +94,7 @@ importers:
         version: 1.3.14
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
       oxfmt:
         specifier: 'catalog:'
         version: 0.58.0(svelte@5.56.4)
@@ -194,13 +194,13 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -209,7 +209,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -221,7 +221,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -231,7 +231,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:../../packages/plugin-cypress
@@ -240,7 +240,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -259,7 +259,7 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../../packages/plugin-faker
@@ -271,7 +271,7 @@ importers:
         version: 1.11.21
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -284,7 +284,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -293,7 +293,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -303,10 +303,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -327,7 +327,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -343,7 +343,7 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../../packages/plugin-faker
@@ -358,7 +358,7 @@ importers:
         version: 0.10.3(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@26.0.1)(typescript@6.0.3)
@@ -377,7 +377,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -392,7 +392,7 @@ importers:
         version: 5.101.2(react@19.2.7)
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -408,7 +408,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -417,7 +417,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -427,10 +427,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -454,7 +454,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -469,7 +469,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -481,7 +481,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -500,7 +500,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -509,7 +509,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -519,7 +519,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -534,7 +534,7 @@ importers:
         version: 5.101.2(vue@3.5.39(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
@@ -547,7 +547,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -559,7 +559,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -586,7 +586,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -599,11 +599,11 @@ importers:
         version: link:../utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -621,7 +621,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -653,7 +653,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -672,7 +672,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-faker:
     dependencies:
@@ -688,7 +688,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-fetch:
     dependencies:
@@ -707,7 +707,7 @@ importers:
         version: link:../../internals/shared
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -732,7 +732,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-msw:
     dependencies:
@@ -751,7 +751,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-react-query:
     dependencies:
@@ -773,17 +773,17 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-redoc:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
     devDependencies:
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-swr:
     dependencies:
@@ -802,13 +802,13 @@ importers:
         version: link:../../internals/tanstack-query
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-ts:
     dependencies:
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -821,7 +821,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-vue-query:
     dependencies:
@@ -843,7 +843,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-zod:
     devDependencies:
@@ -855,7 +855,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   tests/3.0.x:
     dependencies:
@@ -864,13 +864,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -909,7 +909,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -925,10 +925,10 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -964,7 +964,7 @@ importers:
         version: 15.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@26.0.1)(typescript@6.0.3)
@@ -992,10 +992,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)
+        version: 5.0.0-beta.95(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.94
+        version: 5.0.0-beta.95
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -1010,7 +1010,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1244,58 +1244,58 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kubb/adapter-oas@5.0.0-beta.94':
-    resolution: {integrity: sha512-qwbirjiBp0ad3sJhJrDVoAEAYZgKmGXOMN4XIlFP74mP2v2Tcub89HaIdsV8uq1Z2JJ7JnFSkSu4Vunqmf2wiw==}
+  '@kubb/adapter-oas@5.0.0-beta.95':
+    resolution: {integrity: sha512-hJDWbVv5xS5JZftAH216c/jMcajGbN8MwQv/dfyXW3dcmqnMcxRmZn37k0q8oRpJEucLSWFnXN+WHW7oL8oadw==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-beta.94':
-    resolution: {integrity: sha512-lgcI6Op1eRuEt0saRmapvGpTEqHIaYJ8ciBxyyROV4D9NFbo6tPkuKDGDHtAhBNoZ3PQj+WXvR0Tee3xY7tWTQ==}
+  '@kubb/ast@5.0.0-beta.95':
+    resolution: {integrity: sha512-xhxLp642XYFEAB44ks/inCml//lL7qJkl6fPCRxfgiexihQWyM3WWkVmh5MVXPS1znMGA00d7UlrCLj5vgJTnA==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-beta.94':
-    resolution: {integrity: sha512-2Dr6Xdj99XF4euSwDdHKew/edyLUUdLt4EyWB32DoilWtG9KmbMdnAvq12kW4BeZAh9daArejehrtOd/4lLEzQ==}
+  '@kubb/cli@5.0.0-beta.95':
+    resolution: {integrity: sha512-uEI3BcIctCJ7132YazZhPNtP0sOhquE148/BN1gS1v2N3QnLS8Cqz1DL5SA66+CKawYNZY9SEkxuEJStS+HJFA==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.94
-      '@kubb/mcp': 5.0.0-beta.94
+      '@kubb/adapter-oas': 5.0.0-beta.95
+      '@kubb/mcp': 5.0.0-beta.95
     peerDependenciesMeta:
       '@kubb/adapter-oas':
         optional: true
       '@kubb/mcp':
         optional: true
 
-  '@kubb/core@5.0.0-beta.94':
-    resolution: {integrity: sha512-xthWSSKur/pGQJEYpKQUdnLIuFGL7nj4Sq++NQdEMWSnVtQpAnZ8GKRO2pcucWWTlFulQyHnHt7k8f9Ve/jDww==}
+  '@kubb/core@5.0.0-beta.95':
+    resolution: {integrity: sha512-/fBvBgfrXFYtdoFqtx5Mf4j0v+wHif4LaZOZTe5mybkSVprbeZ9144VY4E4F18R0fLZ/6+4F/hfGICgbcYoTdg==}
     engines: {node: '>=22'}
 
-  '@kubb/kit@5.0.0-beta.94':
-    resolution: {integrity: sha512-un0ItkmbWT4Hp18qPP37Ma+v4hnE6Ga7eLgot+wS2021Al5LHEzrYYe/tAAS14oraszT/Dw5Ab6K2WOz3l5k5g==}
+  '@kubb/kit@5.0.0-beta.95':
+    resolution: {integrity: sha512-ZrUhXtc58o1p78ep2T+fACUPGtypBPtvb8lXV9FKwjKpAXSZAWFyt1SVwmizROkOKYEYNwdgkEIlB73NN4NLaQ==}
     engines: {node: '>=22'}
 
-  '@kubb/mcp@5.0.0-beta.94':
-    resolution: {integrity: sha512-LxOPSabSVMRf+47AaTxB53x9Exp5SY/nUg/VAdd2I7Dq7OIHoS2WxwgiEyCXGOBd1g0HUGm2eH76ERROY57oSw==}
+  '@kubb/mcp@5.0.0-beta.95':
+    resolution: {integrity: sha512-I0rLTsR1Dhbzvo2X8rJfnYhyjdq0nkd2TNfdTJglrN+eaphsnUevl2d0Tja8CM9TOicOBhVG8Gn2kD6SW+pbtg==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.94
+      '@kubb/renderer-jsx': 5.0.0-beta.95
 
-  '@kubb/parser-md@5.0.0-beta.94':
-    resolution: {integrity: sha512-fotbf0dRimaJxK2a57MA70nhkdhX6NKS+hE3E6PfcKtbVHit+x0waYlOOlLpaOTEx/cI2s3MIHnLzJZENArjig==}
+  '@kubb/parser-md@5.0.0-beta.95':
+    resolution: {integrity: sha512-xWOoe+eGX+5KmOMXHhtAFFHEIyPT1bImEvGVMlMhPTiwloj01m3UWnFbDeajvHt9F0qUtRWKev5h9zpGAjshVQ==}
     engines: {node: '>=22'}
 
-  '@kubb/parser-ts@5.0.0-beta.94':
-    resolution: {integrity: sha512-AEKkamlomFHAID/j24aU4Lprzj9WAaLMe5tT3c+EF3hKPi7TglnBJ8TBRY1PCVlEoPxoGP1XzXnfwNzmOhjHZg==}
+  '@kubb/parser-ts@5.0.0-beta.95':
+    resolution: {integrity: sha512-ompY1wd/uIag/H1HKnV3QmHdX9KuQ4WV7IfFd9AipvtKS3k59WcQHos+MDzQ1101VGwbdjI6FDdBd+KULxgMVA==}
     engines: {node: '>=22'}
 
-  '@kubb/plugin-barrel@5.0.0-beta.94':
-    resolution: {integrity: sha512-DPpWGQNHduOSFfe5gIILzBwZO6caZ5Xf4qmDMu72erNtJReFPhj9q4kXrihGclJYon8K9TtG45JNgX6vS9lbyg==}
+  '@kubb/plugin-barrel@5.0.0-beta.95':
+    resolution: {integrity: sha512-8ikD6HTEl59U2JX+4hDe8oTBD7ph6flaAizoprWNhsCAYtRo6F75l/jTaJ+wQ0EEIxoLomPKFvkiVQ7nHVS5Vw==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-beta.94
+      '@kubb/core': 5.0.0-beta.95
 
-  '@kubb/renderer-jsx@5.0.0-beta.94':
-    resolution: {integrity: sha512-Kj8yL7RePTYEkHCXZyH29n6BYdV+PbfZ9Gxde6XL7kfzOFE+Y+QvVRUjaXeRZLxG3xWkGtV6WOAQDi450BD72w==}
+  '@kubb/renderer-jsx@5.0.0-beta.95':
+    resolution: {integrity: sha512-r4kmD/jv7qfyD/IeKI5K9SpvTY0/9449XzAlBxX2pqCV5L4874kD2AC1kcefm8iSjNA30wyikThhDQDnQVNEcw==}
     engines: {node: '>=22'}
 
   '@manypkg/find-root@1.1.0':
@@ -1613,15 +1613,15 @@ packages:
     peerDependencies:
       ajv: 4.11.8 - 8
 
-  '@readme/openapi-parser@6.2.0':
-    resolution: {integrity: sha512-JS7TheecOlDe4hw/9RJkZwFDWXSwqUPxDBcq0IIY0WL5cPv9hCrUw+gq+Gn2y8d4kSbAKLQlG0/d2V9WXNxujw==}
+  '@readme/openapi-parser@6.2.1':
+    resolution: {integrity: sha512-15kP7exAU30ycF0u5/nW6J64HFzqxKYp06wErb1+cGU2rYz2dDBtf+63RjGLfGEhXND69OXIZ7RvjS7Tu7s1Yg==}
     engines: {node: '>=20'}
     peerDependencies:
       openapi-types: '>=7'
 
-  '@readme/openapi-schemas@3.1.0':
-    resolution: {integrity: sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw==}
-    engines: {node: '>=18'}
+  '@readme/openapi-schemas@4.0.0':
+    resolution: {integrity: sha512-hrG//9/+RpOZTrUDirU4OzfMqaxCdY5BMpr3YuLf3Rje9rfNsydQJsH9iCPTie9ZRu9xe+0OUD4fHe0JmGwa2w==}
+    engines: {node: '>=20'}
 
   '@rolldown/binding-android-arm64@1.1.3':
     resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
@@ -2642,8 +2642,8 @@ packages:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  gunshi@0.35.1:
-    resolution: {integrity: sha512-Fn+IZReFITpU1lfjLdQG9WXk5+NqolwR1Q6gnSeEicstlZZfVKqnANCo4YbR4ml3/4JkyJSi3vYmxb9XdCeN3g==}
+  gunshi@0.36.0:
+    resolution: {integrity: sha512-LJhM/2YiC4GfsaT2fnvccNkGXzbtMCBkgXpyLSM+1QVal2n7k8VJZol8qm1qgm2wmaQ6NBVmcGZIOkB/ms+6uQ==}
     engines: {node: '>= 22'}
 
   has-flag@4.0.0:
@@ -2869,8 +2869,8 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-beta.94:
-    resolution: {integrity: sha512-BCQ1SzoceQXBvHLm44ddFEyhN7Eun0RPqb/6MdyYP5thn803AvyallooupLp0VMvLp6/03/7pDMFSY4Xc1tktw==}
+  kubb@5.0.0-beta.95:
+    resolution: {integrity: sha512-VZwmK/ksoe3/TEmxSSLPv4uv8f3KhbpYf2DNTyPPUOxHpi7mlSGKldmEL84xh3IFkQoutm9euv/sUv+yJ5IyEg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3771,8 +3771,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-beta.94:
-    resolution: {integrity: sha512-HubKagXXf2fNmfAQ2jz8+RY841dUuRUMB167tCwXbbTdN076f8Zi1StL6ui2YUKQO+PDKV+8BBlxexCfPlpQpQ==}
+  unplugin-kubb@5.0.0-beta.95:
+    resolution: {integrity: sha512-nv+R1qnY0wyURQ0PTPIeBYw1tVgMPUMa7qJ1ePZMRCQYfYHv/lrk3Uuqfryoc8sFgeKngdAcZmMMng2ggM5vBw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -4396,46 +4396,46 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kubb/adapter-oas@5.0.0-beta.94(openapi-types@12.1.3)':
+  '@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.94
-      '@kubb/core': 5.0.0-beta.94
-      '@readme/openapi-parser': 6.2.0(openapi-types@12.1.3)
+      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/core': 5.0.0-beta.95
+      '@readme/openapi-parser': 6.2.1(openapi-types@12.1.3)
       '@scalar/openapi-upgrader': 0.2.9
       api-ref-bundler: 0.5.1
       yaml: 2.9.0
     transitivePeerDependencies:
       - openapi-types
 
-  '@kubb/ast@5.0.0-beta.94': {}
+  '@kubb/ast@5.0.0-beta.95': {}
 
-  '@kubb/cli@5.0.0-beta.94(@kubb/adapter-oas@5.0.0-beta.94(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.94(@kubb/renderer-jsx@5.0.0-beta.94)(openapi-types@12.1.3)(typescript@6.0.3))':
+  '@kubb/cli@5.0.0-beta.95(@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3))':
     dependencies:
       '@clack/prompts': 1.7.0
-      '@kubb/core': 5.0.0-beta.94
+      '@kubb/core': 5.0.0-beta.95
       chokidar: 5.0.0
-      gunshi: 0.35.1
+      gunshi: 0.36.0
       jiti: 2.7.0
       tinyexec: 1.2.4
       unconfig: 7.5.0
     optionalDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.94(openapi-types@12.1.3)
-      '@kubb/mcp': 5.0.0-beta.94(@kubb/renderer-jsx@5.0.0-beta.94)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
+      '@kubb/mcp': 5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)
 
-  '@kubb/core@5.0.0-beta.94':
+  '@kubb/core@5.0.0-beta.95':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.94
+      '@kubb/ast': 5.0.0-beta.95
 
-  '@kubb/kit@5.0.0-beta.94':
+  '@kubb/kit@5.0.0-beta.95':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.94
-      '@kubb/core': 5.0.0-beta.94
+      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/core': 5.0.0-beta.95
 
-  '@kubb/mcp@5.0.0-beta.94(@kubb/renderer-jsx@5.0.0-beta.94)(openapi-types@12.1.3)(typescript@6.0.3)':
+  '@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)':
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.94(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.94
-      '@kubb/renderer-jsx': 5.0.0-beta.94
+      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.95
+      '@kubb/renderer-jsx': 5.0.0-beta.95
       '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))
       '@tmcp/transport-stdio': 0.4.3(tmcp@1.19.4(typescript@6.0.3))
       tmcp: 1.19.4(typescript@6.0.3)
@@ -4444,25 +4444,25 @@ snapshots:
       - openapi-types
       - typescript
 
-  '@kubb/parser-md@5.0.0-beta.94':
+  '@kubb/parser-md@5.0.0-beta.95':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.94
-      '@kubb/core': 5.0.0-beta.94
+      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/core': 5.0.0-beta.95
       yaml: 2.9.0
 
-  '@kubb/parser-ts@5.0.0-beta.94':
+  '@kubb/parser-ts@5.0.0-beta.95':
     dependencies:
-      '@kubb/core': 5.0.0-beta.94
+      '@kubb/core': 5.0.0-beta.95
       typescript: 6.0.3
 
-  '@kubb/plugin-barrel@5.0.0-beta.94(@kubb/core@5.0.0-beta.94)':
+  '@kubb/plugin-barrel@5.0.0-beta.95(@kubb/core@5.0.0-beta.95)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.94
-      '@kubb/core': 5.0.0-beta.94
+      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/core': 5.0.0-beta.95
 
-  '@kubb/renderer-jsx@5.0.0-beta.94':
+  '@kubb/renderer-jsx@5.0.0-beta.95':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.94
+      '@kubb/ast': 5.0.0-beta.95
       yaml: 2.9.0
 
   '@manypkg/find-root@1.1.0':
@@ -4682,17 +4682,19 @@ snapshots:
       leven: 3.1.0
       picocolors: 1.1.1
 
-  '@readme/openapi-parser@6.2.0(openapi-types@12.1.3)':
+  '@readme/openapi-parser@6.2.1(openapi-types@12.1.3)':
     dependencies:
       '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
       '@readme/better-ajv-errors': 2.4.0(ajv@8.20.0)
-      '@readme/openapi-schemas': 3.1.0
+      '@readme/openapi-schemas': 4.0.0
       '@types/json-schema': 7.0.15
       ajv: 8.20.0
       ajv-draft-04: 1.0.0(ajv@8.20.0)
       openapi-types: 12.1.3
 
-  '@readme/openapi-schemas@3.1.0': {}
+  '@readme/openapi-schemas@4.0.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
 
   '@rolldown/binding-android-arm64@1.1.3':
     optional: true
@@ -5743,7 +5745,7 @@ snapshots:
 
   graphql@16.14.2: {}
 
-  gunshi@0.35.1: {}
+  gunshi@0.36.0: {}
 
   has-flag@4.0.0: {}
 
@@ -5930,19 +5932,19 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
+  kubb@5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.94(openapi-types@12.1.3)
-      '@kubb/ast': 5.0.0-beta.94
-      '@kubb/cli': 5.0.0-beta.94(@kubb/adapter-oas@5.0.0-beta.94(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.94(@kubb/renderer-jsx@5.0.0-beta.94)(openapi-types@12.1.3)(typescript@6.0.3))
-      '@kubb/core': 5.0.0-beta.94
-      '@kubb/kit': 5.0.0-beta.94
-      '@kubb/mcp': 5.0.0-beta.94(@kubb/renderer-jsx@5.0.0-beta.94)(openapi-types@12.1.3)(typescript@6.0.3)
-      '@kubb/parser-md': 5.0.0-beta.94
-      '@kubb/parser-ts': 5.0.0-beta.94
-      '@kubb/plugin-barrel': 5.0.0-beta.94(@kubb/core@5.0.0-beta.94)
-      '@kubb/renderer-jsx': 5.0.0-beta.94
-      unplugin-kubb: 5.0.0-beta.94(@kubb/core@5.0.0-beta.94)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
+      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/cli': 5.0.0-beta.95(@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3))
+      '@kubb/core': 5.0.0-beta.95
+      '@kubb/kit': 5.0.0-beta.95
+      '@kubb/mcp': 5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/parser-md': 5.0.0-beta.95
+      '@kubb/parser-ts': 5.0.0-beta.95
+      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
+      '@kubb/renderer-jsx': 5.0.0-beta.95
+      unplugin-kubb: 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@nuxt/kit'
@@ -5958,19 +5960,19 @@ snapshots:
       - vite
       - webpack
 
-  kubb@5.0.0-beta.94(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
+  kubb@5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.94(openapi-types@12.1.3)
-      '@kubb/ast': 5.0.0-beta.94
-      '@kubb/cli': 5.0.0-beta.94(@kubb/adapter-oas@5.0.0-beta.94(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.94(@kubb/renderer-jsx@5.0.0-beta.94)(openapi-types@12.1.3)(typescript@6.0.3))
-      '@kubb/core': 5.0.0-beta.94
-      '@kubb/kit': 5.0.0-beta.94
-      '@kubb/mcp': 5.0.0-beta.94(@kubb/renderer-jsx@5.0.0-beta.94)(openapi-types@12.1.3)(typescript@6.0.3)
-      '@kubb/parser-md': 5.0.0-beta.94
-      '@kubb/parser-ts': 5.0.0-beta.94
-      '@kubb/plugin-barrel': 5.0.0-beta.94(@kubb/core@5.0.0-beta.94)
-      '@kubb/renderer-jsx': 5.0.0-beta.94
-      unplugin-kubb: 5.0.0-beta.94(@kubb/core@5.0.0-beta.94)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
+      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/cli': 5.0.0-beta.95(@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3))
+      '@kubb/core': 5.0.0-beta.95
+      '@kubb/kit': 5.0.0-beta.95
+      '@kubb/mcp': 5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/parser-md': 5.0.0-beta.95
+      '@kubb/parser-ts': 5.0.0-beta.95
+      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
+      '@kubb/renderer-jsx': 5.0.0-beta.95
+      unplugin-kubb: 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@nuxt/kit'
@@ -6886,12 +6888,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-beta.94(@kubb/core@5.0.0-beta.94)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.94(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.94
-      '@kubb/parser-ts': 5.0.0-beta.94
-      '@kubb/plugin-barrel': 5.0.0-beta.94(@kubb/core@5.0.0-beta.94)
+      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.95
+      '@kubb/parser-ts': 5.0.0-beta.95
+      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
       unplugin: 3.3.0(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       rolldown: 1.1.3
@@ -6902,12 +6904,12 @@ snapshots:
       - openapi-types
       - unloader
 
-  unplugin-kubb@5.0.0-beta.94(@kubb/core@5.0.0-beta.94)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.94(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.94
-      '@kubb/parser-ts': 5.0.0-beta.94
-      '@kubb/plugin-barrel': 5.0.0-beta.94(@kubb/core@5.0.0-beta.94)
+      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.95
+      '@kubb/parser-ts': 5.0.0-beta.95
+      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
       unplugin: 3.3.0(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       rolldown: 1.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,22 +12,22 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.94
-  '@kubb/core': 5.0.0-beta.94
-  '@kubb/kit': 5.0.0-beta.94
-  '@kubb/plugin-barrel': 5.0.0-beta.94
-  '@kubb/parser-ts': 5.0.0-beta.94
+  '@kubb/adapter-oas': 5.0.0-beta.95
+  '@kubb/core': 5.0.0-beta.95
+  '@kubb/kit': 5.0.0-beta.95
+  '@kubb/plugin-barrel': 5.0.0-beta.95
+  '@kubb/parser-ts': 5.0.0-beta.95
   '@types/node': ^22.20.1
   '@types/react': ^19.2.17
   '@vitest/coverage-v8': ^4.1.10
   '@vitest/ui': ^4.1.10
-  kubb: 5.0.0-beta.94
+  kubb: 5.0.0-beta.95
   oxfmt: ^0.58.0
   oxlint: ^1.73.0
   prettier: ^3.9.4
   tsdown: ^0.22.3
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.94
+  unplugin-kubb: 5.0.0-beta.95
   vitest: ^4.1.10
 #
 #overrides:


### PR DESCRIPTION
## 🎯 Changes

Companion to kubb-labs/kubb#3768, which moves import resolution from the adapter to the resolver and stamps collision renames (`targetName`) on ref nodes during parsing.

### Generators: `adapter.getImports` → `resolver.imports`

Every `adapter.getImports` call in plugin-ts, plugin-zod, and plugin-faker becomes a `resolver.imports` call. The callback that rebuilt naming and file conventions inline is gone:

```tsx
// before
const imports = adapter.getImports(node, (schemaName) => ({
  name: resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver }),
  path: resolver.file({ name: schemaName, extname: '.ts', root, output, group }).path,
}))

// after
const importName = (schemaName: string) => resolveImportName({ schemaName, enumOptions, enumSchemaNames, resolver })
const imports = resolver.imports({ node, root, output, group, name: importName })
```

plugin-ts keeps its enum key-suffix naming (`StatusKey`) and plugin-zod keeps its codec input-variant naming through the per-call `name` callback. plugin-faker uses the plain defaults.

### Printers: `nameMapping` option removed

The `nameMapping` option is removed from `printerTs`, `printerZod`, `printerZodMini`, and `printerFaker`. Their `ref()` handlers, the codec ref collection, and the cyclic-schema checks all resolve through `ast.resolveRefName`, which reads `targetName` straight off the node:

```ts
// before
const refName = node.ref ? (this.options.nameMapping?.get(node.ref) ?? ast.extractRefName(node.ref) ?? node.name) : node.name

// after
const refName = ast.resolveRefName(node)
```

A new shared helper, `collectRefNames` in `internals/shared`, gathers the referenced schema names for the response-type collision checks in plugin-ts and plugin-zod.

### Generated output

Real builds are unchanged: all 14 examples regenerate byte-identical. Unit-test snapshots gain the ref imports the mocked adapter used to suppress (its `getImports` stub returned `[]`), which the real adapter already emitted.

> [!IMPORTANT]
> CI stays red until the `@kubb/core` and `@kubb/adapter-oas` release from kubb-labs/kubb#3768 ships and the catalog pins are bumped. Validated locally via the workspace `link:` overrides: build, typecheck, lint, and all 1227 tests pass, examples regenerate with no diff, and the e2e project generates and typechecks.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/plugins/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGYyHAJz2SsziJErwZ53cX