### PR TITLE
refactor: remove unused exports flagged by Fallow

### DIFF
--- a/.changeset/fallow-remove-unused-exports.md
+++ b/.changeset/fallow-remove-unused-exports.md
@@ -1,0 +1,8 @@
+---
+"@kubb/plugin-ts": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-vue-query": patch
+---
+
+Remove unused exports flagged by Fallow. Internal `factory.ts` helpers in `@kubb/plugin-ts` are now module-private, and the plugin `utils.ts` files no longer re-export helpers nothing imports. None of these symbols were part of a package's public `exports` map, so consumers are unaffected.

--- a/configs/mocks.ts
+++ b/configs/mocks.ts
@@ -1,5 +1,5 @@
 import type { ast } from 'kubb/kit'
-import { createMockedPluginDriver, matchFiles as matchFilesBase } from 'kubb/kit/testing'
+import { matchFiles as matchFilesBase } from 'kubb/kit/testing'
 import { parserTs } from '@kubb/parser-ts'
 import type { Options } from 'prettier'
 import { format as prettierFormat } from 'prettier'
@@ -25,8 +25,6 @@ export async function format(source?: string): Promise<string> {
     return source
   }
 }
-
-export const mockedPluginDriver = createMockedPluginDriver()
 
 const parsers = new Map<`.${string}`, any>([['.ts', parserTs()]])
 

--- a/packages/plugin-react-query/src/utils.ts
+++ b/packages/plugin-react-query/src/utils.ts
@@ -5,7 +5,6 @@ import type { Infinite, ResolvedOptions } from './types.ts'
 
 export { buildQueryKeyParams, maybeValueOrGetter, resolveOperationOverrides } from '@internals/tanstack-query'
 export { buildClientOptionType, buildOperationComments as getComments, buildRequestConfigType } from '@internals/shared'
-export { resolveErrorNames, resolveSuccessNames }
 
 type OperationClassification = {
   isQuery: boolean

--- a/packages/plugin-swr/src/utils.ts
+++ b/packages/plugin-swr/src/utils.ts
@@ -1,2 +1,2 @@
-export { buildQueryKeyParams, resolveOperationOverrides } from '@internals/tanstack-query'
+export { buildQueryKeyParams } from '@internals/tanstack-query'
 export { buildClientOptionType, buildOperationComments as getComments, buildRequestConfigType, resolveErrorNames } from '@internals/shared'

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -267,7 +267,7 @@ export function appendJSDocToNode<TNode extends ts.Node>({ node, comments }: { n
  * Creates a TypeScript index signature for dynamic property access.
  * Defines the key type (default: `string`) and value type on an object.
  */
-export function createIndexSignature(
+function createIndexSignature(
   type: ts.TypeNode,
   {
     modifiers,
@@ -286,7 +286,7 @@ export function createIndexSignature(
 /**
  * Creates a TypeScript type alias declaration with optional modifiers and type parameters.
  */
-export function createTypeAliasDeclaration({
+function createTypeAliasDeclaration({
   modifiers,
   name,
   typeParameters,
@@ -303,7 +303,7 @@ export function createTypeAliasDeclaration({
 /**
  * Creates a TypeScript interface declaration with optional modifiers, type parameters, and members.
  */
-export function createInterfaceDeclaration({
+function createInterfaceDeclaration({
   modifiers,
   name,
   typeParameters,
@@ -791,62 +791,57 @@ export const createTypeReferenceNode = factory.createTypeReferenceNode
 /**
  * Creates a numeric literal type node.
  */
-export const createNumericLiteral = factory.createNumericLiteral
+const createNumericLiteral = factory.createNumericLiteral
 
 /**
  * Creates a string literal type node.
  */
-export const createStringLiteral = factory.createStringLiteral
+const createStringLiteral = factory.createStringLiteral
 
 /**
  * Creates an array type node (e.g., `T[]`).
  */
-export const createArrayTypeNode = factory.createArrayTypeNode
+const createArrayTypeNode = factory.createArrayTypeNode
 
 /**
  * Creates a literal type node (e.g., `'hello'`, `42`, `true`).
  */
-export const createLiteralTypeNode = factory.createLiteralTypeNode
+const createLiteralTypeNode = factory.createLiteralTypeNode
 
 /**
  * Creates an identifier node.
  */
-export const createIdentifier = factory.createIdentifier
+const createIdentifier = factory.createIdentifier
 
 /**
  * Creates an optional type node (e.g., `T | undefined`).
  */
-export const createOptionalTypeNode = factory.createOptionalTypeNode
+const createOptionalTypeNode = factory.createOptionalTypeNode
 
 /**
  * Creates a tuple type node (e.g., `[string, number]`).
  */
-export const createTupleTypeNode = factory.createTupleTypeNode
+const createTupleTypeNode = factory.createTupleTypeNode
 
 /**
  * Creates a rest type node for variadic tuple elements (e.g., `...T[]`).
  */
-export const createRestTypeNode = factory.createRestTypeNode
+const createRestTypeNode = factory.createRestTypeNode
 
 /**
  * Creates a boolean true literal type node.
  */
-export const createTrue = factory.createTrue
+const createTrue = factory.createTrue
 
 /**
  * Creates a boolean false literal type node.
  */
-export const createFalse = factory.createFalse
+const createFalse = factory.createFalse
 
 /**
  * Creates a prefix unary expression (e.g., negative numbers, logical not).
  */
-export const createPrefixUnaryExpression = factory.createPrefixUnaryExpression
-
-/**
- * Exports TypeScript SyntaxKind enum for AST node type checking.
- */
-export { SyntaxKind }
+const createPrefixUnaryExpression = factory.createPrefixUnaryExpression
 
 // ─── Printer helpers ──────────────────────────────────────────────────────────
 

--- a/packages/plugin-vue-query/src/utils.ts
+++ b/packages/plugin-vue-query/src/utils.ts
@@ -1,7 +1,7 @@
 import { getRequestGroups } from '@internals/shared'
 import type { ast } from 'kubb/kit'
 
-export { buildQueryKeyParams, maybeRefOrGetter, resolveOperationOverrides } from '@internals/tanstack-query'
+export { maybeRefOrGetter } from '@internals/tanstack-query'
 export { buildClientOptionType, buildOperationComments as getComments, buildRequestConfigType, resolveErrorNames, resolveSuccessNames } from '@internals/shared'
 
 const requestGroupOrder = ['path', 'query', 'body', 'headers'] as const


### PR DESCRIPTION
## 🎯 Changes

Ran [Fallow](https://fallow.tools) (`fallow dead-code --format json --quiet --unused-exports` and `fallow dupes --mode mild`) over the repo. It flagged 1676 unused exports, but nearly all of them live in Kubb-generated output (`tests/3.0.x`, `examples/*`, `__snapshots__`) that has to stay as-is. This PR fixes the hand-written ones:

- `packages/plugin-ts/src/factory.ts`: 14 factory helpers (`createIndexSignature`, `createTypeAliasDeclaration`, `createInterfaceDeclaration`, and the `factory.*` aliases like `createIdentifier`, `createTrue`, `createFalse`) are now module-private, and the unused `export { SyntaxKind }` statement is gone. Every one of them is still used inside the file; nothing imported them from outside, including `factory.test.ts`.
- `packages/plugin-react-query/src/utils.ts`: drops the `export { resolveErrorNames, resolveSuccessNames }` re-export. Both are still imported and used internally by `buildResponseTypes`.
- `packages/plugin-swr/src/utils.ts`: drops the unused `resolveOperationOverrides` re-export.
- `packages/plugin-vue-query/src/utils.ts`: drops the unused `buildQueryKeyParams` and `resolveOperationOverrides` re-exports.
- `configs/mocks.ts`: deletes the unused `mockedPluginDriver` and its now-unneeded import.

None of these symbols are reachable through a package's public `exports` map (each plugin exposes only `.`), so the published API is unchanged. A changeset with patch bumps for the four touched packages is included.

Duplication scan for reference (`fallow dupes`): the biggest hand-written clone families are the `serializers.ts` template shared verbatim between plugin-axios and plugin-fetch (427 lines), large shared blocks between `templates/axios.ts` and `templates/fetch.ts`, and the InfiniteQueryOptions/SuspenseInfiniteQueryOptions components in react-query/vue-query. Consolidating those is a bigger refactor left out of this PR.

Verified with `pnpm turbo run typecheck` and `test` for the four packages (all green), `pnpm lint`, and `pnpm format`. A rerun of Fallow reports no remaining unused exports in `packages/`, `internals/`, or `configs/`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dHSbuoSN5pYaXowWwZj5B

---
_Generated by [Claude Code](https://claude.ai/code/session_014dHSbuoSN5pYaXowWwZj5B)_