### PR TITLE
refactor(plugin-zod): share printer helpers between printerZod and printerZodMini

### DIFF
--- a/.changeset/share-zod-printer-helpers.md
+++ b/.changeset/share-zod-printer-helpers.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-zod": patch
+---
+
+Share the traversal and formatting logic between `printerZod` and `printerZodMini` in a single `printers/shared.ts` module, parameterized by a `ZodDialect` that carries the few emissions where the chainable and `zod/mini` APIs differ. Generated output is unchanged; a fix applied to the shared traversal now reaches both printers instead of silently missing one (kubb-labs/plugins#674).

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -1,20 +1,8 @@
-import { buildList, buildObject, lazyGetter, objectKey, stringify } from '@internals/utils'
 import { ast } from 'kubb/kit'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import {
-  applyModifiers,
-  buildEnum,
-  containsCodec,
-  formatLiteral,
-  getCodec,
-  isObjectComposableIntersection,
-  isObjectSchemaNode,
-  lengthConstraints,
-  numberConstraints,
-  omitUnwrapChain,
-  patternKeySchema,
-  shouldCoerce,
-} from '../utils.ts'
+import { applyModifiers, getCodec, lengthConstraints, numberConstraints, patternKeySchema, shouldCoerce } from '../utils.ts'
+import { sharedZodNodes } from './shared.ts'
+import type { ZodDialect } from './shared.ts'
 import type { AdapterOas } from '@kubb/adapter-oas'
 
 /**
@@ -108,30 +96,30 @@ export type PrinterZodOptions = {
  */
 export type PrinterZodFactory = ast.PrinterFactoryOptions<'zod', PrinterZodOptions, string, string>
 
-function strictOneOfMember(member: string, node: ast.SchemaNode, cyclicSchemas?: ReadonlySet<string>): string {
-  if (node.type === 'object' && node.additionalProperties === undefined) {
+function strictOneOfMember({ member, schema, cyclicSchemas }: { member: string; schema: ast.SchemaNode; cyclicSchemas?: ReadonlySet<string> }): string {
+  if (schema.type === 'object' && schema.additionalProperties === undefined) {
     return `${member}.strict()`
   }
 
-  if (node.type === 'ref') {
+  if (schema.type === 'ref') {
     if (member.startsWith('z.lazy(')) {
       return member
     }
 
     // A cyclic ref is annotated `z.ZodType`, and a nullable/optional ref is wrapped in
     // ZodNullable/ZodOptional, and neither exposes `.strict()`. Only a bare `ZodObject` ref takes it.
-    const refName = ast.resolveRefName(node)
+    const refName = ast.resolveRefName(schema)
     if (refName && cyclicSchemas?.has(refName)) {
       return member
     }
 
-    const schema = ast.syncSchemaRef(node)
+    const resolved = ast.syncSchemaRef(schema)
 
-    if (schema.nullable || schema.optional || node.nullable || node.optional) {
+    if (resolved.nullable || resolved.optional || schema.nullable || schema.optional) {
       return member
     }
 
-    if (schema.type === 'object' && (schema.additionalProperties === undefined || schema.additionalProperties === false)) {
+    if (resolved.type === 'object' && (resolved.additionalProperties === undefined || resolved.additionalProperties === false)) {
       return `${member}.strict()`
     }
   }
@@ -139,67 +127,20 @@ function strictOneOfMember(member: string, node: ast.SchemaNode, cyclicSchemas?:
   return member
 }
 
-function getMemberConstraint({ member, regexType }: { member: ast.SchemaNode; regexType: PrinterZodOptions['regexType'] }): string | undefined {
-  if (member.primitive === 'string') return lengthConstraints({ ...(ast.narrowSchema(member, 'string') ?? {}), regexType }) || undefined
-  if (member.primitive === 'number' || member.primitive === 'integer')
-    return numberConstraints(ast.narrowSchema(member, 'number') ?? ast.narrowSchema(member, 'integer') ?? {}) || undefined
-  if (member.primitive === 'array') return lengthConstraints({ ...(ast.narrowSchema(member, 'array') ?? {}), regexType }) || undefined
-}
-
 /**
- * The printer slice `buildZodObjectShape` needs: the recursive `transform` and the resolved options.
+ * Chainable Zod v4 emission for the shared printer handlers.
  */
-type ZodPrinterContext = {
-  transform: (node: ast.SchemaNode) => string | null
-  options: PrinterZodOptions
-}
-
-/**
- * Builds the `{ key: value, … }` shape for an object node, shared by the `z.object(...)` and
- * `.extend(...)` renderings so they stay in lockstep.
- */
-function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): string {
-  const objectNode = ast.narrowSchema(node, 'object')
-  if (!objectNode) return '{}'
-
-  const isCyclic = (schema: ast.SchemaNode): boolean =>
-    ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
-
-  const entries = ast
-    .mapSchemaProperties(objectNode, (schema) => {
-      // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
-      // nested refs by temporarily clearing cyclicSchemas.
-      const hasSelfRef = isCyclic(schema)
-      const savedCyclicSchemas = ctx.options.cyclicSchemas
-      if (hasSelfRef) ctx.options.cyclicSchemas = undefined
-      const baseOutput = ctx.transform(schema) ?? ctx.transform(ast.factory.createSchema({ type: 'unknown' }))!
-      if (hasSelfRef) ctx.options.cyclicSchemas = savedCyclicSchemas
-      return baseOutput
-    })
-    .map(({ name: propName, property, output: baseOutput }) => {
-      const { schema } = property
-      const meta = ast.syncSchemaRef(schema)
-
-      // When a property schema is not a ref but the metadata is from a ref (e.g., discriminator
-      // property override), skip applying the description from the ref target to avoid applying
-      // metadata from a replaced schema.
-      const descriptionToApply = schema.type !== 'ref' && meta.type === 'ref' ? undefined : meta.description
-
-      const value = applyModifiers({
-        value: baseOutput,
-        schema,
-        nullable: meta.nullable,
-        optional: schema.optional || property.required === false,
-        nullish: schema.nullish,
-        defaultValue: meta.default,
-        description: descriptionToApply,
-        examples: meta.examples,
-      })
-
-      return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
-    })
-
-  return buildObject(entries)
+const zodDialect: ZodDialect = {
+  applyModifiers,
+  lengthConstraints,
+  numberConstraints,
+  patternKeySchema,
+  nullable: (value) => `${value}.nullable()`,
+  strictObject: (objectBase) => `${objectBase}.strict()`,
+  catchall: ({ objectBase, value }) => `${objectBase}.catchall(${value})`,
+  extend: ({ base, shape }) => `${base}.extend(${shape})`,
+  intersect: ({ base, member }) => `${base}.and(${member})`,
+  strictOneOfMember,
 }
 
 /**
@@ -215,20 +156,13 @@ function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): stri
  * ```
  */
 export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
-  // The object handler temporarily reassigns `options.cyclicSchemas` to `undefined` while rendering a
-  // getter body (to suppress nested `z.lazy()`), so capture a stable reference for the `.strict()`
-  // skip decision, which must still see cyclic members inside those getter bodies.
-  const cyclicSchemaNames = options.cyclicSchemas
+  const shared = sharedZodNodes({ dialect: zodDialect, cyclicSchemas: options.cyclicSchemas })
+
   return {
     name: 'zod',
     options,
     nodes: {
-      any: () => 'z.any()',
-      unknown: () => 'z.unknown()',
-      void: () => 'z.void()',
-      never: () => 'z.never()',
-      boolean: () => 'z.boolean()',
-      null: () => 'z.null()',
+      ...shared.nodes,
       string(node) {
         const base = shouldCoerce(this.options.coercion, 'strings') ? 'z.coerce.string()' : 'z.string()'
 
@@ -273,183 +207,8 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
 
         return shouldCoerce(this.options.coercion, 'dates') ? 'z.coerce.date()' : 'z.date()'
       },
-      uuid(node) {
-        const base = this.options.guidType === 'guid' ? 'z.guid()' : 'z.uuid()'
-
-        return `${base}${lengthConstraints({ ...node, regexType: this.options.regexType })}`
-      },
-      email(node) {
-        return `z.email()${lengthConstraints({ ...node, regexType: this.options.regexType })}`
-      },
-      url(node) {
-        return `z.url()${lengthConstraints({ ...node, regexType: this.options.regexType })}`
-      },
-      ipv4: () => 'z.ipv4()',
-      ipv6: () => 'z.ipv6()',
-      blob: () => 'z.instanceof(File)',
-      enum(node) {
-        const values = node.namedEnumValues?.map((v) => v.value) ?? node.enumValues ?? []
-        const nonNullValues = values.filter((v): v is string | number | boolean => v !== null)
-
-        // asConst-style enum: use z.union([z.literal(…), …])
-        if (node.namedEnumValues?.length) {
-          const literals = nonNullValues.map((v) => `z.literal(${formatLiteral(v)})`)
-
-          if (literals.length === 1) return literals[0]!
-          return `z.union([${literals.join(', ')}])`
-        }
-
-        // Regular enum: z.enum for all-string sets, z.literal/z.union otherwise
-        return buildEnum(nonNullValues)
-      },
-      ref(node) {
-        if (!node.name) return null
-        const refName = ast.resolveRefName(node)
-        if (!refName) return null
-
-        // In the input direction, a date-bearing component resolves to its `${name}InputSchema`
-        // variant so request bodies encode `Date → string` instead of decoding.
-        const useInputVariant = node.ref != null && this.options.direction === 'input' && containsCodec(node)
-        const resolvedName = node.ref
-          ? useInputVariant
-            ? (this.options.resolver?.schema.inputName(refName) ?? refName)
-            : (this.options.resolver?.name(refName) ?? refName)
-          : node.name
-
-        if (node.ref && this.options.cyclicSchemas?.has(refName)) {
-          return `z.lazy(() => ${resolvedName})`
-        }
-
-        return resolvedName
-      },
-      object(node) {
-        const entries = node.properties ?? []
-        const objectBase = `z.object(${buildZodObjectShape(this, node)})`
-
-        const result = (() => {
-          const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
-
-          if (node.additionalProperties && node.additionalProperties !== true) {
-            const catchallType = this.transform(node.additionalProperties)
-            return catchallType ? `${objectBase}.catchall(${catchallType})` : objectBase
-          }
-          if (node.additionalProperties === true) return `${objectBase}.catchall(${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
-          // `additionalProperties: false` still permits patternProperties keys, so skip `.strict()` when patterns exist.
-          if (node.additionalProperties === false && patterns.length === 0) return `${objectBase}.strict()`
-
-          // No fixed properties: z.record enforces the key pattern. With fixed properties a record would
-          // reject the declared keys, so fall back to .catchall (value validated, key pattern not).
-          if (patterns.length > 0) {
-            const values = patterns.map(([, valueSchema]) => {
-              const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
-              return valueSchema.nullable ? `${valueType}.nullable()` : valueType
-            })
-            const distinct = [...new Set(values)]
-            const value = distinct.length === 1 ? distinct[0]! : `z.union([${distinct.join(', ')}])`
-
-            if (entries.length > 0) return `${objectBase}.catchall(${value})`
-            return `z.record(${patternKeySchema({ patterns: patterns.map(([pattern]) => pattern), regexType: this.options.regexType })}, ${value})`
-          }
-          return objectBase
-        })()
-
-        return result
-      },
-      array(node) {
-        const items = ast
-          .mapSchemaItems(node, (item) => this.transform(item))
-          .map(({ output }) => output)
-          .filter(Boolean)
-        const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
-        const base = `z.array(${inner})${lengthConstraints({ ...node, regexType: this.options.regexType })}`
-
-        return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
-      },
-      tuple(node) {
-        const items = ast
-          .mapSchemaItems(node, (item) => this.transform(item))
-          .map(({ output }) => output)
-          .filter(Boolean)
-
-        return `z.tuple(${buildList(items)})`
-      },
-      union(node) {
-        const nodeMembers = node.members ?? []
-        const members = ast
-          .mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
-          .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema, cyclicSchemaNames) : output))
-          .filter(Boolean)
-        if (members.length === 0) return ''
-        if (members.length === 1) return members[0]!
-        // z.discriminatedUnion needs every option to be a ZodObject. Object variants (refs or
-        // `.extend(…)`-composed `allOf`) qualify; intersections, cyclic `z.lazy(…)` refs, and
-        // non-objects fall back to z.union.
-        const allDiscriminable = nodeMembers.every((m) => isObjectSchemaNode(m, cyclicSchemaNames))
-        if (node.discriminatorPropertyName && allDiscriminable) {
-          return `z.discriminatedUnion(${stringify(node.discriminatorPropertyName)}, ${buildList(members)})`
-        }
-
-        return `z.union(${buildList(members)})`
-      },
-      intersection(node) {
-        const members = node.members ?? []
-        if (members.length === 0) return ''
-
-        const [first, ...rest] = members
-        if (!first) return ''
-
-        const firstBase = this.transform(first)
-        if (!firstBase) return ''
-
-        // An object `allOf` is a merge, not a runtime intersection: `.extend({ … })` keeps it a
-        // ZodObject (usable in z.discriminatedUnion) instead of the non-discriminable `.and(…)`.
-        if (rest.length > 0 && isObjectComposableIntersection(node, cyclicSchemaNames)) {
-          return rest.reduce((acc, member) => `${acc}.extend(${buildZodObjectShape(this, member)})`, firstBase)
-        }
-
-        return rest.reduce((acc, member) => {
-          const constraint = getMemberConstraint({ member, regexType: this.options.regexType })
-          if (constraint) return acc + constraint
-          const transformed = this.transform(member)
-          return transformed ? `${acc}.and(${transformed})` : acc
-        }, firstBase)
-      },
     },
     overrides: options.nodes,
-    print(node) {
-      const { keysToOmit } = this.options
-
-      const transformed = this.transform(node)
-      if (!transformed) return null
-
-      const meta = ast.syncSchemaRef(node)
-
-      const base = (() => {
-        if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed
-        // Discriminated unions (z.discriminatedUnion) do not support .omit(), so skip them.
-
-        // A nullable/optional ref resolves to a ZodNullable/ZodOptional variable; .omit() lives on
-        // the inner ZodObject, so unwrap down to it first (mirrors printerTs `Omit<NonNullable<T>, …>`).
-        // applyModifiers re-applies the nullable/optional wrapper after the omit.
-        const unwrap = omitUnwrapChain(node)
-        const omit = `.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} })`
-
-        // If this is a lazy reference, apply omit inside the lazy function
-        const lazyMatch = transformed.match(/^z\.lazy\(\(\)\s*=>\s*(.+)\)$/)
-        if (lazyMatch) return `z.lazy(() => ${lazyMatch[1]}${unwrap}${omit})`
-        return `${transformed}${unwrap}${omit}`
-      })()
-
-      return applyModifiers({
-        value: base,
-        schema: node,
-        nullable: meta.nullable,
-        optional: meta.optional,
-        nullish: meta.nullish,
-        defaultValue: meta.default,
-        description: meta.description,
-        examples: meta.examples,
-      })
-    },
+    print: shared.print,
   }
 })

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -1,17 +1,8 @@
-import { buildList, buildObject, lazyGetter, objectKey, stringify } from '@internals/utils'
 import { ast } from 'kubb/kit'
 import type { PluginZod, ResolverZod } from '../types.ts'
-import {
-  applyMiniModifiers,
-  buildEnum,
-  formatLiteral,
-  isObjectComposableIntersection,
-  isObjectSchemaNode,
-  lengthChecksMini,
-  numberChecksMini,
-  omitUnwrapChain,
-  patternKeySchemaMini,
-} from '../utils.ts'
+import { applyMiniModifiers, lengthChecksMini, numberChecksMini, patternKeySchemaMini } from '../utils.ts'
+import { sharedZodNodes } from './shared.ts'
+import type { ZodDialect } from './shared.ts'
 
 /**
  * Partial map of node-type overrides for the Zod Mini printer.
@@ -75,66 +66,48 @@ export type PrinterZodMiniOptions = {
  */
 export type PrinterZodMiniFactory = ast.PrinterFactoryOptions<'zod-mini', PrinterZodMiniOptions, string, string>
 
-function strictOneOfMember(member: string, node: ast.SchemaNode): string {
-  if (node.type === 'object' && (node.additionalProperties === undefined || node.additionalProperties === false)) {
+function strictOneOfMember({ member, schema }: { member: string; schema: ast.SchemaNode }): string {
+  if (schema.type === 'object' && (schema.additionalProperties === undefined || schema.additionalProperties === false)) {
     return member.replace(/^z\.object\(/, 'z.strictObject(')
   }
 
   return member
 }
 
-function getMemberConstraintMini({ member, regexType }: { member: ast.SchemaNode; regexType: PrinterZodMiniOptions['regexType'] }): string | undefined {
-  if (member.primitive === 'string') return lengthChecksMini({ ...(ast.narrowSchema(member, 'string') ?? {}), regexType }) || undefined
-  if (member.primitive === 'number' || member.primitive === 'integer')
-    return numberChecksMini(ast.narrowSchema(member, 'number') ?? ast.narrowSchema(member, 'integer') ?? {}) || undefined
-  if (member.primitive === 'array') return lengthChecksMini({ ...(ast.narrowSchema(member, 'array') ?? {}), regexType }) || undefined
+function nullableMini(value: string): string {
+  return `z.nullable(${value})`
+}
+
+function strictObjectMini(objectBase: string): string {
+  return objectBase.replace(/^z\.object\(/, 'z.strictObject(')
+}
+
+function catchallMini({ objectBase, value }: { objectBase: string; value: string }): string {
+  return `z.catchall(${objectBase}, ${value})`
+}
+
+function extendMini({ base, shape }: { base: string; shape: string }): string {
+  return `z.extend(${base}, ${shape})`
+}
+
+function intersectionMini({ base, member }: { base: string; member: string }): string {
+  return `z.intersection(${base}, ${member})`
 }
 
 /**
- * The Mini printer slice `buildZodMiniObjectShape` needs: the recursive `transform` and the options.
+ * Functional `zod/mini` emission for the shared printer handlers.
  */
-type ZodMiniPrinterContext = {
-  transform: (node: ast.SchemaNode) => string | null
-  options: PrinterZodMiniOptions
-}
-
-/**
- * Builds the `{ key: value, … }` shape for an object node with the functional `zod/mini` modifiers,
- * shared by the `z.object(...)` and `z.extend(...)` renderings so they stay in lockstep.
- */
-function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNode): string {
-  const objectNode = ast.narrowSchema(node, 'object')
-  if (!objectNode) return '{}'
-
-  const isCyclic = (schema: ast.SchemaNode): boolean =>
-    ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
-
-  const entries = ast
-    .mapSchemaProperties(objectNode, (schema) => {
-      const hasSelfRef = isCyclic(schema)
-      const savedCyclicSchemas = ctx.options.cyclicSchemas
-      if (hasSelfRef) ctx.options.cyclicSchemas = undefined
-      const baseOutput = ctx.transform(schema) ?? ctx.transform(ast.factory.createSchema({ type: 'unknown' }))!
-      if (hasSelfRef) ctx.options.cyclicSchemas = savedCyclicSchemas
-      return baseOutput
-    })
-    .map(({ name: propName, property, output: baseOutput }) => {
-      const { schema } = property
-      const meta = ast.syncSchemaRef(schema)
-
-      const value = applyMiniModifiers({
-        value: baseOutput,
-        schema,
-        nullable: meta.nullable,
-        optional: schema.optional || property.required === false,
-        nullish: schema.nullish,
-        defaultValue: meta.default,
-      })
-
-      return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
-    })
-
-  return buildObject(entries)
+const zodMiniDialect: ZodDialect = {
+  applyModifiers: applyMiniModifiers,
+  lengthConstraints: lengthChecksMini,
+  numberConstraints: numberChecksMini,
+  patternKeySchema: patternKeySchemaMini,
+  nullable: nullableMini,
+  strictObject: strictObjectMini,
+  catchall: catchallMini,
+  extend: extendMini,
+  intersect: intersectionMini,
+  strictOneOfMember,
 }
 
 /**
@@ -150,19 +123,13 @@ function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNod
  * ```
  */
 export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options) => {
-  // The object handler temporarily clears `options.cyclicSchemas` while rendering a getter body, so
-  // capture a stable reference for the intersection/union discriminability decisions.
-  const cyclicSchemaNames = options.cyclicSchemas
+  const shared = sharedZodNodes({ dialect: zodMiniDialect, cyclicSchemas: options.cyclicSchemas })
+
   return {
     name: 'zod-mini',
     options,
     nodes: {
-      any: () => 'z.any()',
-      unknown: () => 'z.unknown()',
-      void: () => 'z.void()',
-      never: () => 'z.never()',
-      boolean: () => 'z.boolean()',
-      null: () => 'z.null()',
+      ...shared.nodes,
       string(node) {
         return `z.string()${lengthChecksMini({ ...node, regexType: this.options.regexType })}`
       },
@@ -193,167 +160,8 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
 
         return 'z.date()'
       },
-      uuid(node) {
-        const base = this.options.guidType === 'guid' ? 'z.guid()' : 'z.uuid()'
-
-        return `${base}${lengthChecksMini({ ...node, regexType: this.options.regexType })}`
-      },
-      email(node) {
-        return `z.email()${lengthChecksMini({ ...node, regexType: this.options.regexType })}`
-      },
-      url(node) {
-        return `z.url()${lengthChecksMini({ ...node, regexType: this.options.regexType })}`
-      },
-      ipv4: () => 'z.ipv4()',
-      ipv6: () => 'z.ipv6()',
-      blob: () => 'z.instanceof(File)',
-      enum(node) {
-        const values = node.namedEnumValues?.map((v) => v.value) ?? node.enumValues ?? []
-        const nonNullValues = values.filter((v): v is string | number | boolean => v !== null)
-
-        // asConst-style enum: use z.union([z.literal(…), …])
-        if (node.namedEnumValues?.length) {
-          const literals = nonNullValues.map((v) => `z.literal(${formatLiteral(v)})`)
-          if (literals.length === 1) return literals[0]!
-          return `z.union([${literals.join(', ')}])`
-        }
-
-        // Regular enum: z.enum for all-string sets, z.literal/z.union otherwise
-        return buildEnum(nonNullValues)
-      },
-
-      ref(node) {
-        if (!node.name) return null
-        const refName = ast.resolveRefName(node)
-        if (!refName) return null
-        const resolvedName = node.ref ? (this.options.resolver?.name(refName) ?? refName) : node.name
-
-        if (node.ref && this.options.cyclicSchemas?.has(refName)) {
-          return `z.lazy(() => ${resolvedName})`
-        }
-
-        return resolvedName
-      },
-      object(node) {
-        const entries = node.properties ?? []
-        const objectBase = `z.object(${buildZodMiniObjectShape(this, node)})`
-
-        // zod/mini has no chainable `.catchall()`/`.strict()`, so route through the functional forms.
-        const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
-
-        if (node.additionalProperties && node.additionalProperties !== true) {
-          const catchallType = this.transform(node.additionalProperties)
-          return catchallType ? `z.catchall(${objectBase}, ${catchallType})` : objectBase
-        }
-        if (node.additionalProperties === true) return `z.catchall(${objectBase}, ${this.transform(ast.factory.createSchema({ type: 'unknown' }))})`
-        if (node.additionalProperties === false && patterns.length === 0) return objectBase.replace(/^z\.object\(/, 'z.strictObject(')
-
-        if (patterns.length > 0) {
-          const values = patterns.map(([, valueSchema]) => {
-            const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
-            return valueSchema.nullable ? `z.nullable(${valueType})` : valueType
-          })
-          const distinct = [...new Set(values)]
-          const value = distinct.length === 1 ? distinct[0]! : `z.union([${distinct.join(', ')}])`
-
-          if (entries.length > 0) return `z.catchall(${objectBase}, ${value})`
-          return `z.record(${patternKeySchemaMini({ patterns: patterns.map(([pattern]) => pattern), regexType: this.options.regexType })}, ${value})`
-        }
-        return objectBase
-      },
-      array(node) {
-        const items = ast
-          .mapSchemaItems(node, (item) => this.transform(item))
-          .map(({ output }) => output)
-          .filter(Boolean)
-        const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
-        const base = `z.array(${inner})${lengthChecksMini({ ...node, regexType: this.options.regexType })}`
-
-        return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
-      },
-      tuple(node) {
-        const items = ast
-          .mapSchemaItems(node, (item) => this.transform(item))
-          .map(({ output }) => output)
-          .filter(Boolean)
-
-        return `z.tuple(${buildList(items)})`
-      },
-      union(node) {
-        const nodeMembers = node.members ?? []
-        const members = ast
-          .mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
-          .map(({ schema, output }) => (output && node.strategy === 'one' ? strictOneOfMember(output, schema) : output))
-          .filter(Boolean)
-        if (members.length === 0) return ''
-        if (members.length === 1) return members[0]!
-        // z.discriminatedUnion needs every option to be a Zod object. Object variants (refs or
-        // `z.extend(…)`-composed `allOf`) qualify; intersections, cyclic `z.lazy(…)` refs, and
-        // non-objects fall back to z.union.
-        const allDiscriminable = nodeMembers.every((m) => isObjectSchemaNode(m, cyclicSchemaNames))
-        if (node.discriminatorPropertyName && allDiscriminable) {
-          return `z.discriminatedUnion(${stringify(node.discriminatorPropertyName)}, ${buildList(members)})`
-        }
-
-        return `z.union(${buildList(members)})`
-      },
-      intersection(node) {
-        const members = node.members ?? []
-        if (members.length === 0) return ''
-
-        const [first, ...rest] = members
-        if (!first) return ''
-
-        const firstBase = this.transform(first)
-        if (!firstBase) return ''
-
-        // An object `allOf` is a merge, not a runtime intersection: `z.extend(base, { … })` keeps it
-        // a Zod object (usable in z.discriminatedUnion) instead of a non-discriminable `z.intersection`.
-        if (rest.length > 0 && isObjectComposableIntersection(node, cyclicSchemaNames)) {
-          return rest.reduce((acc, member) => `z.extend(${acc}, ${buildZodMiniObjectShape(this, member)})`, firstBase)
-        }
-
-        return rest.reduce((acc, member) => {
-          const constraint = getMemberConstraintMini({ member, regexType: this.options.regexType })
-          if (constraint) return acc + constraint
-          const transformed = this.transform(member)
-          return transformed ? `z.intersection(${acc}, ${transformed})` : acc
-        }, firstBase)
-      },
     },
     overrides: options.nodes,
-    print(node) {
-      const { keysToOmit } = this.options
-
-      const transformed = this.transform(node)
-      if (!transformed) return null
-
-      const meta = ast.syncSchemaRef(node)
-
-      const base = (() => {
-        if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed
-        // Discriminated unions (z.discriminatedUnion) do not support .omit(), so skip them.
-
-        // A nullable/optional ref resolves to a ZodMiniNullable/ZodMiniOptional variable; .omit() lives
-        // on the inner object, so unwrap down to it first (mirrors printerTs `Omit<NonNullable<T>, …>`).
-        // applyMiniModifiers re-applies the nullable/optional wrapper after the omit.
-        const unwrap = omitUnwrapChain(node)
-        const omit = `.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} })`
-
-        // If this is a lazy reference, apply omit inside the lazy function
-        const lazyMatch = transformed.match(/^z\.lazy\(\(\)\s*=>\s*(.+)\)$/)
-        if (lazyMatch) return `z.lazy(() => ${lazyMatch[1]}${unwrap}${omit})`
-        return `${transformed}${unwrap}${omit}`
-      })()
-
-      return applyMiniModifiers({
-        value: base,
-        schema: node,
-        nullable: meta.nullable,
-        optional: meta.optional,
-        nullish: meta.nullish,
-        defaultValue: meta.default,
-      })
-    },
+    print: shared.print,
   }
 })

--- a/packages/plugin-zod/src/printers/shared.ts
+++ b/packages/plugin-zod/src/printers/shared.ts
@@ -1,0 +1,375 @@
+import { buildList, buildObject, lazyGetter, objectKey, stringify } from '@internals/utils'
+import { ast } from 'kubb/kit'
+import type { PluginZod, ResolverZod } from '../types.ts'
+import { buildEnum, containsCodec, formatLiteral, isObjectComposableIntersection, isObjectSchemaNode, omitUnwrapChain } from '../utils.ts'
+import type { LengthConstraints, ModifierOptions, NumericConstraints } from '../utils.ts'
+
+/**
+ * The slice of printer options the shared handlers read. Both `PrinterZodOptions` and
+ * `PrinterZodMiniOptions` satisfy this shape; `direction` only exists on the classic printer
+ * and stays `undefined` for `zod/mini`.
+ */
+export type SharedPrinterOptions = {
+  /**
+   * Use `z.guid()` or `z.uuid()` for UUID/GUID validation.
+   */
+  guidType?: PluginZod['resolvedOptions']['guidType']
+  /**
+   * Output form for an OpenAPI `pattern`: a regex literal (`'literal'`) or the
+   * `RegExp` constructor (`'constructor'`).
+   */
+  regexType?: PluginZod['resolvedOptions']['regexType']
+  /**
+   * Transforms raw schema names into valid JavaScript identifiers.
+   */
+  resolver?: ResolverZod
+  /**
+   * Properties to exclude using `.omit({ key: true })`.
+   */
+  keysToOmit?: Array<string> | null
+  /**
+   * Schema names that form circular dependency chains.
+   */
+  cyclicSchemas?: ReadonlySet<string>
+  /**
+   * Print direction for codec-bearing fields. Only the classic printer sets this.
+   */
+  direction?: 'input' | 'output'
+}
+
+/**
+ * The printer context the shared handlers need: the recursive `transform` and the resolved options.
+ */
+type SharedPrinterContext = {
+  transform: (node: ast.SchemaNode) => string | null
+  options: SharedPrinterOptions
+}
+
+/**
+ * The zod-API-specific emission the shared traversal is parameterized by. `printerZod` maps these
+ * to the chainable Zod v4 API (`.catchall(…)`, `.strict()`), `printerZodMini` to the functional
+ * `zod/mini` forms (`z.catchall(…)`, `z.strictObject(…)`).
+ */
+export type ZodDialect = {
+  /**
+   * Apply nullable / optional / nullish / default modifiers to a schema value. The classic API
+   * also applies `.describe()` and `.meta({ examples })`; `zod/mini` ignores both.
+   */
+  applyModifiers(options: ModifierOptions): string
+  /**
+   * Build min / max / pattern constraints for strings and arrays.
+   */
+  lengthConstraints(constraints: LengthConstraints): string
+  /**
+   * Build numeric bound constraints.
+   */
+  numberConstraints(constraints: NumericConstraints): string
+  /**
+   * Build the record key schema enforcing `patternProperties` regexes.
+   */
+  patternKeySchema(options: { patterns: Array<string>; regexType?: SharedPrinterOptions['regexType'] }): string
+  /**
+   * Wrap a value schema as nullable.
+   */
+  nullable(value: string): string
+  /**
+   * Turn a rendered `z.object(…)` into its strict variant.
+   */
+  strictObject(objectBase: string): string
+  /**
+   * Attach a catchall schema for `additionalProperties`.
+   */
+  catchall(options: { objectBase: string; value: string }): string
+  /**
+   * Merge an inline object shape into an object base (`allOf` composition), keeping the result a
+   * Zod object usable in `z.discriminatedUnion`.
+   */
+  extend(options: { base: string; shape: string }): string
+  /**
+   * Combine two members as a runtime intersection.
+   */
+  intersect(options: { base: string; member: string }): string
+  /**
+   * Tighten a `oneOf` member so unknown keys fail validation, when the member supports it.
+   */
+  strictOneOfMember(options: { member: string; schema: ast.SchemaNode; cyclicSchemas?: ReadonlySet<string> }): string
+}
+
+type BuildObjectShapeOptions = {
+  ctx: SharedPrinterContext
+  node: ast.SchemaNode
+  dialect: ZodDialect
+}
+
+/**
+ * Builds the `{ key: value, … }` shape for an object node, shared by the object and
+ * extend renderings so they stay in lockstep.
+ */
+function buildObjectShape({ ctx, node, dialect }: BuildObjectShapeOptions): string {
+  const objectNode = ast.narrowSchema(node, 'object')
+  if (!objectNode) return '{}'
+
+  const isCyclic = (schema: ast.SchemaNode): boolean =>
+    ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
+
+  const entries = ast
+    .mapSchemaProperties(objectNode, (schema) => {
+      // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
+      // nested refs by temporarily clearing cyclicSchemas.
+      const hasSelfRef = isCyclic(schema)
+      const savedCyclicSchemas = ctx.options.cyclicSchemas
+      if (hasSelfRef) ctx.options.cyclicSchemas = undefined
+      const baseOutput = ctx.transform(schema) ?? ctx.transform(ast.factory.createSchema({ type: 'unknown' }))!
+      if (hasSelfRef) ctx.options.cyclicSchemas = savedCyclicSchemas
+      return baseOutput
+    })
+    .map(({ name: propName, property, output: baseOutput }) => {
+      const { schema } = property
+      const meta = ast.syncSchemaRef(schema)
+
+      // When a property schema is not a ref but the metadata is from a ref (e.g., discriminator
+      // property override), skip applying the description from the ref target to avoid applying
+      // metadata from a replaced schema.
+      const descriptionToApply = schema.type !== 'ref' && meta.type === 'ref' ? undefined : meta.description
+
+      const value = dialect.applyModifiers({
+        value: baseOutput,
+        schema,
+        nullable: meta.nullable,
+        optional: schema.optional || property.required === false,
+        nullish: schema.nullish,
+        defaultValue: meta.default,
+        description: descriptionToApply,
+        examples: meta.examples,
+      })
+
+      return isCyclic(schema) ? lazyGetter({ name: propName, body: value }) : `${objectKey(propName)}: ${value}`
+    })
+
+  return buildObject(entries)
+}
+
+type TransformItemsOptions = {
+  ctx: SharedPrinterContext
+  node: ast.ArraySchemaNode
+}
+
+function transformItems({ ctx, node }: TransformItemsOptions): Array<string> {
+  return ast
+    .mapSchemaItems(node, (item) => ctx.transform(item))
+    .map(({ output }) => output)
+    .filter((output): output is string => Boolean(output))
+}
+
+type MemberConstraintOptions = {
+  member: ast.SchemaNode
+  regexType: SharedPrinterOptions['regexType']
+  dialect: ZodDialect
+}
+
+function memberConstraint({ member, regexType, dialect }: MemberConstraintOptions): string | undefined {
+  if (member.primitive === 'string') return dialect.lengthConstraints({ ...(ast.narrowSchema(member, 'string') ?? {}), regexType }) || undefined
+  if (member.primitive === 'number' || member.primitive === 'integer')
+    return dialect.numberConstraints(ast.narrowSchema(member, 'number') ?? ast.narrowSchema(member, 'integer') ?? {}) || undefined
+  if (member.primitive === 'array') return dialect.lengthConstraints({ ...(ast.narrowSchema(member, 'array') ?? {}), regexType }) || undefined
+}
+
+type SharedZodNodesOptions = {
+  dialect: ZodDialect
+  /**
+   * Stable snapshot of the printer's `cyclicSchemas`. The object handler temporarily clears
+   * `options.cyclicSchemas` while rendering a getter body, but the `oneOf` strictness and
+   * discriminability decisions must still see cyclic members inside those bodies.
+   */
+  cyclicSchemas?: ReadonlySet<string>
+}
+
+/**
+ * Shared node handlers and root `print` for the two Zod printers. Everything here is the
+ * traversal and formatting both APIs agree on; the API-specific emission comes in through
+ * `dialect`. The node types left out (`string`, `number`, `integer`, `bigint`, `date`,
+ * `datetime`, `time`) genuinely differ between zod and zod/mini and live in each printer.
+ */
+export function sharedZodNodes({ dialect, cyclicSchemas }: SharedZodNodesOptions) {
+  const nodes = {
+    any: () => 'z.any()',
+    unknown: () => 'z.unknown()',
+    void: () => 'z.void()',
+    never: () => 'z.never()',
+    boolean: () => 'z.boolean()',
+    null: () => 'z.null()',
+    ipv4: () => 'z.ipv4()',
+    ipv6: () => 'z.ipv6()',
+    blob: () => 'z.instanceof(File)',
+    uuid(node) {
+      const base = this.options.guidType === 'guid' ? 'z.guid()' : 'z.uuid()'
+
+      return `${base}${dialect.lengthConstraints({ ...node, regexType: this.options.regexType })}`
+    },
+    email(node) {
+      return `z.email()${dialect.lengthConstraints({ ...node, regexType: this.options.regexType })}`
+    },
+    url(node) {
+      return `z.url()${dialect.lengthConstraints({ ...node, regexType: this.options.regexType })}`
+    },
+    enum(node) {
+      const values = node.namedEnumValues?.map((v) => v.value) ?? node.enumValues ?? []
+      const nonNullValues = values.filter((v): v is string | number | boolean => v !== null)
+
+      // asConst-style enum: use z.union([z.literal(…), …])
+      if (node.namedEnumValues?.length) {
+        const literals = nonNullValues.map((v) => `z.literal(${formatLiteral(v)})`)
+
+        if (literals.length === 1) return literals[0]!
+        return `z.union([${literals.join(', ')}])`
+      }
+
+      // Regular enum: z.enum for all-string sets, z.literal/z.union otherwise
+      return buildEnum(nonNullValues)
+    },
+    ref(node) {
+      if (!node.name) return null
+      const refName = ast.resolveRefName(node)
+      if (!refName) return null
+
+      // In the input direction, a date-bearing component resolves to its `${name}InputSchema`
+      // variant so request bodies encode `Date → string` instead of decoding. Only the classic
+      // printer sets `direction`.
+      const useInputVariant = node.ref != null && this.options.direction === 'input' && containsCodec(node)
+      const resolvedName = node.ref
+        ? useInputVariant
+          ? (this.options.resolver?.schema.inputName(refName) ?? refName)
+          : (this.options.resolver?.name(refName) ?? refName)
+        : node.name
+
+      if (node.ref && this.options.cyclicSchemas?.has(refName)) {
+        return `z.lazy(() => ${resolvedName})`
+      }
+
+      return resolvedName
+    },
+    object(node) {
+      const entries = node.properties ?? []
+      const objectBase = `z.object(${buildObjectShape({ ctx: this, node, dialect })})`
+      const patterns = node.patternProperties ? Object.entries(node.patternProperties) : []
+
+      if (node.additionalProperties && node.additionalProperties !== true) {
+        const catchallType = this.transform(node.additionalProperties)
+        return catchallType ? dialect.catchall({ objectBase, value: catchallType }) : objectBase
+      }
+      if (node.additionalProperties === true) {
+        return dialect.catchall({ objectBase, value: this.transform(ast.factory.createSchema({ type: 'unknown' }))! })
+      }
+      // `additionalProperties: false` still permits patternProperties keys, so skip the strict form when patterns exist.
+      if (node.additionalProperties === false && patterns.length === 0) return dialect.strictObject(objectBase)
+
+      // No fixed properties: z.record enforces the key pattern. With fixed properties a record would
+      // reject the declared keys, so fall back to a catchall (value validated, key pattern not).
+      if (patterns.length > 0) {
+        const values = patterns.map(([, valueSchema]) => {
+          const valueType = this.transform(valueSchema) ?? this.transform(ast.factory.createSchema({ type: 'unknown' }))!
+          return valueSchema.nullable ? dialect.nullable(valueType) : valueType
+        })
+        const distinct = [...new Set(values)]
+        const value = distinct.length === 1 ? distinct[0]! : `z.union([${distinct.join(', ')}])`
+
+        if (entries.length > 0) return dialect.catchall({ objectBase, value })
+        return `z.record(${dialect.patternKeySchema({ patterns: patterns.map(([pattern]) => pattern), regexType: this.options.regexType })}, ${value})`
+      }
+      return objectBase
+    },
+    array(node) {
+      const items = transformItems({ ctx: this, node })
+      const inner = items.join(', ') || this.transform(ast.factory.createSchema({ type: 'unknown' }))!
+      const base = `z.array(${inner})${dialect.lengthConstraints({ ...node, regexType: this.options.regexType })}`
+
+      return node.unique ? `${base}.refine(items => new Set(items).size === items.length, { message: "Array entries must be unique" })` : base
+    },
+    tuple(node) {
+      return `z.tuple(${buildList(transformItems({ ctx: this, node }))})`
+    },
+    union(node) {
+      const nodeMembers = node.members ?? []
+      const members = ast
+        .mapSchemaMembers(node, (memberNode) => this.transform(memberNode))
+        .map(({ schema, output }) => (output && node.strategy === 'one' ? dialect.strictOneOfMember({ member: output, schema, cyclicSchemas }) : output))
+        .filter(Boolean)
+      if (members.length === 0) return ''
+      if (members.length === 1) return members[0]!
+      // z.discriminatedUnion needs every option to be a Zod object. Object variants (refs or
+      // extend-composed `allOf`) qualify; intersections, cyclic `z.lazy(…)` refs, and
+      // non-objects fall back to z.union.
+      const allDiscriminable = nodeMembers.every((m) => isObjectSchemaNode(m, cyclicSchemas))
+      if (node.discriminatorPropertyName && allDiscriminable) {
+        return `z.discriminatedUnion(${stringify(node.discriminatorPropertyName)}, ${buildList(members)})`
+      }
+
+      return `z.union(${buildList(members)})`
+    },
+    intersection(node) {
+      const members = node.members ?? []
+      if (members.length === 0) return ''
+
+      const [first, ...rest] = members
+      if (!first) return ''
+
+      const firstBase = this.transform(first)
+      if (!firstBase) return ''
+
+      // An object `allOf` is a merge, not a runtime intersection: extending keeps it a Zod object
+      // (usable in z.discriminatedUnion) instead of a non-discriminable intersection.
+      if (rest.length > 0 && isObjectComposableIntersection(node, cyclicSchemas)) {
+        return rest.reduce((acc, member) => dialect.extend({ base: acc, shape: buildObjectShape({ ctx: this, node: member, dialect }) }), firstBase)
+      }
+
+      return rest.reduce((acc, member) => {
+        const constraint = memberConstraint({ member, regexType: this.options.regexType, dialect })
+        if (constraint) return acc + constraint
+        const transformed = this.transform(member)
+        return transformed ? dialect.intersect({ base: acc, member: transformed }) : acc
+      }, firstBase)
+    },
+  } satisfies ast.PrinterPartial<string, SharedPrinterOptions>
+
+  /**
+   * Root-level `print`: transforms the node, applies `keysToOmit` via `.omit(…)`, then the
+   * top-level modifiers.
+   */
+  function print(this: SharedPrinterContext, node: ast.SchemaNode): string | null {
+    const { keysToOmit } = this.options
+
+    const transformed = this.transform(node)
+    if (!transformed) return null
+
+    const meta = ast.syncSchemaRef(node)
+
+    const base = (() => {
+      if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed
+      // Discriminated unions (z.discriminatedUnion) do not support .omit(), so skip them.
+
+      // A nullable/optional ref resolves to a nullable/optional variable; .omit() lives on the
+      // inner object schema, so unwrap down to it first (mirrors printerTs `Omit<NonNullable<T>, …>`).
+      // applyModifiers re-applies the nullable/optional wrapper after the omit.
+      const unwrap = omitUnwrapChain(node)
+      const omit = `.omit({ ${keysToOmit.map((k: string) => `"${k}": true`).join(', ')} })`
+
+      // If this is a lazy reference, apply omit inside the lazy function
+      const lazyMatch = transformed.match(/^z\.lazy\(\(\)\s*=>\s*(.+)\)$/)
+      if (lazyMatch) return `z.lazy(() => ${lazyMatch[1]}${unwrap}${omit})`
+      return `${transformed}${unwrap}${omit}`
+    })()
+
+    return dialect.applyModifiers({
+      value: base,
+      schema: node,
+      nullable: meta.nullable,
+      optional: meta.optional,
+      nullish: meta.nullish,
+      defaultValue: meta.default,
+      description: meta.description,
+      examples: meta.examples,
+    })
+  }
+
+  return { nodes, print }
+}


### PR DESCRIPTION
## 🎯 Changes

Closes #674.

The two zod printers duplicated about 180 lines of traversal and formatting logic, so a fix applied to one silently missed the other. This PR moves that logic into a new `packages/plugin-zod/src/printers/shared.ts`:

- `sharedZodNodes({ dialect, cyclicSchemas })` returns the node handlers both printers agree on (`enum`, `ref`, `object`, `array`, `tuple`, `union`, `intersection`, `uuid`, `email`, `url`, the scalar one-liners) plus the root `print` with the `keysToOmit` handling.
- `ZodDialect` carries the emissions where the APIs differ: modifier application, length and number constraints, pattern key schemas, and the nullable / strict / catchall / extend / intersect forms.
- `printerZod` keeps the chainable dialect (`.catchall(…)`, `.strict()`, `.extend(…)`, `.and(…)`) and its coercion-aware handlers (`string`, `number`, `integer`, `bigint`, `date`, `datetime`, `time`).
- `printerZodMini` keeps the functional dialect (`z.catchall(…)`, `z.strictObject(…)`, `z.extend(…)`, `z.intersection(…)`) and its mini-specific handlers for the same node types.

`fallow dupes --mode mild` on `packages/plugin-zod/src` now reports no duplication (it previously found 8 clone groups between the printers). Generated output is unchanged: the printer suites and plugin snapshots pass without updates. Public exports are untouched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXLKTv9KokDqB11i8D3w1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXLKTv9KokDqB11i8D3w1n)_