### PR TITLE
chore: bump kubb catalog pins to 5.0.0-beta.96

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-beta.95
-      version: 5.0.0-beta.95
+      specifier: 5.0.0-beta.96
+      version: 5.0.0-beta.96
     '@kubb/core':
-      specifier: 5.0.0-beta.95
-      version: 5.0.0-beta.95
+      specifier: 5.0.0-beta.96
+      version: 5.0.0-beta.96
     '@kubb/parser-ts':
-      specifier: 5.0.0-beta.95
-      version: 5.0.0-beta.95
+      specifier: 5.0.0-beta.96
+      version: 5.0.0-beta.96
     '@kubb/plugin-barrel':
-      specifier: 5.0.0-beta.95
-      version: 5.0.0-beta.95
+      specifier: 5.0.0-beta.96
+      version: 5.0.0-beta.96
     '@types/node':
       specifier: ^22.20.1
       version: 22.20.1
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
     kubb:
-      specifier: 5.0.0-beta.95
-      version: 5.0.0-beta.95
+      specifier: 5.0.0-beta.96
+      version: 5.0.0-beta.96
     oxfmt:
       specifier: ^0.58.0
       version: 0.58.0
@@ -64,13 +64,13 @@ importers:
         version: 2.31.0(@types/node@22.20.1)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       '@kubb/plugin-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
+        version: 5.0.0-beta.96(@kubb/core@5.0.0-beta.96)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -94,7 +94,7 @@ importers:
         version: 1.3.14
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
       oxfmt:
         specifier: 'catalog:'
         version: 0.58.0(svelte@5.56.4)
@@ -194,13 +194,13 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -209,7 +209,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -221,7 +221,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -231,7 +231,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:../../packages/plugin-cypress
@@ -240,7 +240,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -259,7 +259,7 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../../packages/plugin-faker
@@ -271,7 +271,7 @@ importers:
         version: 1.11.21
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -284,7 +284,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -293,7 +293,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -303,10 +303,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -327,7 +327,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -343,7 +343,7 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../../packages/plugin-faker
@@ -358,7 +358,7 @@ importers:
         version: 0.10.3(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@26.0.1)(typescript@6.0.3)
@@ -377,7 +377,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -392,7 +392,7 @@ importers:
         version: 5.101.2(react@19.2.7)
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -408,7 +408,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -417,7 +417,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -427,10 +427,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -454,7 +454,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -469,7 +469,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -481,7 +481,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -500,7 +500,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -509,7 +509,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -519,7 +519,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -534,7 +534,7 @@ importers:
         version: 5.101.2(vue@3.5.39(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
@@ -547,7 +547,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -559,7 +559,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -586,7 +586,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -599,11 +599,11 @@ importers:
         version: link:../utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -621,7 +621,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -653,7 +653,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -672,7 +672,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-faker:
     dependencies:
@@ -688,7 +688,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-fetch:
     dependencies:
@@ -707,7 +707,7 @@ importers:
         version: link:../../internals/shared
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -732,7 +732,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-msw:
     dependencies:
@@ -751,7 +751,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-react-query:
     dependencies:
@@ -773,17 +773,17 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-redoc:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
     devDependencies:
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-swr:
     dependencies:
@@ -805,13 +805,13 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-ts:
     dependencies:
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -824,7 +824,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-vue-query:
     dependencies:
@@ -846,7 +846,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-zod:
     devDependencies:
@@ -858,7 +858,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   tests/3.0.x:
     dependencies:
@@ -867,13 +867,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -912,7 +912,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -928,10 +928,10 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -967,7 +967,7 @@ importers:
         version: 15.18.0
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@26.0.1)(typescript@6.0.3)
@@ -995,10 +995,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)
+        version: 5.0.0-beta.96(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.95
+        version: 5.0.0-beta.96
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -1013,7 +1013,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1247,58 +1247,58 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kubb/adapter-oas@5.0.0-beta.95':
-    resolution: {integrity: sha512-hJDWbVv5xS5JZftAH216c/jMcajGbN8MwQv/dfyXW3dcmqnMcxRmZn37k0q8oRpJEucLSWFnXN+WHW7oL8oadw==}
+  '@kubb/adapter-oas@5.0.0-beta.96':
+    resolution: {integrity: sha512-onYqIX3dyIzhVLlYopaZigOYcB5thvpD+7sq5Di0j2Vuvq2vIf8t1GRZEtKOVwSVyux7l8VTMl/SU++jeKN8dA==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-beta.95':
-    resolution: {integrity: sha512-xhxLp642XYFEAB44ks/inCml//lL7qJkl6fPCRxfgiexihQWyM3WWkVmh5MVXPS1znMGA00d7UlrCLj5vgJTnA==}
+  '@kubb/ast@5.0.0-beta.96':
+    resolution: {integrity: sha512-nqa8mlwART0PW86o6LWwit/Q6YxIcMcaTrI3zZbx4b6yonw4j/xQ0R+pC3Cra8p+bG77zB7ftiCFFxUj7CDRoQ==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-beta.95':
-    resolution: {integrity: sha512-uEI3BcIctCJ7132YazZhPNtP0sOhquE148/BN1gS1v2N3QnLS8Cqz1DL5SA66+CKawYNZY9SEkxuEJStS+HJFA==}
+  '@kubb/cli@5.0.0-beta.96':
+    resolution: {integrity: sha512-XCC9C4UmFzDMeUoxTdBG3IzUwgwWifuXuC3baYLUC9u+FYYq+JI3pwKLLBTIEXbjPclyU5RknEli23NEEyueuQ==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.95
-      '@kubb/mcp': 5.0.0-beta.95
+      '@kubb/adapter-oas': 5.0.0-beta.96
+      '@kubb/mcp': 5.0.0-beta.96
     peerDependenciesMeta:
       '@kubb/adapter-oas':
         optional: true
       '@kubb/mcp':
         optional: true
 
-  '@kubb/core@5.0.0-beta.95':
-    resolution: {integrity: sha512-/fBvBgfrXFYtdoFqtx5Mf4j0v+wHif4LaZOZTe5mybkSVprbeZ9144VY4E4F18R0fLZ/6+4F/hfGICgbcYoTdg==}
+  '@kubb/core@5.0.0-beta.96':
+    resolution: {integrity: sha512-dmFK0xtB25gQDqQjpDasP9+nyhYKsi87tPWZIcHzZwl9bbnTbKegKiyqD7l7HOhBKa6zLjM5TrVKJQ7Ml5G/ug==}
     engines: {node: '>=22'}
 
-  '@kubb/kit@5.0.0-beta.95':
-    resolution: {integrity: sha512-ZrUhXtc58o1p78ep2T+fACUPGtypBPtvb8lXV9FKwjKpAXSZAWFyt1SVwmizROkOKYEYNwdgkEIlB73NN4NLaQ==}
+  '@kubb/kit@5.0.0-beta.96':
+    resolution: {integrity: sha512-/7zp6A4n1mpQiMgN3gTipD0I9IEYLu0kRdDxsiHMaalqqKxh8KVpwJ7qpi8rUNxH9BeZ+YAz5X4Np/E+nT7wCA==}
     engines: {node: '>=22'}
 
-  '@kubb/mcp@5.0.0-beta.95':
-    resolution: {integrity: sha512-I0rLTsR1Dhbzvo2X8rJfnYhyjdq0nkd2TNfdTJglrN+eaphsnUevl2d0Tja8CM9TOicOBhVG8Gn2kD6SW+pbtg==}
+  '@kubb/mcp@5.0.0-beta.96':
+    resolution: {integrity: sha512-0QwtWqoXHwH8STLftIUhdr6t+bmzs3GrvaLWidf6sJlRKKsBcS0AlXNQhXUl+2ig3ujh8ntRNdfiGxiNxF95/Q==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.95
+      '@kubb/renderer-jsx': 5.0.0-beta.96
 
-  '@kubb/parser-md@5.0.0-beta.95':
-    resolution: {integrity: sha512-xWOoe+eGX+5KmOMXHhtAFFHEIyPT1bImEvGVMlMhPTiwloj01m3UWnFbDeajvHt9F0qUtRWKev5h9zpGAjshVQ==}
+  '@kubb/parser-md@5.0.0-beta.96':
+    resolution: {integrity: sha512-6SKETgLUOtRZrIQfFyGc/fhkYC+iaMYrsnjvaK1arT8XNtAOkjv6JvynfBBLH/3G0yUZSWlpARQvxTo2x6uWYA==}
     engines: {node: '>=22'}
 
-  '@kubb/parser-ts@5.0.0-beta.95':
-    resolution: {integrity: sha512-ompY1wd/uIag/H1HKnV3QmHdX9KuQ4WV7IfFd9AipvtKS3k59WcQHos+MDzQ1101VGwbdjI6FDdBd+KULxgMVA==}
+  '@kubb/parser-ts@5.0.0-beta.96':
+    resolution: {integrity: sha512-cZm/cJNC4utNElVwAVssBiBVcA2Zrg+HgJpquPFnq7IUH28TxddEzhh5fHPTHiJg7ZPHj8W27knEHhjgAs/l2Q==}
     engines: {node: '>=22'}
 
-  '@kubb/plugin-barrel@5.0.0-beta.95':
-    resolution: {integrity: sha512-8ikD6HTEl59U2JX+4hDe8oTBD7ph6flaAizoprWNhsCAYtRo6F75l/jTaJ+wQ0EEIxoLomPKFvkiVQ7nHVS5Vw==}
+  '@kubb/plugin-barrel@5.0.0-beta.96':
+    resolution: {integrity: sha512-IMxCrZHNUh0tBsMdI0pc/Zc6IlZ4IcBwZyTSlzrwR//kz4gz8+1GD6z+nR/QngPyynCni0Ft2yDSQqdqz8E8eQ==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-beta.95
+      '@kubb/core': 5.0.0-beta.96
 
-  '@kubb/renderer-jsx@5.0.0-beta.95':
-    resolution: {integrity: sha512-r4kmD/jv7qfyD/IeKI5K9SpvTY0/9449XzAlBxX2pqCV5L4874kD2AC1kcefm8iSjNA30wyikThhDQDnQVNEcw==}
+  '@kubb/renderer-jsx@5.0.0-beta.96':
+    resolution: {integrity: sha512-kG0WhlXf3A2PsjF+ExvfW41AbpH8m+ZbnuVm+UsQTtaQk3g8x+UPP+7OiVeex0p3ysrKSqSxeBf97GDcRspFxA==}
     engines: {node: '>=22'}
 
   '@manypkg/find-root@1.1.0':
@@ -2872,8 +2872,8 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-beta.95:
-    resolution: {integrity: sha512-VZwmK/ksoe3/TEmxSSLPv4uv8f3KhbpYf2DNTyPPUOxHpi7mlSGKldmEL84xh3IFkQoutm9euv/sUv+yJ5IyEg==}
+  kubb@5.0.0-beta.96:
+    resolution: {integrity: sha512-nHWUAzmMTfTJLhe9jHNBPlr2sUIJgQcM4NEOu5WadzQlkvaYb06y+QV3pRuyMQSHQ376btIL1/yPteYNqQPsBA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3774,8 +3774,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-beta.95:
-    resolution: {integrity: sha512-nv+R1qnY0wyURQ0PTPIeBYw1tVgMPUMa7qJ1ePZMRCQYfYHv/lrk3Uuqfryoc8sFgeKngdAcZmMMng2ggM5vBw==}
+  unplugin-kubb@5.0.0-beta.96:
+    resolution: {integrity: sha512-DTlusdBJUr6G2vkKldmdyZw66NSpjAufpyD3QHpDY5ic+m4o/lfiqJo8mfqqcHcK6eYMZPBlowSFCB9xl/j0EA==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -4399,10 +4399,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3)':
+  '@kubb/adapter-oas@5.0.0-beta.96(openapi-types@12.1.3)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.95
-      '@kubb/core': 5.0.0-beta.95
+      '@kubb/ast': 5.0.0-beta.96
+      '@kubb/core': 5.0.0-beta.96
       '@readme/openapi-parser': 6.2.1(openapi-types@12.1.3)
       '@scalar/openapi-upgrader': 0.2.9
       api-ref-bundler: 0.5.1
@@ -4410,35 +4410,35 @@ snapshots:
     transitivePeerDependencies:
       - openapi-types
 
-  '@kubb/ast@5.0.0-beta.95': {}
+  '@kubb/ast@5.0.0-beta.96': {}
 
-  '@kubb/cli@5.0.0-beta.95(@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3))':
+  '@kubb/cli@5.0.0-beta.96(@kubb/adapter-oas@5.0.0-beta.96(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.96(@kubb/renderer-jsx@5.0.0-beta.96)(openapi-types@12.1.3)(typescript@6.0.3))':
     dependencies:
       '@clack/prompts': 1.7.0
-      '@kubb/core': 5.0.0-beta.95
+      '@kubb/core': 5.0.0-beta.96
       chokidar: 5.0.0
       gunshi: 0.36.0
       jiti: 2.7.0
       tinyexec: 1.2.4
       unconfig: 7.5.0
     optionalDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
-      '@kubb/mcp': 5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/adapter-oas': 5.0.0-beta.96(openapi-types@12.1.3)
+      '@kubb/mcp': 5.0.0-beta.96(@kubb/renderer-jsx@5.0.0-beta.96)(openapi-types@12.1.3)(typescript@6.0.3)
 
-  '@kubb/core@5.0.0-beta.95':
+  '@kubb/core@5.0.0-beta.96':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/ast': 5.0.0-beta.96
 
-  '@kubb/kit@5.0.0-beta.95':
+  '@kubb/kit@5.0.0-beta.96':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.95
-      '@kubb/core': 5.0.0-beta.95
+      '@kubb/ast': 5.0.0-beta.96
+      '@kubb/core': 5.0.0-beta.96
 
-  '@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)':
+  '@kubb/mcp@5.0.0-beta.96(@kubb/renderer-jsx@5.0.0-beta.96)(openapi-types@12.1.3)(typescript@6.0.3)':
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.95
-      '@kubb/renderer-jsx': 5.0.0-beta.95
+      '@kubb/adapter-oas': 5.0.0-beta.96(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.96
+      '@kubb/renderer-jsx': 5.0.0-beta.96
       '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))
       '@tmcp/transport-stdio': 0.4.3(tmcp@1.19.4(typescript@6.0.3))
       tmcp: 1.19.4(typescript@6.0.3)
@@ -4447,25 +4447,25 @@ snapshots:
       - openapi-types
       - typescript
 
-  '@kubb/parser-md@5.0.0-beta.95':
+  '@kubb/parser-md@5.0.0-beta.96':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.95
-      '@kubb/core': 5.0.0-beta.95
+      '@kubb/ast': 5.0.0-beta.96
+      '@kubb/core': 5.0.0-beta.96
       yaml: 2.9.0
 
-  '@kubb/parser-ts@5.0.0-beta.95':
+  '@kubb/parser-ts@5.0.0-beta.96':
     dependencies:
-      '@kubb/core': 5.0.0-beta.95
+      '@kubb/core': 5.0.0-beta.96
       typescript: 6.0.3
 
-  '@kubb/plugin-barrel@5.0.0-beta.95(@kubb/core@5.0.0-beta.95)':
+  '@kubb/plugin-barrel@5.0.0-beta.96(@kubb/core@5.0.0-beta.96)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.95
-      '@kubb/core': 5.0.0-beta.95
+      '@kubb/ast': 5.0.0-beta.96
+      '@kubb/core': 5.0.0-beta.96
 
-  '@kubb/renderer-jsx@5.0.0-beta.95':
+  '@kubb/renderer-jsx@5.0.0-beta.96':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.95
+      '@kubb/ast': 5.0.0-beta.96
       yaml: 2.9.0
 
   '@manypkg/find-root@1.1.0':
@@ -5935,19 +5935,19 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
+  kubb@5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
-      '@kubb/ast': 5.0.0-beta.95
-      '@kubb/cli': 5.0.0-beta.95(@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3))
-      '@kubb/core': 5.0.0-beta.95
-      '@kubb/kit': 5.0.0-beta.95
-      '@kubb/mcp': 5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)
-      '@kubb/parser-md': 5.0.0-beta.95
-      '@kubb/parser-ts': 5.0.0-beta.95
-      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
-      '@kubb/renderer-jsx': 5.0.0-beta.95
-      unplugin-kubb: 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@kubb/adapter-oas': 5.0.0-beta.96(openapi-types@12.1.3)
+      '@kubb/ast': 5.0.0-beta.96
+      '@kubb/cli': 5.0.0-beta.96(@kubb/adapter-oas@5.0.0-beta.96(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.96(@kubb/renderer-jsx@5.0.0-beta.96)(openapi-types@12.1.3)(typescript@6.0.3))
+      '@kubb/core': 5.0.0-beta.96
+      '@kubb/kit': 5.0.0-beta.96
+      '@kubb/mcp': 5.0.0-beta.96(@kubb/renderer-jsx@5.0.0-beta.96)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/parser-md': 5.0.0-beta.96
+      '@kubb/parser-ts': 5.0.0-beta.96
+      '@kubb/plugin-barrel': 5.0.0-beta.96(@kubb/core@5.0.0-beta.96)
+      '@kubb/renderer-jsx': 5.0.0-beta.96
+      unplugin-kubb: 5.0.0-beta.96(@kubb/core@5.0.0-beta.96)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@nuxt/kit'
@@ -5963,19 +5963,19 @@ snapshots:
       - vite
       - webpack
 
-  kubb@5.0.0-beta.95(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
+  kubb@5.0.0-beta.96(openapi-types@12.1.3)(rolldown@1.1.3)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
-      '@kubb/ast': 5.0.0-beta.95
-      '@kubb/cli': 5.0.0-beta.95(@kubb/adapter-oas@5.0.0-beta.95(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3))
-      '@kubb/core': 5.0.0-beta.95
-      '@kubb/kit': 5.0.0-beta.95
-      '@kubb/mcp': 5.0.0-beta.95(@kubb/renderer-jsx@5.0.0-beta.95)(openapi-types@12.1.3)(typescript@6.0.3)
-      '@kubb/parser-md': 5.0.0-beta.95
-      '@kubb/parser-ts': 5.0.0-beta.95
-      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
-      '@kubb/renderer-jsx': 5.0.0-beta.95
-      unplugin-kubb: 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@kubb/adapter-oas': 5.0.0-beta.96(openapi-types@12.1.3)
+      '@kubb/ast': 5.0.0-beta.96
+      '@kubb/cli': 5.0.0-beta.96(@kubb/adapter-oas@5.0.0-beta.96(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.96(@kubb/renderer-jsx@5.0.0-beta.96)(openapi-types@12.1.3)(typescript@6.0.3))
+      '@kubb/core': 5.0.0-beta.96
+      '@kubb/kit': 5.0.0-beta.96
+      '@kubb/mcp': 5.0.0-beta.96(@kubb/renderer-jsx@5.0.0-beta.96)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/parser-md': 5.0.0-beta.96
+      '@kubb/parser-ts': 5.0.0-beta.96
+      '@kubb/plugin-barrel': 5.0.0-beta.96(@kubb/core@5.0.0-beta.96)
+      '@kubb/renderer-jsx': 5.0.0-beta.96
+      unplugin-kubb: 5.0.0-beta.96(@kubb/core@5.0.0-beta.96)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@nuxt/kit'
@@ -6891,12 +6891,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.96(@kubb/core@5.0.0-beta.96)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.95
-      '@kubb/parser-ts': 5.0.0-beta.95
-      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
+      '@kubb/adapter-oas': 5.0.0-beta.96(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.96
+      '@kubb/parser-ts': 5.0.0-beta.96
+      '@kubb/plugin-barrel': 5.0.0-beta.96(@kubb/core@5.0.0-beta.96)
       unplugin: 3.3.0(rolldown@1.1.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       rolldown: 1.1.3
@@ -6907,12 +6907,12 @@ snapshots:
       - openapi-types
       - unloader
 
-  unplugin-kubb@5.0.0-beta.95(@kubb/core@5.0.0-beta.95)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.96(@kubb/core@5.0.0-beta.96)(openapi-types@12.1.3)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.95(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.95
-      '@kubb/parser-ts': 5.0.0-beta.95
-      '@kubb/plugin-barrel': 5.0.0-beta.95(@kubb/core@5.0.0-beta.95)
+      '@kubb/adapter-oas': 5.0.0-beta.96(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.96
+      '@kubb/parser-ts': 5.0.0-beta.96
+      '@kubb/plugin-barrel': 5.0.0-beta.96(@kubb/core@5.0.0-beta.96)
       unplugin: 3.3.0(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       rolldown: 1.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,22 +12,22 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.95
-  '@kubb/core': 5.0.0-beta.95
-  '@kubb/kit': 5.0.0-beta.95
-  '@kubb/plugin-barrel': 5.0.0-beta.95
-  '@kubb/parser-ts': 5.0.0-beta.95
+  '@kubb/adapter-oas': 5.0.0-beta.96
+  '@kubb/core': 5.0.0-beta.96
+  '@kubb/kit': 5.0.0-beta.96
+  '@kubb/plugin-barrel': 5.0.0-beta.96
+  '@kubb/parser-ts': 5.0.0-beta.96
   '@types/node': ^22.20.1
   '@types/react': ^19.2.17
   '@vitest/coverage-v8': ^4.1.10
   '@vitest/ui': ^4.1.10
-  kubb: 5.0.0-beta.95
+  kubb: 5.0.0-beta.96
   oxfmt: ^0.58.0
   oxlint: ^1.73.0
   prettier: ^3.9.4
   tsdown: ^0.22.3
   typescript: ^6.0.3
-  unplugin-kubb: 5.0.0-beta.95
+  unplugin-kubb: 5.0.0-beta.96
   vitest: ^4.1.10
 #
 #overrides:


### PR DESCRIPTION
## What

Move the kubb core catalog pins from `5.0.0-beta.95` to `5.0.0-beta.96` so the plugins build and test against the latest kubb core: `@kubb/core`, `@kubb/kit`, `@kubb/adapter-oas`, `@kubb/parser-ts`, `@kubb/plugin-barrel`, `kubb`, and `unplugin-kubb`.

beta.96 is the release that re-exports `Hookable` from `kubb/kit` (kubb-labs/kubb#3780). The plugins' `resolver.imports`-based source is unchanged and compatible with it.

## Verification

- Lockfile regenerated; no beta.95 kubb remnants.
- `@kubb/plugin-ts` builds against beta.96 (DTS generation typechecks against the beta.96 core/kit/adapter types).
- `@kubb/plugin-ts` tests: **252 passed**.

No changeset: this is a dev/peer catalog pin bump, matching how prior kubb-version bumps landed. The published `peerDependencies.kubb` picks up the catalog value on the next release from the existing changeset backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew4223tfK92qE2WKigE5aw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ew4223tfK92qE2WKigE5aw)_