### PR TITLE
chore(examples): use the positional spec argument for kubb validate

### DIFF
--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('./dist', {recursive:true,force:true})\"",
     "generate": "KUBB_DISABLE_TELEMETRY=1 kubb generate",
-    "validate": "kubb validate --input petStore.yaml",
+    "validate": "kubb validate petStore.yaml",
     "mcp": "kubb mcp",
     "generate:watch": "KUBB_DISABLE_TELEMETRY=1 kubb generate --watch",
     "generate:debug": "NODE_OPTIONS='--inspect-brk' KUBB_DISABLE_TELEMETRY=1 kubb generate",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -15,7 +15,7 @@
     "clean": "node -e \"require('node:fs').rmSync('./dist', {recursive:true,force:true})\"",
     "generate": "KUBB_DISABLE_TELEMETRY=1 kubb generate",
     "generate:debug": "NODE_OPTIONS='--inspect-brk' KUBB_DISABLE_TELEMETRY=1 kubb generate",
-    "validate": "kubb validate --input petStore.yaml",
+    "validate": "kubb validate petStore.yaml",
     "test": "vitest",
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },


### PR DESCRIPTION
## 🎯 Changes

`kubb validate` now takes the spec as a positional argument instead of the `--input` flag. This updates the example `validate` scripts to match:

- `examples/advanced/package.json`: `kubb validate petStore.yaml`
- `examples/typescript/package.json`: `kubb validate petStore.yaml`

Pairs with kubb-labs/kubb#3782, which makes the CLI change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjfJLz3uEZDnVwmbshX2PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjfJLz3uEZDnVwmbshX2PQ)_