### PR TITLE
fix(plugin-ts): serialize structured JSDoc examples

### DIFF
--- a/.changeset/clean-jsdoc-examples.md
+++ b/.changeset/clean-jsdoc-examples.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-ts": patch
+---
+
+Serialize structured JSDoc examples as JSON instead of `[object Object]`.

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -238,4 +238,34 @@ describe('buildPropertyJSDocComments', () => {
     expect(comments).toContain('@example a')
     expect(comments).toContain('@example b')
   })
+
+  it('serializes object examples as JSON', () => {
+    const schema = ast.factory.createSchema({ type: 'object', examples: [{ cidr: '10.0.0.0/8', label: 'VPC' }] })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).toContain('@example {"cidr":"10.0.0.0/8","label":"VPC"}')
+  })
+
+  it('serializes array examples as JSON', () => {
+    const schema = ast.factory.createSchema({
+      type: 'array',
+      primitive: 'array',
+      examples: [
+        [
+          { cidr: '10.0.0.0/8', label: 'VPC' },
+          { cidr: '203.0.113.5/32', label: 'Office' },
+        ],
+      ],
+    })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).toContain('@example [{"cidr":"10.0.0.0/8","label":"VPC"},{"cidr":"203.0.113.5/32","label":"Office"}]')
+  })
+
+  it('escapes comment terminators in structured examples', () => {
+    const schema = ast.factory.createSchema({ type: 'object', examples: [{ label: '*/' }] })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).toContain('@example {"label":"*\\/"}')
+  })
 })

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -33,7 +33,8 @@ function formatExample(value: unknown): string {
     return String(value)
   }
 
-  return JSON.stringify(value)?.replaceAll('*/', '*\\/') ?? String(value)
+  const rendered = JSON.stringify(value) ?? String(value)
+  return rendered.replaceAll('*/', '*\\/')
 }
 
 export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: boolean): Array<string | undefined> {

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -28,6 +28,14 @@ function isSchemaOptional(schema: ast.SchemaNode): boolean {
   return Boolean(('optional' in schema && schema.optional) || ('nullish' in schema && schema.nullish))
 }
 
+function formatExample(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return String(value)
+  }
+
+  return JSON.stringify(value)?.replaceAll('*/', '*\\/') ?? String(value)
+}
+
 export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: boolean): Array<string | undefined> {
   const meta = ast.syncSchemaRef(schema)
 
@@ -57,7 +65,7 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: bo
     meta && 'default' in meta && meta.default !== undefined
       ? `@default ${'primitive' in meta && meta.primitive === 'string' && typeof meta.default === 'string' ? stringify(meta.default) : meta.default}`
       : null,
-    ...exampleValues.map((example) => `@example ${example}`),
+    ...exampleValues.map((example) => `@example ${formatExample(example)}`),
     meta && 'primitive' in meta && meta.primitive
       ? [`@type ${meta.primitive}`, (optional ?? isSchemaOptional(schema)) ? ' | undefined' : null].filter(Boolean).join('')
       : null,


### PR DESCRIPTION
## Summary

- serialize non-primitive schema examples before emitting `@example` JSDoc lines
- preserve existing primitive example output
- add coverage for object examples, array examples, and escaped comment terminators
- add a patch changeset for `@kubb/plugin-ts`

## Why

`@kubb/plugin-ts` currently interpolates schema examples directly into JSDoc. When an OpenAPI schema example is an object or array of objects, JavaScript string coercion renders it as `[object Object]`, so generated TypeScript types lose the example shape.

## Validation

- `pnpm vitest run --config ./configs/vitest.config.ts packages/plugin-ts/src/utils.test.ts`
- `pnpm --filter @kubb/plugin-ts typecheck`
- `pnpm --filter @kubb/plugin-ts lint`
