### PR TITLE
Reach macros, moved ast utils, and collectSync directly from kubb/kit

### DIFF
--- a/.changeset/kit-collect-utils-reexports.md
+++ b/.changeset/kit-collect-utils-reexports.md
@@ -1,0 +1,9 @@
+---
+'@kubb/plugin-ts': patch
+'@kubb/plugin-zod': patch
+'@kubb/plugin-faker': patch
+---
+
+Reach `childName`, `enumPropName`, `extractRefName`, `isStringType`, `mergeAdjacentObjectsLazy`, `syncSchemaRef`, `containsCircularRef`, and `collectSync` from `kubb/kit` directly instead of through the `ast` namespace.
+
+These helpers moved out of `@kubb/ast`'s `ast` namespace into `kubb/kit`'s flat exports in kubb-labs/kubb, and `ast.collect` now refers to the renamed lazy `collectLazy`. No behavior change; requires the matching `kubb` release.

--- a/internals/client/src/macros.ts
+++ b/internals/client/src/macros.ts
@@ -1,8 +1,9 @@
-import { ast } from 'kubb/kit'
+import { macroSimplifyUnion } from 'kubb/kit'
+import type { ast } from 'kubb/kit'
 
 /**
  * Macros the client plugins apply by default, ahead of any user macros. `macroSimplifyUnion`
  * drops union members a broader scalar already covers, keeping the generated response and error
  * unions tidy. A plugin wires them with `ctx.setMacros([...defaultMacros, ...userMacros])`.
  */
-export const defaultMacros: ReadonlyArray<ast.Macro> = [ast.macroSimplifyUnion]
+export const defaultMacros: ReadonlyArray<ast.Macro> = [macroSimplifyUnion]

--- a/internals/shared/src/refs.ts
+++ b/internals/shared/src/refs.ts
@@ -6,7 +6,7 @@ import { ast } from 'kubb/kit'
  * `resolver.imports` would resolve file paths that are then discarded.
  */
 export function collectRefNames(schema: ast.SchemaNode): Array<string> {
-  return ast.collect(schema, {
+  return ast.collectSync(schema, {
     schema: (node) => {
       const refNode = ast.narrowSchema(node, 'ref')
       if (!refNode?.ref) return null

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -1,5 +1,6 @@
 import { jsStringEscape } from '@internals/utils'
-import { ast } from 'kubb/kit'
+import { containsCircularRef } from 'kubb/kit'
+import type { ast } from 'kubb/kit'
 import { createFunctionParameter, createFunctionParameters, functionPrinter } from '@kubb/plugin-ts'
 import { File, Function } from 'kubb/jsx'
 import type { KubbReactNode } from 'kubb/jsx'
@@ -109,7 +110,7 @@ export function Faker({ node, description, name, typeName, printer, seed, canOve
   const hasGetters =
     node.type === 'object' &&
     !!cyclicSchemas &&
-    (node.properties ?? []).some((p) => ast.containsCircularRef(p.schema, { circularSchemas: cyclicSchemas, excludeName: schemaName }))
+    (node.properties ?? []).some((p) => containsCircularRef(p.schema, { circularSchemas: cyclicSchemas, excludeName: schemaName }))
 
   const functionBody = hasGetters
     ? `{

--- a/packages/plugin-faker/src/printers/printerFaker.ts
+++ b/packages/plugin-faker/src/printers/printerFaker.ts
@@ -1,6 +1,6 @@
 import { mapSchemaItems, mapSchemaMembers } from '@internals/shared'
 import { buildObject, objectKey, stringify, toRegExpString } from '@internals/utils'
-import { ast } from 'kubb/kit'
+import { ast, containsCircularRef } from 'kubb/kit'
 import type { PluginFaker, ResolverFaker } from '../types.ts'
 
 /**
@@ -386,7 +386,7 @@ export const printerFaker: (options: PrinterFakerOptions) => ast.Printer<Printer
           // emit a memoizing lazy getter. On first access it computes the value,
           // replaces itself with a plain data property via Object.defineProperty,
           // and returns the cached value, so every subsequent read is stable.
-          if (cyclicSchemas && ast.containsCircularRef(property.schema, { circularSchemas: cyclicSchemas, excludeName: this.options.schemaName })) {
+          if (cyclicSchemas && containsCircularRef(property.schema, { circularSchemas: cyclicSchemas, excludeName: this.options.schemaName })) {
             return `get ${objectKey(property.name)}() { const _value = ${value}; Object.defineProperty(this, ${JSON.stringify(property.name)}, { value: _value, configurable: true, writable: true, enumerable: true }); return _value }`
           }
 

--- a/packages/plugin-ts/src/components/Type.tsx
+++ b/packages/plugin-ts/src/components/Type.tsx
@@ -19,7 +19,7 @@ type Props = {
 }
 
 export function Type({ name, node, printer, enum: enumOptions, resolver }: Props): KubbReactNode {
-  const enumSchemaNodes = ast.collect<ast.EnumSchemaNode>(node, {
+  const enumSchemaNodes = ast.collectSync<ast.EnumSchemaNode>(node, {
     schema(n): ast.EnumSchemaNode | undefined {
       const enumNode = ast.narrowSchema(n, ast.schemaTypes.enum)
       // Skip an inline `const` (single-value enum the adapter did not register): it renders as a

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -1,5 +1,6 @@
 import { camelCase, pascalCase, screamingSnakeCase, snakeCase } from '@internals/utils'
-import { ast } from 'kubb/kit'
+import { syncSchemaRef } from 'kubb/kit'
+import type { ast } from 'kubb/kit'
 import ts from 'typescript'
 import { OPTIONAL_ADDS_UNDEFINED } from './constants.ts'
 
@@ -917,7 +918,7 @@ export function buildPropertyType(
   optional?: boolean,
 ): ts.TypeNode {
   const addsUndefined = OPTIONAL_ADDS_UNDEFINED.has(optionalType)
-  const meta = ast.syncSchemaRef(schema)
+  const meta = syncSchemaRef(schema)
 
   let type = baseType
 

--- a/packages/plugin-ts/src/printers/printerTs.ts
+++ b/packages/plugin-ts/src/printers/printerTs.ts
@@ -1,5 +1,5 @@
 import { mapSchemaItems, mapSchemaProperties } from '@internals/shared'
-import { ast } from 'kubb/kit'
+import { ast, isStringType, syncSchemaRef } from 'kubb/kit'
 import { parserTs } from '@kubb/parser-ts'
 import type ts from 'typescript'
 import { ENUM_TYPES_WITH_KEY_SUFFIX, OPTIONAL_ADDS_QUESTION_TOKEN, OPTIONAL_ADDS_UNDEFINED } from '../constants.ts'
@@ -204,12 +204,12 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
           const enumNode = ast.narrowSchema(m, ast.schemaTypes.enum)
           return enumNode?.primitive === 'string'
         })
-        const hasPlainString = members.some((m) => ast.isStringType(m))
+        const hasPlainString = members.some((m) => isStringType(m))
 
         if (hasStringLiteral && hasPlainString) {
           const memberNodes = members
             .map((m) => {
-              if (ast.isStringType(m)) {
+              if (isStringType(m)) {
                 return factory.createIntersectionDeclaration({
                   nodes: [factory.keywordTypeNodes.string, factory.createTypeLiteralNode([])],
                   withParentheses: true,
@@ -247,7 +247,7 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
           const baseType = output ?? factory.keywordTypeNodes.unknown
           const optional = !property.required || !!property.schema.optional || !!property.schema.nullish
           const type = factory.buildPropertyType(property.schema, baseType, options.optionalType, optional)
-          const propMeta = ast.syncSchemaRef(property.schema)
+          const propMeta = syncSchemaRef(property.schema)
 
           const propertyNode = factory.createPropertySignature({
             questionToken: optional ? addsQuestionToken : false,
@@ -276,7 +276,7 @@ export const printerTs = ast.createPrinter<PrinterTs>((options) => {
       if (!transformed) return null
 
       // For ref nodes, structural metadata lives on node.schema rather than the ref node itself.
-      const meta = ast.syncSchemaRef(node)
+      const meta = syncSchemaRef(node)
 
       // Without name, apply modifiers inline and return.
       if (!name) {

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -1,6 +1,6 @@
 import { resolveContentTypeVariants } from '@internals/shared'
 import { jsStringEscape, stringify } from '@internals/utils'
-import { ast } from 'kubb/kit'
+import { ast, syncSchemaRef } from 'kubb/kit'
 import type { ResolverTs } from './types.ts'
 
 /**
@@ -38,7 +38,7 @@ function formatExample(value: unknown): string {
 }
 
 export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: boolean): Array<string | undefined> {
-  const meta = ast.syncSchemaRef(schema)
+  const meta = syncSchemaRef(schema)
 
   const isArray = meta?.primitive === 'array'
 

--- a/packages/plugin-zod/src/printers/printerZod.ts
+++ b/packages/plugin-zod/src/printers/printerZod.ts
@@ -1,6 +1,6 @@
 import { mapSchemaItems, mapSchemaMembers, mapSchemaProperties } from '@internals/shared'
 import { buildList, buildObject, lazyGetter, objectKey, stringify } from '@internals/utils'
-import { ast } from 'kubb/kit'
+import { ast, containsCircularRef, syncSchemaRef } from 'kubb/kit'
 import type { PluginZod, ResolverZod } from '../types.ts'
 import {
   applyModifiers,
@@ -126,7 +126,7 @@ function strictOneOfMember(member: string, node: ast.SchemaNode, cyclicSchemas?:
       return member
     }
 
-    const schema = ast.syncSchemaRef(node)
+    const schema = syncSchemaRef(node)
 
     if (schema.nullable || schema.optional || node.nullable || node.optional) {
       return member
@@ -164,7 +164,7 @@ function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): stri
   if (!objectNode) return '{}'
 
   const isCyclic = (schema: ast.SchemaNode): boolean =>
-    ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
+    ctx.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
 
   const entries = mapSchemaProperties(objectNode, (schema) => {
     // Inside a getter the getter itself defers evaluation, so suppress z.lazy() wrapping on
@@ -177,7 +177,7 @@ function buildZodObjectShape(ctx: ZodPrinterContext, node: ast.SchemaNode): stri
     return baseOutput
   }).map(({ name: propName, property, output: baseOutput }) => {
     const { schema } = property
-    const meta = ast.syncSchemaRef(schema)
+    const meta = syncSchemaRef(schema)
 
     // When a property schema is not a ref but the metadata is from a ref (e.g., discriminator
     // property override), skip applying the description from the ref target to avoid applying
@@ -418,7 +418,7 @@ export const printerZod = ast.createPrinter<PrinterZodFactory>((options) => {
       const transformed = this.transform(node)
       if (!transformed) return null
 
-      const meta = ast.syncSchemaRef(node)
+      const meta = syncSchemaRef(node)
 
       const base = (() => {
         if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed

--- a/packages/plugin-zod/src/printers/printerZodMini.ts
+++ b/packages/plugin-zod/src/printers/printerZodMini.ts
@@ -1,6 +1,6 @@
 import { mapSchemaItems, mapSchemaMembers, mapSchemaProperties } from '@internals/shared'
 import { buildList, buildObject, lazyGetter, objectKey, stringify } from '@internals/utils'
-import { ast } from 'kubb/kit'
+import { ast, containsCircularRef, syncSchemaRef } from 'kubb/kit'
 import type { PluginZod, ResolverZod } from '../types.ts'
 import {
   applyMiniModifiers,
@@ -108,7 +108,7 @@ function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNod
   if (!objectNode) return '{}'
 
   const isCyclic = (schema: ast.SchemaNode): boolean =>
-    ctx.options.cyclicSchemas != null && ast.containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
+    ctx.options.cyclicSchemas != null && containsCircularRef(schema, { circularSchemas: ctx.options.cyclicSchemas })
 
   const entries = mapSchemaProperties(objectNode, (schema) => {
     const hasSelfRef = isCyclic(schema)
@@ -119,7 +119,7 @@ function buildZodMiniObjectShape(ctx: ZodMiniPrinterContext, node: ast.SchemaNod
     return baseOutput
   }).map(({ name: propName, property, output: baseOutput }) => {
     const { schema } = property
-    const meta = ast.syncSchemaRef(schema)
+    const meta = syncSchemaRef(schema)
 
     const value = applyMiniModifiers({
       value: baseOutput,
@@ -324,7 +324,7 @@ export const printerZodMini = ast.createPrinter<PrinterZodMiniFactory>((options)
       const transformed = this.transform(node)
       if (!transformed) return null
 
-      const meta = ast.syncSchemaRef(node)
+      const meta = syncSchemaRef(node)
 
       const base = (() => {
         if (!keysToOmit?.length || meta.primitive !== 'object' || (meta.type === 'union' && meta.discriminatorPropertyName)) return transformed

--- a/packages/plugin-zod/src/utils.ts
+++ b/packages/plugin-zod/src/utils.ts
@@ -1,5 +1,5 @@
 import { stringify, toRegExpString } from '@internals/utils'
-import { ast } from 'kubb/kit'
+import { ast, extractRefName, syncSchemaRef } from 'kubb/kit'
 import type { PluginZod } from './types.ts'
 
 /**
@@ -86,12 +86,12 @@ export function containsCodec(node: ast.SchemaNode | undefined, seen: Set<string
 
   if (node.type === 'ref') {
     if (!node.ref) return false
-    const refName = ast.extractRefName(node.ref)
+    const refName = extractRefName(node.ref)
     if (refName) {
       if (seen.has(refName)) return false
       seen.add(refName)
     }
-    const resolved = ast.syncSchemaRef(node)
+    const resolved = syncSchemaRef(node)
     if (resolved.type === 'ref') return false
     return containsCodec(resolved, seen)
   }
@@ -110,7 +110,7 @@ export function containsCodec(node: ast.SchemaNode | undefined, seen: Set<string
  * them to their input (encode) variant.
  */
 export function collectCodecRefNames(node: ast.SchemaNode): Array<string> {
-  return ast.collect<string>(node, {
+  return ast.collectSync<string>(node, {
     schema: (n) => (n.type === 'ref' && n.ref && containsCodec(n) ? (ast.resolveRefName(n) ?? undefined) : undefined),
   })
 }
@@ -138,7 +138,7 @@ export function isObjectSchemaNode(node: ast.SchemaNode, cyclicSchemas?: Readonl
   if (node.type === 'ref') {
     const refName = ast.resolveRefName(node)
     if (refName && cyclicSchemas?.has(refName)) return false
-    const resolved = ast.syncSchemaRef(node)
+    const resolved = syncSchemaRef(node)
     // An unresolved ref keeps its `ref` type; assume it resolves to an object (matches the printer's
     // prior optimism that only a resolved intersection blocks a discriminated union).
     return resolved.type === 'ref' || isObjectSchemaNode(resolved, cyclicSchemas)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,17 +7,17 @@ settings:
 catalogs:
   default:
     '@kubb/adapter-oas':
-      specifier: 5.0.0-beta.99
-      version: 5.0.0-beta.99
+      specifier: 5.0.0-beta.100
+      version: 5.0.0-beta.100
     '@kubb/core':
-      specifier: 5.0.0-beta.99
-      version: 5.0.0-beta.99
+      specifier: 5.0.0-beta.100
+      version: 5.0.0-beta.100
     '@kubb/parser-ts':
-      specifier: 5.0.0-beta.99
-      version: 5.0.0-beta.99
+      specifier: 5.0.0-beta.100
+      version: 5.0.0-beta.100
     '@kubb/plugin-barrel':
-      specifier: 5.0.0-beta.99
-      version: 5.0.0-beta.99
+      specifier: 5.0.0-beta.100
+      version: 5.0.0-beta.100
     '@types/node':
       specifier: ^22.20.1
       version: 22.20.1
@@ -31,8 +31,8 @@ catalogs:
       specifier: ^4.1.10
       version: 4.1.10
     kubb:
-      specifier: 5.0.0-beta.99
-      version: 5.0.0-beta.99
+      specifier: 5.0.0-beta.100
+      version: 5.0.0-beta.100
     oxfmt:
       specifier: ^0.58.0
       version: 0.58.0
@@ -64,13 +64,13 @@ importers:
         version: 2.31.0(@types/node@22.20.1)
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       '@kubb/plugin-barrel':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(@kubb/core@5.0.0-beta.99)
+        version: 5.0.0-beta.100(@kubb/core@5.0.0-beta.100)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:packages/plugin-cypress
@@ -94,7 +94,7 @@ importers:
         version: 1.3.14
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
       oxfmt:
         specifier: 'catalog:'
         version: 0.58.0(svelte@5.56.4)
@@ -194,13 +194,13 @@ importers:
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -209,7 +209,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -221,7 +221,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -231,7 +231,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-cypress':
         specifier: workspace:*
         version: link:../../packages/plugin-cypress
@@ -240,7 +240,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -259,7 +259,7 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../../packages/plugin-faker
@@ -271,7 +271,7 @@ importers:
         version: 1.11.21
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -284,7 +284,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -293,7 +293,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -303,10 +303,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -327,7 +327,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -343,7 +343,7 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-faker':
         specifier: workspace:*
         version: link:../../packages/plugin-faker
@@ -358,7 +358,7 @@ importers:
         version: 0.10.3(msw@2.15.0(@types/node@26.0.1)(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       msw:
         specifier: ^2.15.0
         version: 2.15.0(@types/node@26.0.1)(typescript@6.0.3)
@@ -377,7 +377,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -392,7 +392,7 @@ importers:
         version: 5.101.2(react@19.2.7)
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -408,7 +408,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -417,7 +417,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -427,10 +427,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -454,7 +454,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -469,7 +469,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -481,7 +481,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -500,7 +500,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -509,7 +509,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -519,7 +519,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-fetch':
         specifier: workspace:*
         version: link:../../packages/plugin-fetch
@@ -534,7 +534,7 @@ importers:
         version: 5.101.2(vue@3.5.39(typescript@6.0.3))
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       vue:
         specifier: ^3.5.39
         version: 3.5.39(typescript@6.0.3)
@@ -547,7 +547,7 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/plugin-ts':
         specifier: workspace:*
         version: link:../../packages/plugin-ts
@@ -559,7 +559,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -586,7 +586,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -599,11 +599,11 @@ importers:
         version: link:../utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@types/node':
         specifier: 'catalog:'
         version: 22.20.1
@@ -621,7 +621,7 @@ importers:
         version: link:../../packages/plugin-ts
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -653,7 +653,7 @@ importers:
         version: 1.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -672,7 +672,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-faker:
     dependencies:
@@ -688,7 +688,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-fetch:
     dependencies:
@@ -707,7 +707,7 @@ importers:
         version: link:../../internals/shared
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -732,7 +732,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-msw:
     dependencies:
@@ -751,7 +751,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-react-query:
     dependencies:
@@ -773,17 +773,17 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-redoc:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
     devDependencies:
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-swr:
     dependencies:
@@ -805,13 +805,13 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-ts:
     dependencies:
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -824,7 +824,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-vue-query:
     dependencies:
@@ -846,7 +846,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/plugin-zod:
     devDependencies:
@@ -858,7 +858,7 @@ importers:
         version: link:../../internals/utils
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
 
   tests/3.0.x:
     dependencies:
@@ -867,13 +867,13 @@ importers:
         version: link:../../internals/utils
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -912,7 +912,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -928,10 +928,10 @@ importers:
         version: 10.5.0
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/parser-ts':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -967,7 +967,7 @@ importers:
         version: 15.18.1
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
       msw:
         specifier: ^2.15.0
         version: 2.15.0(@types/node@26.0.1)(typescript@6.0.3)
@@ -995,10 +995,10 @@ importers:
     dependencies:
       '@kubb/adapter-oas':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)
+        version: 5.0.0-beta.100(openapi-types@12.1.3)
       '@kubb/core':
         specifier: 'catalog:'
-        version: 5.0.0-beta.99
+        version: 5.0.0-beta.100
       '@kubb/plugin-axios':
         specifier: workspace:*
         version: link:../../packages/plugin-axios
@@ -1013,7 +1013,7 @@ importers:
         version: link:../../packages/plugin-zod
       kubb:
         specifier: 'catalog:'
-        version: 5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -1226,58 +1226,58 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@kubb/adapter-oas@5.0.0-beta.99':
-    resolution: {integrity: sha512-c2KlXDUKOTNrBn0gur2rIhcacoLmQyBq7eFGaNewH5f9zqMilo0X9E6x2qmh5BTHDiTcAjwQoGObrWs5dmSWFQ==}
+  '@kubb/adapter-oas@5.0.0-beta.100':
+    resolution: {integrity: sha512-xMzRczqu3wMb7fQ+g1vNE0ti/9POVQ8YMj3GxyBOwWIMcnCtewEQY1ueifYrOhSFSj+alikLE2RJNMeyNRsYiQ==}
     engines: {node: '>=22'}
 
-  '@kubb/ast@5.0.0-beta.99':
-    resolution: {integrity: sha512-kPHSh8TikWf68pawSrJRQDCZp/TRtW29Acterc0CA9RRvVYFgpwAAaOaqE8arfMj+AT6tZyt4q0kaQAI3KZgAA==}
+  '@kubb/ast@5.0.0-beta.100':
+    resolution: {integrity: sha512-s/nMRnPkTO+EMafjv5Y6erxCN37l5r67DsiM4seajC20bw7xbjfHWryrDdkRhd0zEdv/mWvhHU97h18DT6xnrA==}
     engines: {node: '>=22'}
 
-  '@kubb/cli@5.0.0-beta.99':
-    resolution: {integrity: sha512-/CoXfXkaypSVAg//ESnM2RgsBtmVFXoCcaTidc4s9xFdRKxSNFyXqW/0DX6217ZobVR0Gci85UG6s9G9Hw+49g==}
+  '@kubb/cli@5.0.0-beta.100':
+    resolution: {integrity: sha512-AOhUTnAiapViw+lfBwyvAEI5+az9BDN277SCUjW9VgqgDzFF9EKY/7qTmLhHr/MXnEg3FU1WbPFKW9cSqGCVig==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.99
-      '@kubb/mcp': 5.0.0-beta.99
+      '@kubb/adapter-oas': 5.0.0-beta.100
+      '@kubb/mcp': 5.0.0-beta.100
     peerDependenciesMeta:
       '@kubb/adapter-oas':
         optional: true
       '@kubb/mcp':
         optional: true
 
-  '@kubb/core@5.0.0-beta.99':
-    resolution: {integrity: sha512-40e55P5wrgjuIL/fxq8wIo0h0FCvR3khJBFU/edlOuDRfqN5SbEmNXvev9ioBZGRJBU9QWqH22zPfqElKZy5Jg==}
+  '@kubb/core@5.0.0-beta.100':
+    resolution: {integrity: sha512-9PKNaUcqPflcxaGDm66udIdGwgJvnx4PrTJJBgWudBYTFeyaImddXS9fc60MeNYBaIIo3q33IZTdp7xpFMeqTQ==}
     engines: {node: '>=22'}
 
-  '@kubb/kit@5.0.0-beta.99':
-    resolution: {integrity: sha512-7kd44d77GuXS7aeVRkb6VXzOVxruyoNLTxH/HaxauJRX+a8T6SARbmQPUJvThSQUG2xXnEP5ua1ntFHvMWDR1A==}
+  '@kubb/kit@5.0.0-beta.100':
+    resolution: {integrity: sha512-Z4XmO8mFd8LdX48UgW+7ufohJWS+7hKEtggRsg01szPDAMTeUeMw9fIxssBJ9o7/RNEM5nbf9KtVAWJ0sEQrbQ==}
     engines: {node: '>=22'}
 
-  '@kubb/mcp@5.0.0-beta.99':
-    resolution: {integrity: sha512-5JIc1QM2fb1Sn3Uq0JmHjv9H0qGQk5a3pbK8fumQjFKJxItcBpzoKi+TqpMrjzsCPbzgtw5+LZO5+FuvX5G3dA==}
+  '@kubb/mcp@5.0.0-beta.100':
+    resolution: {integrity: sha512-vgjS4jlfPg2AAgmCdhrCN6lpdbtG1lvIi0n0fzpMNz2JUNWVFt/Kj7j/z0oyo+juwqa+uldOPTRi7dSH2sX5fw==}
     engines: {node: '>=22'}
     hasBin: true
     peerDependencies:
-      '@kubb/renderer-jsx': 5.0.0-beta.99
+      '@kubb/renderer-jsx': 5.0.0-beta.100
 
-  '@kubb/parser-md@5.0.0-beta.99':
-    resolution: {integrity: sha512-KKrnqWmv/BKta+PPCUZ7plnhOopqSOOISYL+rHAYIzMDqDf0+bqsuHYeNZ4y/JZCvcy6vyOT65g3Mbvqw7qFQQ==}
+  '@kubb/parser-md@5.0.0-beta.100':
+    resolution: {integrity: sha512-OA71wHdD6Zgn4wOuu7akHOGEcHoHWVMnTgkMd8ffDI3ypyynG5+57+IQYWnwhpRQ9NiWkAVr/ohI5QXT9zk2jA==}
     engines: {node: '>=22'}
 
-  '@kubb/parser-ts@5.0.0-beta.99':
-    resolution: {integrity: sha512-ENuzk24g81G+dh0yi4caWFx9IOnZhrP4zHdul8nstPi9umJ2CQfeQGrNhUOXwQhWxyqz09dBzyy2AW3mJ5/sfw==}
+  '@kubb/parser-ts@5.0.0-beta.100':
+    resolution: {integrity: sha512-/dJYuTvD2+TaFjqs1RWEYdtY4UyUKSnlnjpoMuw9r23NA+cnb0NmT8G8rlfDAfkH1K+aQMCGySjesGPbiq/y7Q==}
     engines: {node: '>=22'}
 
-  '@kubb/plugin-barrel@5.0.0-beta.99':
-    resolution: {integrity: sha512-0wjLSi2KNvMnFrlXkIaFLtf+N6fRn5lF9C+CNP8HIl6X7yRVOZhxeVYT0PC+jy9THGwZ+WpZ/o4hJBcNreqkTQ==}
+  '@kubb/plugin-barrel@5.0.0-beta.100':
+    resolution: {integrity: sha512-Rt1/wB+dkfVxplRWaZyulNUiZbHgnpzsv/i8XRa8puVum2QCufBPdC1Nnb+N2BAQvAzaWg2F5ZrC/P8b8SM9Zw==}
     engines: {node: '>=22'}
     peerDependencies:
-      '@kubb/core': 5.0.0-beta.99
+      '@kubb/core': 5.0.0-beta.100
 
-  '@kubb/renderer-jsx@5.0.0-beta.99':
-    resolution: {integrity: sha512-/DoRZIONhNkhKYEoYRtMNfg2anClRC4GrJNHJ1oaMJcasFWnDq2G9BEBy/x22ZMtyZ7CLya9esN7XMj9SmwiUg==}
+  '@kubb/renderer-jsx@5.0.0-beta.100':
+    resolution: {integrity: sha512-CVKT8+heYlaJPAnofvruB6M/J49Q7yxR+v1eX6Li+Er1gcY4dw/zN3vrdB4IBSE990BEf6on14Z9F3dEeb/hTg==}
     engines: {node: '>=22'}
 
   '@manypkg/find-root@1.1.0':
@@ -2961,8 +2961,8 @@ packages:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
     engines: {'0': node >=0.6.0}
 
-  kubb@5.0.0-beta.99:
-    resolution: {integrity: sha512-rjDoLVQmrDHfms/9wD5DibILktc/XtENWH61WVereSD2RCNfHiGJFmm0rwec83RjK2PNOiNd9wGuI1RKmkJZ/g==}
+  kubb@5.0.0-beta.100:
+    resolution: {integrity: sha512-u39VFfsAguWY4U+ZNFHIFlOchTUBgLMIJOYf962ToBdupHB8lE/iuwrGm2hbWFExYy3sDm8HXAwHsUqAZafOQQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3867,8 +3867,8 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unplugin-kubb@5.0.0-beta.99:
-    resolution: {integrity: sha512-6t3Y/re6X1DT6Nosz6up7doHuuRBq0KMokHNCPpNxxVfC6y44fpOJc/ysAPRRb3Iyvh77piRS5D0SFqcd70ePw==}
+  unplugin-kubb@5.0.0-beta.100:
+    resolution: {integrity: sha512-J9nsA3a8tCbI5bS89Dd0cE3dMVmBIdcGFT1X/SYtfRDQywxfqMpUnW4NaQRMTqz7nLOWIN5ply58tXfnc9GqDw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@farmfe/core': ^1.7.0
@@ -4479,10 +4479,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@kubb/adapter-oas@5.0.0-beta.99(openapi-types@12.1.3)':
+  '@kubb/adapter-oas@5.0.0-beta.100(openapi-types@12.1.3)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.99
-      '@kubb/core': 5.0.0-beta.99
+      '@kubb/ast': 5.0.0-beta.100
+      '@kubb/core': 5.0.0-beta.100
+      '@kubb/kit': 5.0.0-beta.100
       '@readme/openapi-parser': 6.2.1(openapi-types@12.1.3)
       '@scalar/openapi-upgrader': 0.2.9
       api-ref-bundler: 0.5.1
@@ -4490,35 +4491,35 @@ snapshots:
     transitivePeerDependencies:
       - openapi-types
 
-  '@kubb/ast@5.0.0-beta.99': {}
+  '@kubb/ast@5.0.0-beta.100': {}
 
-  '@kubb/cli@5.0.0-beta.99(@kubb/adapter-oas@5.0.0-beta.99(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.99(@kubb/renderer-jsx@5.0.0-beta.99)(openapi-types@12.1.3)(typescript@6.0.3))':
+  '@kubb/cli@5.0.0-beta.100(@kubb/adapter-oas@5.0.0-beta.100(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.100(@kubb/renderer-jsx@5.0.0-beta.100)(openapi-types@12.1.3)(typescript@6.0.3))':
     dependencies:
       '@clack/prompts': 1.7.0
-      '@kubb/core': 5.0.0-beta.99
+      '@kubb/core': 5.0.0-beta.100
       chokidar: 5.0.0
       gunshi: 0.36.0
       jiti: 2.7.0
       tinyexec: 1.2.4
       unconfig: 7.5.0
     optionalDependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.99(openapi-types@12.1.3)
-      '@kubb/mcp': 5.0.0-beta.99(@kubb/renderer-jsx@5.0.0-beta.99)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/adapter-oas': 5.0.0-beta.100(openapi-types@12.1.3)
+      '@kubb/mcp': 5.0.0-beta.100(@kubb/renderer-jsx@5.0.0-beta.100)(openapi-types@12.1.3)(typescript@6.0.3)
 
-  '@kubb/core@5.0.0-beta.99':
+  '@kubb/core@5.0.0-beta.100':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.99
+      '@kubb/ast': 5.0.0-beta.100
 
-  '@kubb/kit@5.0.0-beta.99':
+  '@kubb/kit@5.0.0-beta.100':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.99
-      '@kubb/core': 5.0.0-beta.99
+      '@kubb/ast': 5.0.0-beta.100
+      '@kubb/core': 5.0.0-beta.100
 
-  '@kubb/mcp@5.0.0-beta.99(@kubb/renderer-jsx@5.0.0-beta.99)(openapi-types@12.1.3)(typescript@6.0.3)':
+  '@kubb/mcp@5.0.0-beta.100(@kubb/renderer-jsx@5.0.0-beta.100)(openapi-types@12.1.3)(typescript@6.0.3)':
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.99(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.99
-      '@kubb/renderer-jsx': 5.0.0-beta.99
+      '@kubb/adapter-oas': 5.0.0-beta.100(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.100
+      '@kubb/renderer-jsx': 5.0.0-beta.100
       '@tmcp/adapter-valibot': 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))
       '@tmcp/transport-stdio': 0.4.3(tmcp@1.19.4(typescript@6.0.3))
       tmcp: 1.19.4(typescript@6.0.3)
@@ -4527,25 +4528,24 @@ snapshots:
       - openapi-types
       - typescript
 
-  '@kubb/parser-md@5.0.0-beta.99':
+  '@kubb/parser-md@5.0.0-beta.100':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.99
-      '@kubb/core': 5.0.0-beta.99
+      '@kubb/kit': 5.0.0-beta.100
       yaml: 2.9.0
 
-  '@kubb/parser-ts@5.0.0-beta.99':
+  '@kubb/parser-ts@5.0.0-beta.100':
     dependencies:
-      '@kubb/core': 5.0.0-beta.99
+      '@kubb/kit': 5.0.0-beta.100
       typescript: 6.0.3
 
-  '@kubb/plugin-barrel@5.0.0-beta.99(@kubb/core@5.0.0-beta.99)':
+  '@kubb/plugin-barrel@5.0.0-beta.100(@kubb/core@5.0.0-beta.100)':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.99
-      '@kubb/core': 5.0.0-beta.99
+      '@kubb/ast': 5.0.0-beta.100
+      '@kubb/core': 5.0.0-beta.100
 
-  '@kubb/renderer-jsx@5.0.0-beta.99':
+  '@kubb/renderer-jsx@5.0.0-beta.100':
     dependencies:
-      '@kubb/ast': 5.0.0-beta.99
+      '@kubb/kit': 5.0.0-beta.100
       yaml: 2.9.0
 
   '@manypkg/find-root@1.1.0':
@@ -6071,19 +6071,19 @@ snapshots:
       json-schema: 0.4.0
       verror: 1.10.0
 
-  kubb@5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
+  kubb@5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.99(openapi-types@12.1.3)
-      '@kubb/ast': 5.0.0-beta.99
-      '@kubb/cli': 5.0.0-beta.99(@kubb/adapter-oas@5.0.0-beta.99(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.99(@kubb/renderer-jsx@5.0.0-beta.99)(openapi-types@12.1.3)(typescript@6.0.3))
-      '@kubb/core': 5.0.0-beta.99
-      '@kubb/kit': 5.0.0-beta.99
-      '@kubb/mcp': 5.0.0-beta.99(@kubb/renderer-jsx@5.0.0-beta.99)(openapi-types@12.1.3)(typescript@6.0.3)
-      '@kubb/parser-md': 5.0.0-beta.99
-      '@kubb/parser-ts': 5.0.0-beta.99
-      '@kubb/plugin-barrel': 5.0.0-beta.99(@kubb/core@5.0.0-beta.99)
-      '@kubb/renderer-jsx': 5.0.0-beta.99
-      unplugin-kubb: 5.0.0-beta.99(@kubb/core@5.0.0-beta.99)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@kubb/adapter-oas': 5.0.0-beta.100(openapi-types@12.1.3)
+      '@kubb/ast': 5.0.0-beta.100
+      '@kubb/cli': 5.0.0-beta.100(@kubb/adapter-oas@5.0.0-beta.100(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.100(@kubb/renderer-jsx@5.0.0-beta.100)(openapi-types@12.1.3)(typescript@6.0.3))
+      '@kubb/core': 5.0.0-beta.100
+      '@kubb/kit': 5.0.0-beta.100
+      '@kubb/mcp': 5.0.0-beta.100(@kubb/renderer-jsx@5.0.0-beta.100)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/parser-md': 5.0.0-beta.100
+      '@kubb/parser-ts': 5.0.0-beta.100
+      '@kubb/plugin-barrel': 5.0.0-beta.100(@kubb/core@5.0.0-beta.100)
+      '@kubb/renderer-jsx': 5.0.0-beta.100
+      unplugin-kubb: 5.0.0-beta.100(@kubb/core@5.0.0-beta.100)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@nuxt/kit'
@@ -6099,19 +6099,19 @@ snapshots:
       - vite
       - webpack
 
-  kubb@5.0.0-beta.99(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
+  kubb@5.0.0-beta.100(openapi-types@12.1.3)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.99(openapi-types@12.1.3)
-      '@kubb/ast': 5.0.0-beta.99
-      '@kubb/cli': 5.0.0-beta.99(@kubb/adapter-oas@5.0.0-beta.99(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.99(@kubb/renderer-jsx@5.0.0-beta.99)(openapi-types@12.1.3)(typescript@6.0.3))
-      '@kubb/core': 5.0.0-beta.99
-      '@kubb/kit': 5.0.0-beta.99
-      '@kubb/mcp': 5.0.0-beta.99(@kubb/renderer-jsx@5.0.0-beta.99)(openapi-types@12.1.3)(typescript@6.0.3)
-      '@kubb/parser-md': 5.0.0-beta.99
-      '@kubb/parser-ts': 5.0.0-beta.99
-      '@kubb/plugin-barrel': 5.0.0-beta.99(@kubb/core@5.0.0-beta.99)
-      '@kubb/renderer-jsx': 5.0.0-beta.99
-      unplugin-kubb: 5.0.0-beta.99(@kubb/core@5.0.0-beta.99)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@kubb/adapter-oas': 5.0.0-beta.100(openapi-types@12.1.3)
+      '@kubb/ast': 5.0.0-beta.100
+      '@kubb/cli': 5.0.0-beta.100(@kubb/adapter-oas@5.0.0-beta.100(openapi-types@12.1.3))(@kubb/mcp@5.0.0-beta.100(@kubb/renderer-jsx@5.0.0-beta.100)(openapi-types@12.1.3)(typescript@6.0.3))
+      '@kubb/core': 5.0.0-beta.100
+      '@kubb/kit': 5.0.0-beta.100
+      '@kubb/mcp': 5.0.0-beta.100(@kubb/renderer-jsx@5.0.0-beta.100)(openapi-types@12.1.3)(typescript@6.0.3)
+      '@kubb/parser-md': 5.0.0-beta.100
+      '@kubb/parser-ts': 5.0.0-beta.100
+      '@kubb/plugin-barrel': 5.0.0-beta.100(@kubb/core@5.0.0-beta.100)
+      '@kubb/renderer-jsx': 5.0.0-beta.100
+      unplugin-kubb: 5.0.0-beta.100(@kubb/core@5.0.0-beta.100)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@nuxt/kit'
@@ -7027,12 +7027,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-kubb@5.0.0-beta.99(@kubb/core@5.0.0-beta.99)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.100(@kubb/core@5.0.0-beta.100)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.99(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.99
-      '@kubb/parser-ts': 5.0.0-beta.99
-      '@kubb/plugin-barrel': 5.0.0-beta.99(@kubb/core@5.0.0-beta.99)
+      '@kubb/adapter-oas': 5.0.0-beta.100(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.100
+      '@kubb/parser-ts': 5.0.0-beta.100
+      '@kubb/plugin-barrel': 5.0.0-beta.100(@kubb/core@5.0.0-beta.100)
       unplugin: 3.3.0(rolldown@1.1.5)(vite@8.1.0(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       rolldown: 1.1.5
@@ -7043,12 +7043,12 @@ snapshots:
       - openapi-types
       - unloader
 
-  unplugin-kubb@5.0.0-beta.99(@kubb/core@5.0.0-beta.99)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
+  unplugin-kubb@5.0.0-beta.100(@kubb/core@5.0.0-beta.100)(openapi-types@12.1.3)(rolldown@1.1.5)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
-      '@kubb/adapter-oas': 5.0.0-beta.99(openapi-types@12.1.3)
-      '@kubb/core': 5.0.0-beta.99
-      '@kubb/parser-ts': 5.0.0-beta.99
-      '@kubb/plugin-barrel': 5.0.0-beta.99(@kubb/core@5.0.0-beta.99)
+      '@kubb/adapter-oas': 5.0.0-beta.100(openapi-types@12.1.3)
+      '@kubb/core': 5.0.0-beta.100
+      '@kubb/parser-ts': 5.0.0-beta.100
+      '@kubb/plugin-barrel': 5.0.0-beta.100(@kubb/core@5.0.0-beta.100)
       unplugin: 3.3.0(rolldown@1.1.5)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(yaml@2.9.0))
     optionalDependencies:
       rolldown: 1.1.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,15 +12,15 @@ allowBuilds:
   vue-demi: true
 
 catalog:
-  '@kubb/adapter-oas': 5.0.0-beta.99
-  '@kubb/core': 5.0.0-beta.99
-  '@kubb/plugin-barrel': 5.0.0-beta.99
-  '@kubb/parser-ts': 5.0.0-beta.99
+  '@kubb/adapter-oas': 5.0.0-beta.100
+  '@kubb/core': 5.0.0-beta.100
+  '@kubb/plugin-barrel': 5.0.0-beta.100
+  '@kubb/parser-ts': 5.0.0-beta.100
   '@types/node': ^22.20.1
   '@types/react': ^19.2.17
   '@vitest/coverage-v8': ^4.1.10
   '@vitest/ui': ^4.1.10
-  kubb: 5.0.0-beta.99
+  kubb: 5.0.0-beta.100
   oxfmt: ^0.58.0
   oxlint: ^1.73.0
   prettier: ^3.9.5


### PR DESCRIPTION
## 🎯 Changes

Companion change to [kubb-labs/kubb#3794](https://github.com/kubb-labs/kubb/pull/3794), which moves the macro presets and several ref/schema-graph helpers from `@kubb/ast` to `@kubb/kit`, and renames the visitor's collection passes (`collectLazy` → `collect`, `collect` → `collectSync`).

Updates every call site that reached a moved helper through the `ast` namespace (`ast.macroSimplifyUnion`, `ast.isStringType`, `ast.containsCircularRef`, `ast.syncSchemaRef`, `ast.extractRefName`, `ast.collect`) to import the flat export from `kubb/kit` instead:

- `internals/client/src/macros.ts` — `macroSimplifyUnion`
- `internals/shared/src/refs.ts` — `collectSync`
- `packages/plugin-ts/src/{factory.ts,utils.ts,printers/printerTs.ts,components/Type.tsx}` — `syncSchemaRef`, `isStringType`, `collectSync`
- `packages/plugin-zod/src/{utils.ts,printers/printerZod.ts,printers/printerZodMini.ts}` — `extractRefName`, `syncSchemaRef`, `containsCircularRef`
- `packages/plugin-faker/src/{printers/printerFaker.ts,components/Faker.tsx}` — `containsCircularRef`

A few files now use `ast` only for types, so those imports became type-only (`import type { ast } from 'kubb/kit'`).

**This PR depends on the kubb PR above shipping in a `kubb` release.** Verified locally by linking this repo's `kubb`/`@kubb/*` dependencies to the local `kubb` checkout (`pnpm-workspace.yaml`'s commented `overrides` block) and confirming every touched package typechecks, lints, and tests cleanly (`plugin-ts`, `plugin-zod`, `plugin-faker`, `internals/client`, `internals/shared`, and the full `packages/*` typecheck). Against the currently published `kubb` package, this won't typecheck until the kubb PR is merged and released.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for the three packages whose source changed (`plugin-ts`, `plugin-zod`, `plugin-faker`). `@internals/client` and `@internals/shared` are excluded from changesets versioning (private, unpublished workspace packages).
- [ ] This change is for the docs (no release).
