### PR TITLE
fix(plugin-ts): omit bare @type JSDoc comments that duplicate the TS type

### DIFF
--- a/.changeset/quiet-jsdoc-types-vanish.md
+++ b/.changeset/quiet-jsdoc-types-vanish.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-ts": patch
+---
+
+Omit the `@type` JSDoc tag when it would be the only content of a comment block, since it just repeats the TypeScript type already next to the property.

--- a/examples/advanced/src/gen/models/ts/AddPetRequest.ts
+++ b/examples/advanced/src/gen/models/ts/AddPetRequest.ts
@@ -2,9 +2,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { TagTag } from './tag/Tag'
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -18,17 +15,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<TagTag>
   /**
    * @description pet status in the store

--- a/examples/advanced/src/gen/models/ts/Animal.ts
+++ b/examples/advanced/src/gen/models/ts/Animal.ts
@@ -4,15 +4,9 @@ import type { Dog } from './Dog'
 
 export type Animal = (
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
 ) & {

--- a/examples/advanced/src/gen/models/ts/ApiResponse.ts
+++ b/examples/advanced/src/gen/models/ts/ApiResponse.ts
@@ -1,6 +1,3 @@
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -8,12 +5,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/advanced/src/gen/models/ts/Cat.ts
+++ b/examples/advanced/src/gen/models/ts/Cat.ts
@@ -1,18 +1,9 @@
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string
    */
   readonly type: string
-  /**
-   * @type string | undefined
-   */
   name?: string
-  /**
-   * @type boolean
-   */
   indoor: boolean
 }

--- a/examples/advanced/src/gen/models/ts/Category.ts
+++ b/examples/advanced/src/gen/models/ts/Category.ts
@@ -1,6 +1,3 @@
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/advanced/src/gen/models/ts/Dog.ts
+++ b/examples/advanced/src/gen/models/ts/Dog.ts
@@ -1,17 +1,11 @@
 import type { Image } from './Image'
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string
    */
   readonly type: string
-  /**
-   * @type string
-   */
   name: string
   /**
    * @example linode/debian10

--- a/examples/advanced/src/gen/models/ts/Order.ts
+++ b/examples/advanced/src/gen/models/ts/Order.ts
@@ -3,9 +3,6 @@ import type { OrderOrderTypeEnumKey } from './OrderOrderTypeEnum'
 import type { OrderParamsStatusEnumKey } from './OrderParamsStatusEnum'
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -21,18 +18,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: number
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -65,8 +56,5 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/advanced/src/gen/models/ts/Pet.ts
+++ b/examples/advanced/src/gen/models/ts/Pet.ts
@@ -2,9 +2,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { TagTag } from './tag/Tag'
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -13,9 +10,6 @@ export type Pet = {
    * @type integer | undefined
    */
   readonly id?: number
-  /**
-   * @type array | undefined
-   */
   parent?: Array<Pet>
   /**
    * @pattern ^data:image\/(png|jpeg|gif|webp);base64,([A-Za-z0-9+/]+={0,2})$
@@ -34,17 +28,8 @@ export type Pet = {
    * @type string | undefined
    */
   url?: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<TagTag>
   /**
    * @description pet status in the store

--- a/examples/advanced/src/gen/models/ts/PetEvent.ts
+++ b/examples/advanced/src/gen/models/ts/PetEvent.ts
@@ -1,17 +1,11 @@
 import type { Pet } from './Pet'
 import type { PetEventTypeEnumKey } from './PetEventTypeEnum'
 
-/**
- * @type object
- */
 export type PetEvent = {
   /**
    * @description The kind of change that occurred
    */
   type: PetEventTypeEnumKey
-  /**
-   * @type object
-   */
   pet: Pet
   /**
    * @description

--- a/examples/advanced/src/gen/models/ts/PetNotFound.ts
+++ b/examples/advanced/src/gen/models/ts/PetNotFound.ts
@@ -1,6 +1,3 @@
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -8,8 +5,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/advanced/src/gen/models/ts/pet/AddFiles.ts
+++ b/examples/advanced/src/gen/models/ts/pet/AddFiles.ts
@@ -1,18 +1,9 @@
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddFilesStatus200 = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type unknown
- */
 export type AddFilesStatus405 = unknown
 
-/**
- * @type object
- */
 export type AddFilesBodyJson = {
   /**
    * @description URL of the image to upload
@@ -23,16 +14,10 @@ export type AddFilesBodyJson = {
   url: string
 }
 
-/**
- * @type object
- */
 export type AddFilesBodyFormData = Omit<NonNullable<Pet>, 'id'>
 
 export type AddFilesBody = AddFilesBodyJson | AddFilesBodyFormData
 
-/**
- * @type object
- */
 export type AddFilesOptions = {
   body: AddFilesBody
   path?: never
@@ -40,9 +25,6 @@ export type AddFilesOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddFilesResponses = {
   '200': AddFilesStatus200
   '405': AddFilesStatus405

--- a/examples/advanced/src/gen/models/ts/pet/AddPet.ts
+++ b/examples/advanced/src/gen/models/ts/pet/AddPet.ts
@@ -1,9 +1,6 @@
 import type { AddPetRequest } from '../AddPetRequest'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -11,20 +8,11 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type AddPetStatusDefaultJson = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type object
- */
 export type AddPetStatusDefaultXml = Omit<NonNullable<Pet>, 'name'>
 
 export type AddPetStatusDefault = AddPetStatusDefaultJson | AddPetStatusDefaultXml
@@ -49,9 +37,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'id'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -59,9 +44,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '405': AddPetStatus405
   default:

--- a/examples/advanced/src/gen/models/ts/pet/DeletePet.ts
+++ b/examples/advanced/src/gen/models/ts/pet/DeletePet.ts
@@ -1,6 +1,3 @@
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -11,24 +8,12 @@ export type DeletePetPath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -36,9 +21,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/advanced/src/gen/models/ts/pet/FindPetsByStatus.ts
+++ b/examples/advanced/src/gen/models/ts/pet/FindPetsByStatus.ts
@@ -1,35 +1,17 @@
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByStatusPath = {
-  /**
-   * @type string
-   */
   step_id: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path: FindPetsByStatusPath
@@ -37,9 +19,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/advanced/src/gen/models/ts/pet/FindPetsByTags.ts
+++ b/examples/advanced/src/gen/models/ts/pet/FindPetsByTags.ts
@@ -1,9 +1,6 @@
 import type { FindPetsByTagsXEXAMPLEKey } from '../FindPetsByTagsXEXAMPLE'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -22,9 +19,6 @@ export type FindPetsByTagsQuery = {
   pageSize?: number
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsHeaders = {
   /**
    * @description Header parameters
@@ -32,26 +26,14 @@ export type FindPetsByTagsHeaders = {
   'X-EXAMPLE': FindPetsByTagsXEXAMPLEKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -59,9 +41,6 @@ export type FindPetsByTagsOptions = {
   headers: FindPetsByTagsHeaders
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/advanced/src/gen/models/ts/pet/GetPetById.ts
+++ b/examples/advanced/src/gen/models/ts/pet/GetPetById.ts
@@ -1,8 +1,5 @@
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -13,31 +10,16 @@ export type GetPetByIdPath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Omit<NonNullable<Pet>, 'name'>
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -45,9 +27,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/advanced/src/gen/models/ts/pet/UpdatePet.ts
+++ b/examples/advanced/src/gen/models/ts/pet/UpdatePet.ts
@@ -1,20 +1,11 @@
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Omit<NonNullable<Pet>, 'name'>
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type object
- */
 export type UpdatePetStatus202 = {
   /**
    * @description
@@ -25,19 +16,10 @@ export type UpdatePetStatus202 = {
   id?: number
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -60,9 +42,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'id'>
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -70,9 +49,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/advanced/src/gen/models/ts/pet/UpdatePetWithForm.ts
+++ b/examples/advanced/src/gen/models/ts/pet/UpdatePetWithForm.ts
@@ -1,6 +1,3 @@
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -11,9 +8,6 @@ export type UpdatePetWithFormPath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -27,14 +21,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -42,9 +30,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/advanced/src/gen/models/ts/pet/UploadFile.ts
+++ b/examples/advanced/src/gen/models/ts/pet/UploadFile.ts
@@ -1,8 +1,5 @@
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -13,9 +10,6 @@ export type UploadFilePath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -24,19 +18,10 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type string
- */
 export type UploadFileBody = Blob
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -44,9 +29,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/advanced/src/gen/models/ts/pets/CreatePets.ts
+++ b/examples/advanced/src/gen/models/ts/pets/CreatePets.ts
@@ -2,9 +2,6 @@ import type { CreatePetsBoolParamKey } from '../CreatePetsBoolParam'
 import type { CreatePetsXEXAMPLEKey } from '../CreatePetsXEXAMPLE'
 import type { PetNotFound } from '../PetNotFound'
 
-/**
- * @type object
- */
 export type CreatePetsPath = {
   /**
    * @description UUID
@@ -13,9 +10,6 @@ export type CreatePetsPath = {
   uuid: string
 }
 
-/**
- * @type object
- */
 export type CreatePetsQuery = {
   bool_param?: CreatePetsBoolParamKey
   /**
@@ -25,9 +19,6 @@ export type CreatePetsQuery = {
   offset?: number
 }
 
-/**
- * @type object
- */
 export type CreatePetsHeaders = {
   /**
    * @description Header parameters
@@ -35,9 +26,6 @@ export type CreatePetsHeaders = {
   'X-EXAMPLE': CreatePetsXEXAMPLEKey
 }
 
-/**
- * @type unknown
- */
 export type CreatePetsStatus201 = unknown
 
 /**
@@ -46,23 +34,11 @@ export type CreatePetsStatus201 = unknown
  */
 export type CreatePetsStatusDefault = PetNotFound
 
-/**
- * @type object
- */
 export type CreatePetsBody = {
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string
-   */
   tag: string
 }
 
-/**
- * @type object
- */
 export type CreatePetsOptions = {
   body: CreatePetsBody
   path: CreatePetsPath
@@ -70,9 +46,6 @@ export type CreatePetsOptions = {
   headers: CreatePetsHeaders
 }
 
-/**
- * @type object
- */
 export type CreatePetsResponses = {
   '201': CreatePetsStatus201
   default: CreatePetsStatusDefault

--- a/examples/advanced/src/gen/models/ts/store/DeleteOrder.ts
+++ b/examples/advanced/src/gen/models/ts/store/DeleteOrder.ts
@@ -1,6 +1,3 @@
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -11,19 +8,10 @@ export type DeleteOrderPath = {
   orderId: number
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -31,9 +19,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/advanced/src/gen/models/ts/store/GetInventory.ts
+++ b/examples/advanced/src/gen/models/ts/store/GetInventory.ts
@@ -1,13 +1,7 @@
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -15,9 +9,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/advanced/src/gen/models/ts/store/GetOrderById.ts
+++ b/examples/advanced/src/gen/models/ts/store/GetOrderById.ts
@@ -1,8 +1,5 @@
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -13,31 +10,16 @@ export type GetOrderByIdPath = {
   orderId: number
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -45,9 +27,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/advanced/src/gen/models/ts/store/PlaceOrder.ts
+++ b/examples/advanced/src/gen/models/ts/store/PlaceOrder.ts
@@ -1,35 +1,17 @@
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -37,9 +19,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/advanced/src/gen/models/ts/store/PlaceOrderPatch.ts
+++ b/examples/advanced/src/gen/models/ts/store/PlaceOrderPatch.ts
@@ -1,35 +1,17 @@
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -37,9 +19,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/advanced/src/gen/models/ts/stream/StreamPetEvents.ts
+++ b/examples/advanced/src/gen/models/ts/stream/StreamPetEvents.ts
@@ -1,8 +1,5 @@
 import type { PetEvent } from '../PetEvent'
 
-/**
- * @type object
- */
 export type StreamPetEventsPath = {
   /**
    * @description ID of pet to stream events for
@@ -13,14 +10,8 @@ export type StreamPetEventsPath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type StreamPetEventsStatus200 = PetEvent
 
-/**
- * @type object
- */
 export type StreamPetEventsOptions = {
   body?: never
   path: StreamPetEventsPath
@@ -28,9 +19,6 @@ export type StreamPetEventsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type StreamPetEventsResponses = {
   '200': StreamPetEventsStatus200
 }

--- a/examples/advanced/src/gen/models/ts/tag/Tag.ts
+++ b/examples/advanced/src/gen/models/ts/tag/Tag.ts
@@ -11,8 +11,5 @@ export type TagTag = {
    * @type integer | undefined
    */
   id?: number
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/axios/src/gen/models/AddPetRequest.ts
+++ b/examples/axios/src/gen/models/AddPetRequest.ts
@@ -14,9 +14,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/axios/src/gen/models/Address.ts
+++ b/examples/axios/src/gen/models/Address.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Address = {
   /**
    * @example 437 Lytton

--- a/examples/axios/src/gen/models/ApiResponse.ts
+++ b/examples/axios/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/axios/src/gen/models/Category.ts
+++ b/examples/axios/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/axios/src/gen/models/Customer.ts
+++ b/examples/axios/src/gen/models/Customer.ts
@@ -5,9 +5,6 @@
 
 import type { Address } from './Address'
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -21,8 +18,5 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Address[]
 }

--- a/examples/axios/src/gen/models/Order.ts
+++ b/examples/axios/src/gen/models/Order.ts
@@ -19,9 +19,6 @@ export const orderHttpStatusEnum = {
 
 export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof orderHttpStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -62,8 +59,5 @@ export type Order = {
    * @type number | undefined
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/axios/src/gen/models/Pet.ts
+++ b/examples/axios/src/gen/models/Pet.ts
@@ -14,9 +14,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/axios/src/gen/models/PetNotFound.ts
+++ b/examples/axios/src/gen/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/axios/src/gen/models/Tag.ts
+++ b/examples/axios/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/axios/src/gen/models/User.ts
+++ b/examples/axios/src/gen/models/User.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type User = {
   /**
    * @description

--- a/examples/axios/src/gen/models/UserArray.ts
+++ b/examples/axios/src/gen/models/UserArray.ts
@@ -5,7 +5,4 @@
 
 import type { User } from './User'
 
-/**
- * @type array
- */
 export type UserArray = User[]

--- a/examples/axios/src/gen/models/pet/AddPet.ts
+++ b/examples/axios/src/gen/models/pet/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from '../AddPetRequest'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/pet/DeletePet.ts
+++ b/examples/axios/src/gen/models/pet/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/axios/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/axios/src/gen/models/pet/FindPetsByStatus.ts
@@ -13,9 +13,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -25,26 +22,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -52,9 +37,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/axios/src/gen/models/pet/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/pet/GetPetById.ts
+++ b/examples/axios/src/gen/models/pet/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/pet/UpdatePet.ts
+++ b/examples/axios/src/gen/models/pet/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/axios/src/gen/models/pet/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/axios/src/gen/models/pet/UploadFile.ts
+++ b/examples/axios/src/gen/models/pet/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,14 +23,8 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type object
- */
 export type UploadFileBodyJson = {
   /**
    * @description URL of the image to upload
@@ -47,21 +35,12 @@ export type UploadFileBodyJson = {
   url: string
 }
 
-/**
- * @type object
- */
 export type UploadFileBodyFormData = {
-  /**
-   * @type string
-   */
   file: Blob
 }
 
 export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -69,9 +48,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/axios/src/gen/models/store/DeleteOrder.ts
+++ b/examples/axios/src/gen/models/store/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/axios/src/gen/models/store/GetInventory.ts
+++ b/examples/axios/src/gen/models/store/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/axios/src/gen/models/store/GetOrderById.ts
+++ b/examples/axios/src/gen/models/store/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/store/PlaceOrder.ts
+++ b/examples/axios/src/gen/models/store/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/axios/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/axios/src/gen/models/store/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/axios/src/gen/models/user/CreateUser.ts
+++ b/examples/axios/src/gen/models/user/CreateUser.ts
@@ -5,14 +5,8 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultJson = User
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultXml = User
 
 export type CreateUserStatusDefault = CreateUserStatusDefaultJson | CreateUserStatusDefaultXml
@@ -37,9 +31,6 @@ export type CreateUserBodyFormUrlEncoded = User | undefined
 
 export type CreateUserBody = CreateUserBodyJson | CreateUserBodyXml | CreateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type CreateUserOptions = {
   body: CreateUserBody
   path?: never
@@ -47,9 +38,6 @@ export type CreateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUserResponses = {
   default:
     | {

--- a/examples/axios/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/axios/src/gen/models/user/CreateUsersWithListInput.ts
@@ -5,31 +5,16 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Json = User
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Xml = User
 
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
-/**
- * @type unknown
- */
 export type CreateUsersWithListInputStatusDefault = unknown
 
-/**
- * @type array | undefined
- */
 export type CreateUsersWithListInputBody = User[] | undefined
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputOptions = {
   body: CreateUsersWithListInputBody
   path?: never
@@ -37,9 +22,6 @@ export type CreateUsersWithListInputOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/user/DeleteUser.ts
+++ b/examples/axios/src/gen/models/user/DeleteUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteUserPath = {
   /**
    * @description The name that needs to be deleted
@@ -14,19 +11,10 @@ export type DeleteUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteUserOptions = {
   body?: never
   path: DeleteUserPath
@@ -34,9 +22,6 @@ export type DeleteUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteUserResponses = {
   '400': DeleteUserStatus400
   '404': DeleteUserStatus404

--- a/examples/axios/src/gen/models/user/GetUserByName.ts
+++ b/examples/axios/src/gen/models/user/GetUserByName.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type GetUserByNamePath = {
   /**
    * @description The name that needs to be fetched. Use user1 for testing.
@@ -16,31 +13,16 @@ export type GetUserByNamePath = {
   username: string
 }
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Json = User
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Xml = User
 
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetUserByNameOptions = {
   body?: never
   path: GetUserByNamePath
@@ -48,9 +30,6 @@ export type GetUserByNameOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetUserByNameResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/user/LoginUser.ts
+++ b/examples/axios/src/gen/models/user/LoginUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type LoginUserQuery = {
   /**
    * @description The user name for login
@@ -19,26 +16,14 @@ export type LoginUserQuery = {
   password?: string
 }
 
-/**
- * @type string
- */
 export type LoginUserStatus200Xml = string
 
-/**
- * @type string
- */
 export type LoginUserStatus200Json = string
 
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
-/**
- * @type unknown
- */
 export type LoginUserStatus400 = unknown
 
-/**
- * @type object
- */
 export type LoginUserOptions = {
   body?: never
   path?: never
@@ -46,9 +31,6 @@ export type LoginUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LoginUserResponses = {
   '200':
     | {

--- a/examples/axios/src/gen/models/user/LogoutUser.ts
+++ b/examples/axios/src/gen/models/user/LogoutUser.ts
@@ -3,14 +3,8 @@
  * Do not edit manually.
  */
 
-/**
- * @type unknown
- */
 export type LogoutUserStatusDefault = unknown
 
-/**
- * @type object
- */
 export type LogoutUserOptions = {
   body?: never
   path?: never
@@ -18,9 +12,6 @@ export type LogoutUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LogoutUserResponses = {
   default: LogoutUserStatusDefault
 }

--- a/examples/axios/src/gen/models/user/UpdateUser.ts
+++ b/examples/axios/src/gen/models/user/UpdateUser.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type UpdateUserPath = {
   /**
    * @description name that need to be deleted
@@ -16,9 +13,6 @@ export type UpdateUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type UpdateUserStatusDefault = unknown
 
 /**
@@ -41,9 +35,6 @@ export type UpdateUserBodyFormUrlEncoded = User | undefined
 
 export type UpdateUserBody = UpdateUserBodyJson | UpdateUserBodyXml | UpdateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdateUserOptions = {
   body: UpdateUserBody
   path: UpdateUserPath
@@ -51,9 +42,6 @@ export type UpdateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdateUserResponses = {
   default: UpdateUserStatusDefault
 }

--- a/examples/cypress/src/gen-v4/models.ts
+++ b/examples/cypress/src/gen-v4/models.ts
@@ -19,9 +19,6 @@ export const orderHttpStatusEnum = {
 
 export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof orderHttpStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -62,15 +59,9 @@ export type Order = {
    * @type number | undefined
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -86,9 +77,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -96,9 +84,6 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
@@ -110,9 +95,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -126,17 +108,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -153,9 +126,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -169,17 +139,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -188,9 +149,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnumKey
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -198,19 +156,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -218,37 +167,19 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -271,9 +202,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -281,9 +209,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -304,21 +229,12 @@ export type UpdatePetResponses = {
  */
 export type UpdatePetResponse = UpdatePetStatus200 | UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -326,9 +242,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -352,9 +265,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -362,9 +272,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -383,14 +290,8 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type array
- */
 export type OptionsFindPetsByStatusStatus200 = Array<Pet>
 
-/**
- * @type object
- */
 export type OptionsFindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -398,9 +299,6 @@ export type OptionsFindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type OptionsFindPetsByStatusResponses = {
   '200': OptionsFindPetsByStatusStatus200
 }
@@ -418,9 +316,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -430,26 +325,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -457,9 +340,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -478,9 +358,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -499,26 +376,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -526,9 +391,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -547,9 +409,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -560,31 +419,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -592,9 +436,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -614,9 +455,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -627,9 +465,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -643,14 +478,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -658,9 +487,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -670,9 +496,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -683,24 +506,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -708,9 +519,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }
@@ -720,9 +528,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -733,9 +538,6 @@ export type UploadFilePath = {
   pet_id: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -744,19 +546,10 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type string | undefined
- */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -764,9 +557,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -776,16 +566,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -793,9 +577,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -805,36 +586,18 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -842,9 +605,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -855,36 +615,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -892,9 +634,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -905,9 +644,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -918,31 +654,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -950,9 +671,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -972,9 +690,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -985,19 +700,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1005,9 +711,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/cypress/src/gen/models.ts
+++ b/examples/cypress/src/gen/models.ts
@@ -19,9 +19,6 @@ export const orderHttpStatusEnum = {
 
 export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof orderHttpStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -62,15 +59,9 @@ export type Order = {
    * @type number | undefined
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -86,9 +77,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -96,9 +84,6 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
@@ -110,9 +95,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -126,17 +108,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store
@@ -153,9 +126,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -169,17 +139,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store
@@ -188,9 +149,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnumKey
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -198,19 +156,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -218,37 +167,19 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -271,9 +202,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -281,9 +209,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -304,21 +229,12 @@ export type UpdatePetResponses = {
  */
 export type UpdatePetResponse = UpdatePetStatus200 | UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -326,9 +242,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -352,9 +265,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -362,9 +272,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -383,14 +290,8 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type array
- */
 export type OptionsFindPetsByStatusStatus200 = Pet[]
 
-/**
- * @type object
- */
 export type OptionsFindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -398,9 +299,6 @@ export type OptionsFindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type OptionsFindPetsByStatusResponses = {
   '200': OptionsFindPetsByStatusStatus200
 }
@@ -418,9 +316,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -430,26 +325,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -457,9 +340,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -478,9 +358,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -499,26 +376,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -526,9 +391,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -547,9 +409,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -560,31 +419,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -592,9 +436,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -614,9 +455,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -627,9 +465,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -643,14 +478,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -658,9 +487,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -670,9 +496,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -683,24 +506,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -708,9 +519,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }
@@ -720,9 +528,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -733,9 +538,6 @@ export type UploadFilePath = {
   pet_id: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -744,19 +546,10 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type string | undefined
- */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -764,9 +557,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -776,16 +566,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -793,9 +577,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -805,36 +586,18 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -842,9 +605,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -855,36 +615,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -892,9 +634,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -905,9 +644,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -918,31 +654,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -950,9 +671,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -972,9 +690,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -985,19 +700,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1005,9 +711,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/faker/src/gen/models/AddPet.ts
+++ b/examples/faker/src/gen/models/AddPet.ts
@@ -5,21 +5,12 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type unknown
- */
 export type AddPetStatus405 = unknown
 
 /**
@@ -42,9 +33,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -52,9 +40,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/faker/src/gen/models/ApiResponse.ts
+++ b/examples/faker/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/faker/src/gen/models/Category.ts
+++ b/examples/faker/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/faker/src/gen/models/DeleteOrder.ts
+++ b/examples/faker/src/gen/models/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/faker/src/gen/models/DeletePet.ts
+++ b/examples/faker/src/gen/models/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/faker/src/gen/models/FindPetsByStatus.ts
+++ b/examples/faker/src/gen/models/FindPetsByStatus.ts
@@ -13,9 +13,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -25,26 +22,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -52,9 +37,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/faker/src/gen/models/FindPetsByTags.ts
+++ b/examples/faker/src/gen/models/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -16,26 +13,14 @@ export type FindPetsByTagsQuery = {
   tags?: string[]
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -43,9 +28,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/faker/src/gen/models/GetInventory.ts
+++ b/examples/faker/src/gen/models/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/faker/src/gen/models/GetOrderById.ts
+++ b/examples/faker/src/gen/models/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/faker/src/gen/models/GetPetById.ts
+++ b/examples/faker/src/gen/models/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/faker/src/gen/models/Item.ts
+++ b/examples/faker/src/gen/models/Item.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Item = {
   /**
    * @minLength 3

--- a/examples/faker/src/gen/models/Order.ts
+++ b/examples/faker/src/gen/models/Order.ts
@@ -11,9 +11,6 @@ export const orderStatusEnum = {
 
 export type OrderStatusEnumKey = (typeof orderStatusEnum)[keyof typeof orderStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -60,8 +57,5 @@ export type Order = {
    * @type string | undefined
    */
   status?: OrderStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/faker/src/gen/models/Pet.ts
+++ b/examples/faker/src/gen/models/Pet.ts
@@ -14,9 +14,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/faker/src/gen/models/PlaceOrder.ts
+++ b/examples/faker/src/gen/models/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/faker/src/gen/models/Tag.ts
+++ b/examples/faker/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/faker/src/gen/models/UpdatePet.ts
+++ b/examples/faker/src/gen/models/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/faker/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/faker/src/gen/models/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/faker/src/gen/models/UploadFile.ts
+++ b/examples/faker/src/gen/models/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type string | undefined
- */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/fetch/src/gen/models/AddPetRequest.ts
+++ b/examples/fetch/src/gen/models/AddPetRequest.ts
@@ -14,9 +14,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/fetch/src/gen/models/Address.ts
+++ b/examples/fetch/src/gen/models/Address.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Address = {
   /**
    * @example 437 Lytton

--- a/examples/fetch/src/gen/models/ApiResponse.ts
+++ b/examples/fetch/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/fetch/src/gen/models/Category.ts
+++ b/examples/fetch/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/fetch/src/gen/models/Customer.ts
+++ b/examples/fetch/src/gen/models/Customer.ts
@@ -5,9 +5,6 @@
 
 import type { Address } from './Address'
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -21,8 +18,5 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Address[]
 }

--- a/examples/fetch/src/gen/models/Order.ts
+++ b/examples/fetch/src/gen/models/Order.ts
@@ -19,9 +19,6 @@ export const orderHttpStatusEnum = {
 
 export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof orderHttpStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -62,8 +59,5 @@ export type Order = {
    * @type number | undefined
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/fetch/src/gen/models/Pet.ts
+++ b/examples/fetch/src/gen/models/Pet.ts
@@ -14,9 +14,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/fetch/src/gen/models/PetNotFound.ts
+++ b/examples/fetch/src/gen/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/fetch/src/gen/models/Tag.ts
+++ b/examples/fetch/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/fetch/src/gen/models/User.ts
+++ b/examples/fetch/src/gen/models/User.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type User = {
   /**
    * @description

--- a/examples/fetch/src/gen/models/UserArray.ts
+++ b/examples/fetch/src/gen/models/UserArray.ts
@@ -5,7 +5,4 @@
 
 import type { User } from './User'
 
-/**
- * @type array
- */
 export type UserArray = User[]

--- a/examples/fetch/src/gen/models/pet/AddPet.ts
+++ b/examples/fetch/src/gen/models/pet/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from '../AddPetRequest'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/pet/DeletePet.ts
+++ b/examples/fetch/src/gen/models/pet/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/fetch/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/fetch/src/gen/models/pet/FindPetsByStatus.ts
@@ -13,9 +13,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -25,26 +22,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -52,9 +37,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/fetch/src/gen/models/pet/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/pet/GetPetById.ts
+++ b/examples/fetch/src/gen/models/pet/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/pet/UpdatePet.ts
+++ b/examples/fetch/src/gen/models/pet/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/fetch/src/gen/models/pet/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/fetch/src/gen/models/pet/UploadFile.ts
+++ b/examples/fetch/src/gen/models/pet/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,14 +23,8 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type object
- */
 export type UploadFileBodyJson = {
   /**
    * @description URL of the image to upload
@@ -47,21 +35,12 @@ export type UploadFileBodyJson = {
   url: string
 }
 
-/**
- * @type object
- */
 export type UploadFileBodyFormData = {
-  /**
-   * @type string
-   */
   file: Blob
 }
 
 export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -69,9 +48,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/fetch/src/gen/models/store/DeleteOrder.ts
+++ b/examples/fetch/src/gen/models/store/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/fetch/src/gen/models/store/GetInventory.ts
+++ b/examples/fetch/src/gen/models/store/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/fetch/src/gen/models/store/GetOrderById.ts
+++ b/examples/fetch/src/gen/models/store/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/store/PlaceOrder.ts
+++ b/examples/fetch/src/gen/models/store/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/fetch/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/fetch/src/gen/models/store/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/fetch/src/gen/models/user/CreateUser.ts
+++ b/examples/fetch/src/gen/models/user/CreateUser.ts
@@ -5,14 +5,8 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultJson = User
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultXml = User
 
 export type CreateUserStatusDefault = CreateUserStatusDefaultJson | CreateUserStatusDefaultXml
@@ -37,9 +31,6 @@ export type CreateUserBodyFormUrlEncoded = User | undefined
 
 export type CreateUserBody = CreateUserBodyJson | CreateUserBodyXml | CreateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type CreateUserOptions = {
   body: CreateUserBody
   path?: never
@@ -47,9 +38,6 @@ export type CreateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUserResponses = {
   default:
     | {

--- a/examples/fetch/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/fetch/src/gen/models/user/CreateUsersWithListInput.ts
@@ -5,31 +5,16 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Json = User
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Xml = User
 
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
-/**
- * @type unknown
- */
 export type CreateUsersWithListInputStatusDefault = unknown
 
-/**
- * @type array | undefined
- */
 export type CreateUsersWithListInputBody = User[] | undefined
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputOptions = {
   body: CreateUsersWithListInputBody
   path?: never
@@ -37,9 +22,6 @@ export type CreateUsersWithListInputOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/user/DeleteUser.ts
+++ b/examples/fetch/src/gen/models/user/DeleteUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteUserPath = {
   /**
    * @description The name that needs to be deleted
@@ -14,19 +11,10 @@ export type DeleteUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteUserOptions = {
   body?: never
   path: DeleteUserPath
@@ -34,9 +22,6 @@ export type DeleteUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteUserResponses = {
   '400': DeleteUserStatus400
   '404': DeleteUserStatus404

--- a/examples/fetch/src/gen/models/user/GetUserByName.ts
+++ b/examples/fetch/src/gen/models/user/GetUserByName.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type GetUserByNamePath = {
   /**
    * @description The name that needs to be fetched. Use user1 for testing.
@@ -16,31 +13,16 @@ export type GetUserByNamePath = {
   username: string
 }
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Json = User
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Xml = User
 
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetUserByNameOptions = {
   body?: never
   path: GetUserByNamePath
@@ -48,9 +30,6 @@ export type GetUserByNameOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetUserByNameResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/user/LoginUser.ts
+++ b/examples/fetch/src/gen/models/user/LoginUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type LoginUserQuery = {
   /**
    * @description The user name for login
@@ -19,26 +16,14 @@ export type LoginUserQuery = {
   password?: string
 }
 
-/**
- * @type string
- */
 export type LoginUserStatus200Xml = string
 
-/**
- * @type string
- */
 export type LoginUserStatus200Json = string
 
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
-/**
- * @type unknown
- */
 export type LoginUserStatus400 = unknown
 
-/**
- * @type object
- */
 export type LoginUserOptions = {
   body?: never
   path?: never
@@ -46,9 +31,6 @@ export type LoginUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LoginUserResponses = {
   '200':
     | {

--- a/examples/fetch/src/gen/models/user/LogoutUser.ts
+++ b/examples/fetch/src/gen/models/user/LogoutUser.ts
@@ -3,14 +3,8 @@
  * Do not edit manually.
  */
 
-/**
- * @type unknown
- */
 export type LogoutUserStatusDefault = unknown
 
-/**
- * @type object
- */
 export type LogoutUserOptions = {
   body?: never
   path?: never
@@ -18,9 +12,6 @@ export type LogoutUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LogoutUserResponses = {
   default: LogoutUserStatusDefault
 }

--- a/examples/fetch/src/gen/models/user/UpdateUser.ts
+++ b/examples/fetch/src/gen/models/user/UpdateUser.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type UpdateUserPath = {
   /**
    * @description name that need to be deleted
@@ -16,9 +13,6 @@ export type UpdateUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type UpdateUserStatusDefault = unknown
 
 /**
@@ -41,9 +35,6 @@ export type UpdateUserBodyFormUrlEncoded = User | undefined
 
 export type UpdateUserBody = UpdateUserBodyJson | UpdateUserBodyXml | UpdateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdateUserOptions = {
   body: UpdateUserBody
   path: UpdateUserPath
@@ -51,9 +42,6 @@ export type UpdateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdateUserResponses = {
   default: UpdateUserStatusDefault
 }

--- a/examples/mcp/src/gen/models/ts/AddFiles.ts
+++ b/examples/mcp/src/gen/models/ts/AddFiles.ts
@@ -5,19 +5,10 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type AddFilesStatus200 = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type unknown
- */
 export type AddFilesStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type AddFilesBodyJson =
   | {
       /**
@@ -30,16 +21,10 @@ export type AddFilesBodyJson =
     }
   | undefined
 
-/**
- * @type object | undefined
- */
 export type AddFilesBodyFormData = Omit<NonNullable<Pet>, 'id'> | undefined
 
 export type AddFilesBody = AddFilesBodyJson | AddFilesBodyFormData
 
-/**
- * @type object
- */
 export type AddFilesOptions = {
   body: AddFilesBody
   path?: never
@@ -47,9 +32,6 @@ export type AddFilesOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddFilesResponses = {
   '200': AddFilesStatus200
   '405': AddFilesStatus405

--- a/examples/mcp/src/gen/models/ts/AddPet.ts
+++ b/examples/mcp/src/gen/models/ts/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Omit<NonNullable<Pet>, 'name'>
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'id'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/mcp/src/gen/models/ts/AddPetRequest.ts
+++ b/examples/mcp/src/gen/models/ts/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { TagTag } from './tag/Tag'
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: TagTag[]
   /**
    * @description pet status in the store

--- a/examples/mcp/src/gen/models/ts/ApiResponse.ts
+++ b/examples/mcp/src/gen/models/ts/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/mcp/src/gen/models/ts/Category.ts
+++ b/examples/mcp/src/gen/models/ts/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/mcp/src/gen/models/ts/CreatePets.ts
+++ b/examples/mcp/src/gen/models/ts/CreatePets.ts
@@ -6,9 +6,6 @@
 import type { CreatePetsXEXAMPLEKey } from './CreatePetsXEXAMPLE'
 import type { PetNotFound } from './PetNotFound'
 
-/**
- * @type object
- */
 export type CreatePetsPath = {
   /**
    * @description UUID
@@ -17,9 +14,6 @@ export type CreatePetsPath = {
   uuid: string
 }
 
-/**
- * @type object
- */
 export type CreatePetsQuery = {
   /**
    * @description Offset *\/
@@ -28,9 +22,6 @@ export type CreatePetsQuery = {
   offset?: number
 }
 
-/**
- * @type object
- */
 export type CreatePetsHeaders = {
   /**
    * @description Header parameters
@@ -38,9 +29,6 @@ export type CreatePetsHeaders = {
   'X-EXAMPLE': CreatePetsXEXAMPLEKey
 }
 
-/**
- * @type unknown
- */
 export type CreatePetsStatus201 = unknown
 
 /**
@@ -49,23 +37,11 @@ export type CreatePetsStatus201 = unknown
  */
 export type CreatePetsStatusDefault = PetNotFound
 
-/**
- * @type object
- */
 export type CreatePetsBody = {
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string
-   */
   tag: string
 }
 
-/**
- * @type object
- */
 export type CreatePetsOptions = {
   body: CreatePetsBody
   path: CreatePetsPath
@@ -73,9 +49,6 @@ export type CreatePetsOptions = {
   headers: CreatePetsHeaders
 }
 
-/**
- * @type object
- */
 export type CreatePetsResponses = {
   '201': CreatePetsStatus201
   default: CreatePetsStatusDefault

--- a/examples/mcp/src/gen/models/ts/DeleteOrder.ts
+++ b/examples/mcp/src/gen/models/ts/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: number
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/mcp/src/gen/models/ts/DeletePet.ts
+++ b/examples/mcp/src/gen/models/ts/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/mcp/src/gen/models/ts/FindPetsByStatus.ts
+++ b/examples/mcp/src/gen/models/ts/FindPetsByStatus.ts
@@ -5,36 +5,18 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByStatusPath = {
-  /**
-   * @type string
-   */
   step_id: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path: FindPetsByStatusPath
@@ -42,9 +24,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/mcp/src/gen/models/ts/FindPetsByTags.ts
+++ b/examples/mcp/src/gen/models/ts/FindPetsByTags.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByTagsXEXAMPLEKey } from './FindPetsByTagsXEXAMPLE'
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -27,9 +24,6 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsHeaders = {
   /**
    * @description Header parameters
@@ -37,26 +31,14 @@ export type FindPetsByTagsHeaders = {
   'X-EXAMPLE': FindPetsByTagsXEXAMPLEKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -64,9 +46,6 @@ export type FindPetsByTagsOptions = {
   headers: FindPetsByTagsHeaders
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/mcp/src/gen/models/ts/GetInventory.ts
+++ b/examples/mcp/src/gen/models/ts/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/mcp/src/gen/models/ts/GetOrderById.ts
+++ b/examples/mcp/src/gen/models/ts/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: number
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/mcp/src/gen/models/ts/GetPetById.ts
+++ b/examples/mcp/src/gen/models/ts/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Omit<NonNullable<Pet>, 'name'>
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/mcp/src/gen/models/ts/Order.ts
+++ b/examples/mcp/src/gen/models/ts/Order.ts
@@ -7,9 +7,6 @@ import type { OrderHttpStatusEnumKey } from './OrderHttpStatusEnum'
 import type { OrderOrderTypeEnumKey } from './OrderOrderTypeEnum'
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -55,8 +52,5 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/mcp/src/gen/models/ts/Pet.ts
+++ b/examples/mcp/src/gen/models/ts/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { TagTag } from './tag/Tag'
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: TagTag[]
   /**
    * @description pet status in the store

--- a/examples/mcp/src/gen/models/ts/PetNotFound.ts
+++ b/examples/mcp/src/gen/models/ts/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/mcp/src/gen/models/ts/PlaceOrder.ts
+++ b/examples/mcp/src/gen/models/ts/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/mcp/src/gen/models/ts/PlaceOrderPatch.ts
+++ b/examples/mcp/src/gen/models/ts/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/mcp/src/gen/models/ts/UpdatePet.ts
+++ b/examples/mcp/src/gen/models/ts/UpdatePet.ts
@@ -5,21 +5,12 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Omit<NonNullable<Pet>, 'name'>
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Omit<NonNullable<Pet>, 'name'>
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type object
- */
 export type UpdatePetStatus202 = {
   /**
    * @description
@@ -30,19 +21,10 @@ export type UpdatePetStatus202 = {
   id?: number
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -65,9 +47,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'id'>
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -75,9 +54,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/mcp/src/gen/models/ts/UpdatePetWithForm.ts
+++ b/examples/mcp/src/gen/models/ts/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: number
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/mcp/src/gen/models/ts/tag/Tag.ts
+++ b/examples/mcp/src/gen/models/ts/tag/Tag.ts
@@ -16,8 +16,5 @@ export type TagTag = {
    * @type integer | undefined
    */
   id?: number
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/msw/src/gen/models/AddPet.ts
+++ b/examples/msw/src/gen/models/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/msw/src/gen/models/AddPetRequest.ts
+++ b/examples/msw/src/gen/models/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/msw/src/gen/models/ApiResponse.ts
+++ b/examples/msw/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/msw/src/gen/models/Category.ts
+++ b/examples/msw/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/msw/src/gen/models/DeleteOrder.ts
+++ b/examples/msw/src/gen/models/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/msw/src/gen/models/DeletePet.ts
+++ b/examples/msw/src/gen/models/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/msw/src/gen/models/FindPetsByStatus.ts
+++ b/examples/msw/src/gen/models/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/msw/src/gen/models/FindPetsByTags.ts
+++ b/examples/msw/src/gen/models/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/msw/src/gen/models/GetInventory.ts
+++ b/examples/msw/src/gen/models/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/msw/src/gen/models/GetOrderById.ts
+++ b/examples/msw/src/gen/models/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/msw/src/gen/models/GetPetById.ts
+++ b/examples/msw/src/gen/models/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/msw/src/gen/models/OptionsFindPetsByStatus.ts
+++ b/examples/msw/src/gen/models/OptionsFindPetsByStatus.ts
@@ -5,14 +5,8 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type array
- */
 export type OptionsFindPetsByStatusStatus200 = Pet[]
 
-/**
- * @type object
- */
 export type OptionsFindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type OptionsFindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type OptionsFindPetsByStatusResponses = {
   '200': OptionsFindPetsByStatusStatus200
 }

--- a/examples/msw/src/gen/models/Order.ts
+++ b/examples/msw/src/gen/models/Order.ts
@@ -6,9 +6,6 @@
 import type { OrderHttpStatusEnumKey } from './OrderHttpStatusEnum'
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -47,8 +44,5 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/msw/src/gen/models/Pet.ts
+++ b/examples/msw/src/gen/models/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/msw/src/gen/models/PetNotFound.ts
+++ b/examples/msw/src/gen/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/msw/src/gen/models/PlaceOrder.ts
+++ b/examples/msw/src/gen/models/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/msw/src/gen/models/PlaceOrderPatch.ts
+++ b/examples/msw/src/gen/models/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/msw/src/gen/models/Tag.ts
+++ b/examples/msw/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/msw/src/gen/models/UpdatePet.ts
+++ b/examples/msw/src/gen/models/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/msw/src/gen/models/UpdatePetWithForm.ts
+++ b/examples/msw/src/gen/models/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/msw/src/gen/models/UploadFile.ts
+++ b/examples/msw/src/gen/models/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type string | undefined
- */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/react-query/src/gen/models/AddPetRequest.ts
+++ b/examples/react-query/src/gen/models/AddPetRequest.ts
@@ -14,9 +14,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/react-query/src/gen/models/Address.ts
+++ b/examples/react-query/src/gen/models/Address.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Address = {
   /**
    * @example 437 Lytton

--- a/examples/react-query/src/gen/models/ApiResponse.ts
+++ b/examples/react-query/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/react-query/src/gen/models/Category.ts
+++ b/examples/react-query/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/react-query/src/gen/models/Customer.ts
+++ b/examples/react-query/src/gen/models/Customer.ts
@@ -5,9 +5,6 @@
 
 import type { Address } from './Address'
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -21,8 +18,5 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Address[]
 }

--- a/examples/react-query/src/gen/models/Order.ts
+++ b/examples/react-query/src/gen/models/Order.ts
@@ -19,9 +19,6 @@ export const orderHttpStatusEnum = {
 
 export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof orderHttpStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -62,8 +59,5 @@ export type Order = {
    * @type number | undefined
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/react-query/src/gen/models/Pet.ts
+++ b/examples/react-query/src/gen/models/Pet.ts
@@ -14,9 +14,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/react-query/src/gen/models/PetNotFound.ts
+++ b/examples/react-query/src/gen/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/react-query/src/gen/models/Tag.ts
+++ b/examples/react-query/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/react-query/src/gen/models/User.ts
+++ b/examples/react-query/src/gen/models/User.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type User = {
   /**
    * @description

--- a/examples/react-query/src/gen/models/UserArray.ts
+++ b/examples/react-query/src/gen/models/UserArray.ts
@@ -5,7 +5,4 @@
 
 import type { User } from './User'
 
-/**
- * @type array
- */
 export type UserArray = User[]

--- a/examples/react-query/src/gen/models/pet/AddPet.ts
+++ b/examples/react-query/src/gen/models/pet/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from '../AddPetRequest'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/pet/DeletePet.ts
+++ b/examples/react-query/src/gen/models/pet/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/react-query/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/react-query/src/gen/models/pet/FindPetsByStatus.ts
@@ -13,9 +13,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -25,26 +22,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -52,9 +37,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/react-query/src/gen/models/pet/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/pet/GetPetById.ts
+++ b/examples/react-query/src/gen/models/pet/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/pet/UpdatePet.ts
+++ b/examples/react-query/src/gen/models/pet/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/react-query/src/gen/models/pet/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/react-query/src/gen/models/pet/UploadFile.ts
+++ b/examples/react-query/src/gen/models/pet/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,14 +23,8 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type object
- */
 export type UploadFileBodyJson = {
   /**
    * @description URL of the image to upload
@@ -47,21 +35,12 @@ export type UploadFileBodyJson = {
   url: string
 }
 
-/**
- * @type object
- */
 export type UploadFileBodyFormData = {
-  /**
-   * @type string
-   */
   file: Blob
 }
 
 export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -69,9 +48,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/react-query/src/gen/models/store/DeleteOrder.ts
+++ b/examples/react-query/src/gen/models/store/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/react-query/src/gen/models/store/GetInventory.ts
+++ b/examples/react-query/src/gen/models/store/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/react-query/src/gen/models/store/GetOrderById.ts
+++ b/examples/react-query/src/gen/models/store/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/store/PlaceOrder.ts
+++ b/examples/react-query/src/gen/models/store/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/react-query/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/react-query/src/gen/models/store/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/react-query/src/gen/models/user/CreateUser.ts
+++ b/examples/react-query/src/gen/models/user/CreateUser.ts
@@ -5,14 +5,8 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultJson = User
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultXml = User
 
 export type CreateUserStatusDefault = CreateUserStatusDefaultJson | CreateUserStatusDefaultXml
@@ -37,9 +31,6 @@ export type CreateUserBodyFormUrlEncoded = User | undefined
 
 export type CreateUserBody = CreateUserBodyJson | CreateUserBodyXml | CreateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type CreateUserOptions = {
   body: CreateUserBody
   path?: never
@@ -47,9 +38,6 @@ export type CreateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUserResponses = {
   default:
     | {

--- a/examples/react-query/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/react-query/src/gen/models/user/CreateUsersWithListInput.ts
@@ -5,31 +5,16 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Json = User
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Xml = User
 
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
-/**
- * @type unknown
- */
 export type CreateUsersWithListInputStatusDefault = unknown
 
-/**
- * @type array | undefined
- */
 export type CreateUsersWithListInputBody = User[] | undefined
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputOptions = {
   body: CreateUsersWithListInputBody
   path?: never
@@ -37,9 +22,6 @@ export type CreateUsersWithListInputOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/user/DeleteUser.ts
+++ b/examples/react-query/src/gen/models/user/DeleteUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteUserPath = {
   /**
    * @description The name that needs to be deleted
@@ -14,19 +11,10 @@ export type DeleteUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteUserOptions = {
   body?: never
   path: DeleteUserPath
@@ -34,9 +22,6 @@ export type DeleteUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteUserResponses = {
   '400': DeleteUserStatus400
   '404': DeleteUserStatus404

--- a/examples/react-query/src/gen/models/user/GetUserByName.ts
+++ b/examples/react-query/src/gen/models/user/GetUserByName.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type GetUserByNamePath = {
   /**
    * @description The name that needs to be fetched. Use user1 for testing.
@@ -16,31 +13,16 @@ export type GetUserByNamePath = {
   username: string
 }
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Json = User
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Xml = User
 
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetUserByNameOptions = {
   body?: never
   path: GetUserByNamePath
@@ -48,9 +30,6 @@ export type GetUserByNameOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetUserByNameResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/user/LoginUser.ts
+++ b/examples/react-query/src/gen/models/user/LoginUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type LoginUserQuery = {
   /**
    * @description The user name for login
@@ -19,26 +16,14 @@ export type LoginUserQuery = {
   password?: string
 }
 
-/**
- * @type string
- */
 export type LoginUserStatus200Xml = string
 
-/**
- * @type string
- */
 export type LoginUserStatus200Json = string
 
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
-/**
- * @type unknown
- */
 export type LoginUserStatus400 = unknown
 
-/**
- * @type object
- */
 export type LoginUserOptions = {
   body?: never
   path?: never
@@ -46,9 +31,6 @@ export type LoginUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LoginUserResponses = {
   '200':
     | {

--- a/examples/react-query/src/gen/models/user/LogoutUser.ts
+++ b/examples/react-query/src/gen/models/user/LogoutUser.ts
@@ -3,14 +3,8 @@
  * Do not edit manually.
  */
 
-/**
- * @type unknown
- */
 export type LogoutUserStatusDefault = unknown
 
-/**
- * @type object
- */
 export type LogoutUserOptions = {
   body?: never
   path?: never
@@ -18,9 +12,6 @@ export type LogoutUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LogoutUserResponses = {
   default: LogoutUserStatusDefault
 }

--- a/examples/react-query/src/gen/models/user/UpdateUser.ts
+++ b/examples/react-query/src/gen/models/user/UpdateUser.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type UpdateUserPath = {
   /**
    * @description name that need to be deleted
@@ -16,9 +13,6 @@ export type UpdateUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type UpdateUserStatusDefault = unknown
 
 /**
@@ -41,9 +35,6 @@ export type UpdateUserBodyFormUrlEncoded = User | undefined
 
 export type UpdateUserBody = UpdateUserBodyJson | UpdateUserBodyXml | UpdateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdateUserOptions = {
   body: UpdateUserBody
   path: UpdateUserPath
@@ -51,9 +42,6 @@ export type UpdateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdateUserResponses = {
   default: UpdateUserStatusDefault
 }

--- a/examples/sdk/src/gen/models/AddPetRequest.ts
+++ b/examples/sdk/src/gen/models/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/sdk/src/gen/models/ApiResponse.ts
+++ b/examples/sdk/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/sdk/src/gen/models/Category.ts
+++ b/examples/sdk/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/sdk/src/gen/models/Order.ts
+++ b/examples/sdk/src/gen/models/Order.ts
@@ -6,9 +6,6 @@
 import type { OrderHttpStatusEnumKey } from './OrderHttpStatusEnum'
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -47,8 +44,5 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/sdk/src/gen/models/Pet.ts
+++ b/examples/sdk/src/gen/models/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/sdk/src/gen/models/PetNotFound.ts
+++ b/examples/sdk/src/gen/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/sdk/src/gen/models/Tag.ts
+++ b/examples/sdk/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/sdk/src/gen/models/pet/AddPet.ts
+++ b/examples/sdk/src/gen/models/pet/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from '../AddPetRequest'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/sdk/src/gen/models/pet/DeletePet.ts
+++ b/examples/sdk/src/gen/models/pet/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/sdk/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/sdk/src/gen/models/pet/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from '../FindPetsByStatusStatus'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/sdk/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/sdk/src/gen/models/pet/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/sdk/src/gen/models/pet/GetPetById.ts
+++ b/examples/sdk/src/gen/models/pet/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/sdk/src/gen/models/pet/UpdatePet.ts
+++ b/examples/sdk/src/gen/models/pet/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/sdk/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/sdk/src/gen/models/pet/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/sdk/src/gen/models/pet/UploadFile.ts
+++ b/examples/sdk/src/gen/models/pet/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,14 +23,8 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type object
- */
 export type UploadFileBodyJson = {
   /**
    * @description URL of the image to upload
@@ -47,21 +35,12 @@ export type UploadFileBodyJson = {
   url: string
 }
 
-/**
- * @type object
- */
 export type UploadFileBodyFormData = {
-  /**
-   * @type string
-   */
   file: Blob
 }
 
 export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -69,9 +48,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/sdk/src/gen/models/store/DeleteOrder.ts
+++ b/examples/sdk/src/gen/models/store/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/sdk/src/gen/models/store/GetInventory.ts
+++ b/examples/sdk/src/gen/models/store/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/sdk/src/gen/models/store/GetOrderById.ts
+++ b/examples/sdk/src/gen/models/store/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/sdk/src/gen/models/store/PlaceOrder.ts
+++ b/examples/sdk/src/gen/models/store/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/sdk/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/sdk/src/gen/models/store/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/simple-single/src/gen/models.ts
+++ b/examples/simple-single/src/gen/models.ts
@@ -43,9 +43,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -84,15 +81,9 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -108,9 +99,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -118,25 +106,13 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Person = {
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -150,17 +126,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store
@@ -168,9 +135,6 @@ export type Pet = {
   status?: PetStatusEnumKey
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -184,17 +148,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store
@@ -202,9 +157,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnumKey
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -212,19 +164,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -232,37 +175,19 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -285,9 +210,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -295,9 +217,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -318,21 +237,12 @@ export type UpdatePetResponses = {
  */
 export type UpdatePetResponse = UpdatePetStatus200 | UpdatePetStatus400 | UpdatePetStatus404 | UpdatePetStatus405
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -340,9 +250,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -366,9 +273,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -376,9 +280,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -397,9 +298,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -408,26 +306,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -435,9 +321,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -456,9 +339,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -477,26 +357,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -504,9 +372,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -525,9 +390,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -538,31 +400,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -570,9 +417,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -592,9 +436,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -605,9 +446,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -621,14 +459,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -636,9 +468,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -648,9 +477,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -661,24 +487,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -686,9 +500,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }
@@ -698,9 +509,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -711,9 +519,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -722,19 +527,10 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type string | undefined
- */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -742,9 +538,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -754,16 +547,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -771,9 +558,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -783,36 +567,18 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -820,9 +586,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -833,36 +596,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -870,9 +615,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -883,9 +625,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -896,31 +635,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -928,9 +652,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -950,9 +671,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -963,19 +681,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -983,9 +692,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/swr/src/gen/models/AddPetRequest.ts
+++ b/examples/swr/src/gen/models/AddPetRequest.ts
@@ -14,9 +14,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/swr/src/gen/models/Address.ts
+++ b/examples/swr/src/gen/models/Address.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Address = {
   /**
    * @example 437 Lytton

--- a/examples/swr/src/gen/models/ApiResponse.ts
+++ b/examples/swr/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/swr/src/gen/models/Category.ts
+++ b/examples/swr/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/swr/src/gen/models/Customer.ts
+++ b/examples/swr/src/gen/models/Customer.ts
@@ -5,9 +5,6 @@
 
 import type { Address } from './Address'
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -21,8 +18,5 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Address[]
 }

--- a/examples/swr/src/gen/models/Order.ts
+++ b/examples/swr/src/gen/models/Order.ts
@@ -19,9 +19,6 @@ export const orderHttpStatusEnum = {
 
 export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof orderHttpStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -62,8 +59,5 @@ export type Order = {
    * @type number | undefined
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/swr/src/gen/models/Pet.ts
+++ b/examples/swr/src/gen/models/Pet.ts
@@ -14,9 +14,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/swr/src/gen/models/PetNotFound.ts
+++ b/examples/swr/src/gen/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/swr/src/gen/models/Tag.ts
+++ b/examples/swr/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/swr/src/gen/models/User.ts
+++ b/examples/swr/src/gen/models/User.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type User = {
   /**
    * @description

--- a/examples/swr/src/gen/models/UserArray.ts
+++ b/examples/swr/src/gen/models/UserArray.ts
@@ -5,7 +5,4 @@
 
 import type { User } from './User'
 
-/**
- * @type array
- */
 export type UserArray = User[]

--- a/examples/swr/src/gen/models/pet/AddPet.ts
+++ b/examples/swr/src/gen/models/pet/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from '../AddPetRequest'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/pet/DeletePet.ts
+++ b/examples/swr/src/gen/models/pet/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/swr/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/swr/src/gen/models/pet/FindPetsByStatus.ts
@@ -13,9 +13,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -25,26 +22,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -52,9 +37,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/swr/src/gen/models/pet/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/pet/GetPetById.ts
+++ b/examples/swr/src/gen/models/pet/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/pet/UpdatePet.ts
+++ b/examples/swr/src/gen/models/pet/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/swr/src/gen/models/pet/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/swr/src/gen/models/pet/UploadFile.ts
+++ b/examples/swr/src/gen/models/pet/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,14 +23,8 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type object
- */
 export type UploadFileBodyJson = {
   /**
    * @description URL of the image to upload
@@ -47,21 +35,12 @@ export type UploadFileBodyJson = {
   url: string
 }
 
-/**
- * @type object
- */
 export type UploadFileBodyFormData = {
-  /**
-   * @type string
-   */
   file: Blob
 }
 
 export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -69,9 +48,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/swr/src/gen/models/store/DeleteOrder.ts
+++ b/examples/swr/src/gen/models/store/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/swr/src/gen/models/store/GetInventory.ts
+++ b/examples/swr/src/gen/models/store/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/swr/src/gen/models/store/GetOrderById.ts
+++ b/examples/swr/src/gen/models/store/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/store/PlaceOrder.ts
+++ b/examples/swr/src/gen/models/store/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/swr/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/swr/src/gen/models/store/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/swr/src/gen/models/user/CreateUser.ts
+++ b/examples/swr/src/gen/models/user/CreateUser.ts
@@ -5,14 +5,8 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultJson = User
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultXml = User
 
 export type CreateUserStatusDefault = CreateUserStatusDefaultJson | CreateUserStatusDefaultXml
@@ -37,9 +31,6 @@ export type CreateUserBodyFormUrlEncoded = User | undefined
 
 export type CreateUserBody = CreateUserBodyJson | CreateUserBodyXml | CreateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type CreateUserOptions = {
   body: CreateUserBody
   path?: never
@@ -47,9 +38,6 @@ export type CreateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUserResponses = {
   default:
     | {

--- a/examples/swr/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/swr/src/gen/models/user/CreateUsersWithListInput.ts
@@ -5,31 +5,16 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Json = User
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Xml = User
 
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
-/**
- * @type unknown
- */
 export type CreateUsersWithListInputStatusDefault = unknown
 
-/**
- * @type array | undefined
- */
 export type CreateUsersWithListInputBody = User[] | undefined
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputOptions = {
   body: CreateUsersWithListInputBody
   path?: never
@@ -37,9 +22,6 @@ export type CreateUsersWithListInputOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/user/DeleteUser.ts
+++ b/examples/swr/src/gen/models/user/DeleteUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteUserPath = {
   /**
    * @description The name that needs to be deleted
@@ -14,19 +11,10 @@ export type DeleteUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteUserOptions = {
   body?: never
   path: DeleteUserPath
@@ -34,9 +22,6 @@ export type DeleteUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteUserResponses = {
   '400': DeleteUserStatus400
   '404': DeleteUserStatus404

--- a/examples/swr/src/gen/models/user/GetUserByName.ts
+++ b/examples/swr/src/gen/models/user/GetUserByName.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type GetUserByNamePath = {
   /**
    * @description The name that needs to be fetched. Use user1 for testing.
@@ -16,31 +13,16 @@ export type GetUserByNamePath = {
   username: string
 }
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Json = User
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Xml = User
 
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetUserByNameOptions = {
   body?: never
   path: GetUserByNamePath
@@ -48,9 +30,6 @@ export type GetUserByNameOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetUserByNameResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/user/LoginUser.ts
+++ b/examples/swr/src/gen/models/user/LoginUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type LoginUserQuery = {
   /**
    * @description The user name for login
@@ -19,26 +16,14 @@ export type LoginUserQuery = {
   password?: string
 }
 
-/**
- * @type string
- */
 export type LoginUserStatus200Xml = string
 
-/**
- * @type string
- */
 export type LoginUserStatus200Json = string
 
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
-/**
- * @type unknown
- */
 export type LoginUserStatus400 = unknown
 
-/**
- * @type object
- */
 export type LoginUserOptions = {
   body?: never
   path?: never
@@ -46,9 +31,6 @@ export type LoginUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LoginUserResponses = {
   '200':
     | {

--- a/examples/swr/src/gen/models/user/LogoutUser.ts
+++ b/examples/swr/src/gen/models/user/LogoutUser.ts
@@ -3,14 +3,8 @@
  * Do not edit manually.
  */
 
-/**
- * @type unknown
- */
 export type LogoutUserStatusDefault = unknown
 
-/**
- * @type object
- */
 export type LogoutUserOptions = {
   body?: never
   path?: never
@@ -18,9 +12,6 @@ export type LogoutUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LogoutUserResponses = {
   default: LogoutUserStatusDefault
 }

--- a/examples/swr/src/gen/models/user/UpdateUser.ts
+++ b/examples/swr/src/gen/models/user/UpdateUser.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type UpdateUserPath = {
   /**
    * @description name that need to be deleted
@@ -16,9 +13,6 @@ export type UpdateUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type UpdateUserStatusDefault = unknown
 
 /**
@@ -41,9 +35,6 @@ export type UpdateUserBodyFormUrlEncoded = User | undefined
 
 export type UpdateUserBody = UpdateUserBodyJson | UpdateUserBodyXml | UpdateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdateUserOptions = {
   body: UpdateUserBody
   path: UpdateUserPath
@@ -51,9 +42,6 @@ export type UpdateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdateUserResponses = {
   default: UpdateUserStatusDefault
 }

--- a/examples/typescript/src/gen/models.ts
+++ b/examples/typescript/src/gen/models.ts
@@ -73,9 +73,6 @@ export const deletePetStatus200Enum = {
 
 export type DeletePetStatus200EnumKey = (typeof deletePetStatus200Enum)[keyof typeof deletePetStatus200Enum]
 
-/**
- * @type object
- */
 export interface Order {
   /**
    * @description
@@ -91,18 +88,12 @@ export interface Order {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -127,23 +118,11 @@ export interface Order {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export interface Address {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -162,9 +141,6 @@ export interface Address {
   zip?: string
 }
 
-/**
- * @type object
- */
 export interface Customer {
   /**
    * @description
@@ -173,18 +149,12 @@ export interface Customer {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -192,33 +162,18 @@ export interface Customer {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export interface Category {
   /**
    * @description
@@ -234,9 +189,6 @@ export interface Category {
   name?: string
 }
 
-/**
- * @type object
- */
 export interface Tag {
   /**
    * @description
@@ -244,53 +196,32 @@ export interface Tag {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export interface Dog {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export interface Cat {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -307,17 +238,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -326,20 +248,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export interface AddPetRequest {
   /**
    * @description
@@ -353,17 +266,8 @@ export interface AddPetRequest {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -371,9 +275,6 @@ export interface AddPetRequest {
   status?: AddPetRequestStatusEnumKey
 }
 
-/**
- * @type object
- */
 export interface ApiResponse {
   /**
    * @description
@@ -381,19 +282,10 @@ export interface ApiResponse {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export interface PetNotFound {
   /**
    * @description
@@ -401,9 +293,6 @@ export interface PetNotFound {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -413,19 +302,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -445,9 +325,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface UpdatePetOptions {
   body: UpdatePetBody
   path?: never
@@ -455,9 +332,6 @@ export interface UpdatePetOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface UpdatePetResponses {
   '200':
     | {
@@ -484,9 +358,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export interface AddPetStatus405 {
   /**
    * @description
@@ -494,9 +365,6 @@ export interface AddPetStatus405 {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -518,9 +386,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface AddPetOptions {
   body: AddPetBody
   path?: never
@@ -528,9 +393,6 @@ export interface AddPetOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface AddPetResponses {
   '200':
     | {
@@ -549,9 +411,6 @@ export interface AddPetResponses {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export interface FindPetsByStatusQuery {
   /**
    * @description Status values that need to be considered for filter
@@ -560,26 +419,14 @@ export interface FindPetsByStatusQuery {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export interface FindPetsByStatusOptions {
   body?: never
   path?: never
@@ -587,9 +434,6 @@ export interface FindPetsByStatusOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface FindPetsByStatusResponses {
   '200':
     | {
@@ -608,9 +452,6 @@ export interface FindPetsByStatusResponses {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export interface FindPetsByTagsQuery {
   /**
    * @description Tags to filter by
@@ -629,26 +470,14 @@ export interface FindPetsByTagsQuery {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export interface FindPetsByTagsOptions {
   body?: never
   path?: never
@@ -656,9 +485,6 @@ export interface FindPetsByTagsOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface FindPetsByTagsResponses {
   '200':
     | {
@@ -677,9 +503,6 @@ export interface FindPetsByTagsResponses {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export interface GetPetByIdPath {
   /**
    * @description ID of pet to return
@@ -696,19 +519,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export interface GetPetByIdOptions {
   body?: never
   path: GetPetByIdPath
@@ -716,9 +530,6 @@ export interface GetPetByIdOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface GetPetByIdResponses {
   '200':
     | {
@@ -738,9 +549,6 @@ export interface GetPetByIdResponses {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormPath {
   /**
    * @description ID of pet that needs to be updated
@@ -751,9 +559,6 @@ export interface UpdatePetWithFormPath {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormQuery {
   /**
    * @description Name of pet that needs to be updated
@@ -767,14 +572,8 @@ export interface UpdatePetWithFormQuery {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormOptions {
   body?: never
   path: UpdatePetWithFormPath
@@ -782,9 +581,6 @@ export interface UpdatePetWithFormOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormResponses {
   '405': UpdatePetWithFormStatus405
 }
@@ -794,9 +590,6 @@ export interface UpdatePetWithFormResponses {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export interface DeletePetPath {
   /**
    * @description Pet id to delete
@@ -807,29 +600,14 @@ export interface DeletePetPath {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export interface DeletePetHeaders {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export interface DeletePetOptions {
   body?: never
   path: DeletePetPath
@@ -837,9 +615,6 @@ export interface DeletePetOptions {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export interface DeletePetResponses {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -850,9 +625,6 @@ export interface DeletePetResponses {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export interface UploadFilePath {
   /**
    * @description ID of pet to update
@@ -863,9 +635,6 @@ export interface UploadFilePath {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export interface UploadFileQuery {
   /**
    * @description Additional Metadata
@@ -874,9 +643,6 @@ export interface UploadFileQuery {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -886,9 +652,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export interface UploadFileOptions {
   body: UploadFileBody
   path: UploadFilePath
@@ -896,9 +659,6 @@ export interface UploadFileOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface UploadFileResponses {
   '200': UploadFileStatus200
 }
@@ -908,16 +668,10 @@ export interface UploadFileResponses {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export interface GetInventoryStatus200 {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export interface GetInventoryOptions {
   body?: never
   path?: never
@@ -925,9 +679,6 @@ export interface GetInventoryOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface GetInventoryResponses {
   '200': GetInventoryStatus200
 }
@@ -937,14 +688,8 @@ export interface GetInventoryResponses {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -953,21 +698,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface PlaceOrderOptions {
   body: PlaceOrderBody
   path?: never
@@ -975,9 +711,6 @@ export interface PlaceOrderOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface PlaceOrderResponses {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -988,36 +721,18 @@ export interface PlaceOrderResponses {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface PlaceOrderPatchOptions {
   body: PlaceOrderPatchBody
   path?: never
@@ -1025,9 +740,6 @@ export interface PlaceOrderPatchOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface PlaceOrderPatchResponses {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1038,9 +750,6 @@ export interface PlaceOrderPatchResponses {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export interface GetOrderByIdPath {
   /**
    * @description ID of order that needs to be fetched
@@ -1051,31 +760,16 @@ export interface GetOrderByIdPath {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export interface GetOrderByIdOptions {
   body?: never
   path: GetOrderByIdPath
@@ -1083,9 +777,6 @@ export interface GetOrderByIdOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface GetOrderByIdResponses {
   '200':
     | {
@@ -1105,9 +796,6 @@ export interface GetOrderByIdResponses {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export interface DeleteOrderPath {
   /**
    * @description ID of the order that needs to be deleted
@@ -1118,19 +806,10 @@ export interface DeleteOrderPath {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export interface DeleteOrderOptions {
   body?: never
   path: DeleteOrderPath
@@ -1138,9 +817,6 @@ export interface DeleteOrderOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface DeleteOrderResponses {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen10/models/AddPetRequest.ts
+++ b/examples/typescript/src/gen10/models/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnum } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store

--- a/examples/typescript/src/gen10/models/Address.ts
+++ b/examples/typescript/src/gen10/models/Address.ts
@@ -3,17 +3,8 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto

--- a/examples/typescript/src/gen10/models/ApiResponse.ts
+++ b/examples/typescript/src/gen10/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/typescript/src/gen10/models/Cat.ts
+++ b/examples/typescript/src/gen10/models/Cat.ts
@@ -3,17 +3,11 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/typescript/src/gen10/models/Category.ts
+++ b/examples/typescript/src/gen10/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/typescript/src/gen10/models/Customer.ts
+++ b/examples/typescript/src/gen10/models/Customer.ts
@@ -6,9 +6,6 @@
 import type { Address } from './Address'
 import type { CustomerParamsStatusEnum } from './CustomerParamsStatusEnum'
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -17,18 +14,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -36,8 +27,5 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }

--- a/examples/typescript/src/gen10/models/DeletePetStatus200Enum.ts
+++ b/examples/typescript/src/gen10/models/DeletePetStatus200Enum.ts
@@ -3,7 +3,4 @@
  * Do not edit manually.
  */
 
-/**
- * @type string
- */
 export type DeletePetStatus200Enum = 'TYPE1' | 'TYPE2' | 'TYPE3'

--- a/examples/typescript/src/gen10/models/Dog.ts
+++ b/examples/typescript/src/gen10/models/Dog.ts
@@ -3,17 +3,11 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }

--- a/examples/typescript/src/gen10/models/FullAddress.ts
+++ b/examples/typescript/src/gen10/models/FullAddress.ts
@@ -6,13 +6,7 @@
 import type { Address } from './Address'
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }

--- a/examples/typescript/src/gen10/models/HappyCustomer.ts
+++ b/examples/typescript/src/gen10/models/HappyCustomer.ts
@@ -6,8 +6,5 @@
 import type { Customer } from './Customer'
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }

--- a/examples/typescript/src/gen10/models/Order.ts
+++ b/examples/typescript/src/gen10/models/Order.ts
@@ -7,9 +7,6 @@ import type { OrderHttpStatusEnum } from './OrderHttpStatusEnum'
 import type { OrderParamsStatusEnum } from './OrderParamsStatusEnum'
 import type { OrderStatus } from './OrderStatus'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -25,18 +22,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -61,8 +52,5 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnum
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/typescript/src/gen10/models/OrderStatus.ts
+++ b/examples/typescript/src/gen10/models/OrderStatus.ts
@@ -3,7 +3,4 @@
  * Do not edit manually.
  */
 
-/**
- * @type string
- */
 export type OrderStatus = 'accepted'

--- a/examples/typescript/src/gen10/models/Pet.ts
+++ b/examples/typescript/src/gen10/models/Pet.ts
@@ -12,15 +12,9 @@ import type { Tag } from './Tag'
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -37,17 +31,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store

--- a/examples/typescript/src/gen10/models/PetNotFound.ts
+++ b/examples/typescript/src/gen10/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/typescript/src/gen10/models/PetTypeEnum.ts
+++ b/examples/typescript/src/gen10/models/PetTypeEnum.ts
@@ -3,7 +3,4 @@
  * Do not edit manually.
  */
 
-/**
- * @type string
- */
 export type PetTypeEnum = 'dog' | 'cat'

--- a/examples/typescript/src/gen10/models/Tag.ts
+++ b/examples/typescript/src/gen10/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/typescript/src/gen10/models/UnhappyCustomer.ts
+++ b/examples/typescript/src/gen10/models/UnhappyCustomer.ts
@@ -6,12 +6,6 @@
 import type { Customer } from './Customer'
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }

--- a/examples/typescript/src/gen10/models/pet/AddPet.ts
+++ b/examples/typescript/src/gen10/models/pet/AddPet.ts
@@ -12,9 +12,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -22,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -46,9 +40,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -56,9 +47,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen10/models/pet/DeletePet.ts
+++ b/examples/typescript/src/gen10/models/pet/DeletePet.ts
@@ -5,9 +5,6 @@
 
 import type { DeletePetStatus200Enum } from '../DeletePetStatus200Enum'
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -18,29 +15,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -48,9 +30,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400

--- a/examples/typescript/src/gen10/models/pet/FindPetsByStatus.ts
+++ b/examples/typescript/src/gen10/models/pet/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatus } from '../FindPetsByStatusStatus'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatus
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen10/models/pet/FindPetsByTags.ts
+++ b/examples/typescript/src/gen10/models/pet/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen10/models/pet/GetPetById.ts
+++ b/examples/typescript/src/gen10/models/pet/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -24,19 +21,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -44,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen10/models/pet/UpdatePet.ts
+++ b/examples/typescript/src/gen10/models/pet/UpdatePet.ts
@@ -11,19 +11,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -43,9 +34,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -53,9 +41,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen10/models/pet/UpdatePetWithForm.ts
+++ b/examples/typescript/src/gen10/models/pet/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/typescript/src/gen10/models/pet/UploadFile.ts
+++ b/examples/typescript/src/gen10/models/pet/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,9 +23,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -41,9 +32,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -51,9 +39,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/typescript/src/gen10/models/store/DeleteOrder.ts
+++ b/examples/typescript/src/gen10/models/store/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen10/models/store/GetInventory.ts
+++ b/examples/typescript/src/gen10/models/store/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/typescript/src/gen10/models/store/GetOrderById.ts
+++ b/examples/typescript/src/gen10/models/store/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen10/models/store/PlaceOrder.ts
+++ b/examples/typescript/src/gen10/models/store/PlaceOrder.ts
@@ -5,14 +5,8 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -21,21 +15,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -43,9 +28,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/typescript/src/gen10/models/store/PlaceOrderPatch.ts
+++ b/examples/typescript/src/gen10/models/store/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
+++ b/examples/typescript/src/gen11/modelsPascalCaseKeys.ts
@@ -73,9 +73,6 @@ export const deletePetStatus200Enum = {
 
 export type DeletePetStatus200EnumKey = (typeof deletePetStatus200Enum)[keyof typeof deletePetStatus200Enum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -91,18 +88,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -127,23 +118,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -162,9 +141,6 @@ export type Address = {
   zip?: string
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -173,18 +149,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -192,33 +162,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -234,9 +189,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -244,53 +196,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -307,17 +238,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -326,20 +248,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -353,17 +266,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -371,9 +275,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnumKey
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -381,19 +282,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -401,9 +293,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -413,19 +302,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -445,9 +325,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -455,9 +332,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -484,9 +358,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -494,9 +365,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -518,9 +386,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -528,9 +393,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -549,9 +411,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -560,26 +419,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -587,9 +434,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -608,9 +452,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -629,26 +470,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -656,9 +485,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -677,9 +503,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -696,19 +519,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -716,9 +530,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -738,9 +549,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -751,9 +559,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -767,14 +572,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -782,9 +581,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -794,9 +590,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -807,29 +600,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -837,9 +615,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -850,9 +625,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -863,9 +635,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -874,9 +643,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -886,9 +652,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -896,9 +659,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -908,16 +668,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -925,9 +679,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -937,14 +688,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -953,21 +698,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -975,9 +711,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -988,36 +721,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -1025,9 +740,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1038,9 +750,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1051,31 +760,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -1083,9 +777,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1105,9 +796,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1118,19 +806,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1138,9 +817,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
+++ b/examples/typescript/src/gen12/modelsCamelCaseKeys.ts
@@ -73,9 +73,6 @@ export const deletePetStatus200Enum = {
 
 export type DeletePetStatus200EnumKey = (typeof deletePetStatus200Enum)[keyof typeof deletePetStatus200Enum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -91,18 +88,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -127,23 +118,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -162,9 +141,6 @@ export type Address = {
   zip?: string
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -173,18 +149,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -192,33 +162,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -234,9 +189,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -244,53 +196,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -307,17 +238,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -326,20 +248,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -353,17 +266,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -371,9 +275,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnumKey
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -381,19 +282,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -401,9 +293,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -413,19 +302,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -445,9 +325,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -455,9 +332,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -484,9 +358,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -494,9 +365,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -518,9 +386,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -528,9 +393,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -549,9 +411,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -560,26 +419,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -587,9 +434,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -608,9 +452,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -629,26 +470,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -656,9 +485,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -677,9 +503,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -696,19 +519,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -716,9 +530,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -738,9 +549,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -751,9 +559,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -767,14 +572,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -782,9 +581,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -794,9 +590,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -807,29 +600,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -837,9 +615,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -850,9 +625,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -863,9 +635,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -874,9 +643,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -886,9 +652,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -896,9 +659,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -908,16 +668,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -925,9 +679,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -937,14 +688,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -953,21 +698,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -975,9 +711,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -988,36 +721,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -1025,9 +740,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1038,9 +750,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1051,31 +760,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -1083,9 +777,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1105,9 +796,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1118,19 +806,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1138,9 +817,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen2/modelsConst.ts
+++ b/examples/typescript/src/gen2/modelsConst.ts
@@ -73,9 +73,6 @@ export const deletePetStatus200Enum = {
 
 export type DeletePetStatus200EnumenumType = (typeof deletePetStatus200Enum)[keyof typeof deletePetStatus200Enum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -91,18 +88,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnumenumType
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -127,23 +118,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumenumType
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -162,9 +141,6 @@ export type Address = {
   zip?: string
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -173,18 +149,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnumenumType
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -192,33 +162,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -234,9 +189,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -244,53 +196,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -307,17 +238,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -326,20 +248,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -353,17 +266,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -371,9 +275,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnumenumType
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -381,19 +282,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -401,9 +293,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -413,19 +302,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -445,9 +325,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -455,9 +332,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -484,9 +358,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -494,9 +365,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -518,9 +386,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -528,9 +393,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -549,9 +411,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -560,26 +419,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusenumType
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -587,9 +434,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -608,9 +452,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -629,26 +470,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -656,9 +485,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -677,9 +503,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -696,19 +519,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -716,9 +530,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -738,9 +549,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -751,9 +559,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -767,14 +572,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -782,9 +581,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -794,9 +590,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -807,29 +600,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumenumType>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -837,9 +615,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -850,9 +625,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -863,9 +635,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -874,9 +643,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -886,9 +652,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -896,9 +659,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -908,16 +668,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -925,9 +679,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -937,14 +688,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -953,21 +698,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -975,9 +711,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -988,36 +721,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -1025,9 +740,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1038,9 +750,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1051,31 +760,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -1083,9 +777,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1105,9 +796,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1118,19 +806,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1138,9 +817,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen3/modelsPascalConst.ts
+++ b/examples/typescript/src/gen3/modelsPascalConst.ts
@@ -73,9 +73,6 @@ export const DeletePetStatus200Enum = {
 
 export type DeletePetStatus200EnumKey = (typeof DeletePetStatus200Enum)[keyof typeof DeletePetStatus200Enum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -91,18 +88,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -127,23 +118,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -162,9 +141,6 @@ export type Address = {
   zip?: string
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -173,18 +149,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -192,33 +162,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -234,9 +189,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -244,53 +196,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -307,17 +238,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -326,20 +248,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -353,17 +266,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -371,9 +275,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnumKey
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -381,19 +282,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -401,9 +293,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -413,19 +302,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -445,9 +325,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -455,9 +332,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -484,9 +358,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -494,9 +365,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -518,9 +386,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -528,9 +393,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -549,9 +411,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -560,26 +419,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -587,9 +434,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -608,9 +452,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -629,26 +470,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -656,9 +485,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -677,9 +503,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -696,19 +519,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -716,9 +530,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -738,9 +549,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -751,9 +559,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -767,14 +572,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -782,9 +581,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -794,9 +590,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -807,29 +600,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -837,9 +615,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -850,9 +625,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -863,9 +635,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -874,9 +643,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -886,9 +652,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -896,9 +659,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -908,16 +668,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -925,9 +679,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -937,14 +688,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -953,21 +698,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -975,9 +711,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -988,36 +721,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -1025,9 +740,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1038,9 +750,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1051,31 +760,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -1083,9 +777,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1105,9 +796,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1118,19 +806,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1138,9 +817,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen4/modelsConstEnum.ts
+++ b/examples/typescript/src/gen4/modelsConstEnum.ts
@@ -55,9 +55,6 @@ export const enum DeletePetStatus200Enum {
   TYPE3 = 'TYPE3',
 }
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -73,18 +70,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -109,23 +100,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnum
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -144,9 +123,6 @@ export type Address = {
   zip?: string
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -155,18 +131,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -174,33 +144,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -216,9 +171,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -226,53 +178,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -289,17 +220,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -308,20 +230,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -335,17 +248,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -353,9 +257,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnum
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -363,19 +264,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -383,9 +275,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -395,19 +284,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -427,9 +307,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -437,9 +314,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -466,9 +340,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -476,9 +347,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -500,9 +368,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -510,9 +375,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -531,9 +393,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -542,26 +401,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatus
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -569,9 +416,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -590,9 +434,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -611,26 +452,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -638,9 +467,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -659,9 +485,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -678,19 +501,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -698,9 +512,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -720,9 +531,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -733,9 +541,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -749,14 +554,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -764,9 +563,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -776,9 +572,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -789,29 +582,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -819,9 +597,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -832,9 +607,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -845,9 +617,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -856,9 +625,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -868,9 +634,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -878,9 +641,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -890,16 +650,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -907,9 +661,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -919,14 +670,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -935,21 +680,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -957,9 +693,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -970,36 +703,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -1007,9 +722,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1020,9 +732,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1033,31 +742,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -1065,9 +759,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1087,9 +778,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1100,19 +788,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1120,9 +799,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen5/modelsLiteral.ts
+++ b/examples/typescript/src/gen5/modelsLiteral.ts
@@ -21,9 +21,6 @@ export type FindPetsByStatusStatus = 'available' | 'pending' | 'sold'
 
 export type DeletePetStatus200Enum = 'TYPE1' | 'TYPE2' | 'TYPE3'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -39,18 +36,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -75,23 +66,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnum
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -110,9 +89,6 @@ export type Address = {
   zip?: string
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -121,18 +97,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -140,33 +110,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -182,9 +137,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -192,53 +144,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -255,17 +186,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -274,20 +196,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -301,17 +214,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -319,9 +223,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnum
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -329,19 +230,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -349,9 +241,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -361,19 +250,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -393,9 +273,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -403,9 +280,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -432,9 +306,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -442,9 +313,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -466,9 +334,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -476,9 +341,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -497,9 +359,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -508,26 +367,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatus
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -535,9 +382,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -556,9 +400,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -577,26 +418,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -604,9 +433,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -625,9 +451,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -644,19 +467,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -664,9 +478,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -686,9 +497,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -699,9 +507,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -715,14 +520,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -730,9 +529,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -742,9 +538,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -755,29 +548,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -785,9 +563,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -798,9 +573,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -811,9 +583,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -822,9 +591,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -834,9 +600,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -844,9 +607,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -856,16 +616,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -873,9 +627,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -885,14 +636,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -901,21 +646,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -923,9 +659,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -936,36 +669,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -973,9 +688,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -986,9 +698,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -999,31 +708,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -1031,9 +725,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1053,9 +744,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1066,19 +754,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1086,9 +765,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen6/ts/models/AddPet.ts
+++ b/examples/typescript/src/gen6/ts/models/AddPet.ts
@@ -12,9 +12,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -22,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -46,9 +40,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -56,9 +47,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen6/ts/models/AddPetRequest.ts
+++ b/examples/typescript/src/gen6/ts/models/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store

--- a/examples/typescript/src/gen6/ts/models/Address.ts
+++ b/examples/typescript/src/gen6/ts/models/Address.ts
@@ -3,17 +3,8 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto

--- a/examples/typescript/src/gen6/ts/models/ApiResponse.ts
+++ b/examples/typescript/src/gen6/ts/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/typescript/src/gen6/ts/models/Cat.ts
+++ b/examples/typescript/src/gen6/ts/models/Cat.ts
@@ -3,17 +3,11 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/typescript/src/gen6/ts/models/Category.ts
+++ b/examples/typescript/src/gen6/ts/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/typescript/src/gen6/ts/models/Customer.ts
+++ b/examples/typescript/src/gen6/ts/models/Customer.ts
@@ -6,9 +6,6 @@
 import type { Address } from './Address'
 import type { CustomerParamsStatusEnumKey } from './CustomerParamsStatusEnum'
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -17,18 +14,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -36,8 +27,5 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }

--- a/examples/typescript/src/gen6/ts/models/DeleteOrder.ts
+++ b/examples/typescript/src/gen6/ts/models/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen6/ts/models/DeletePet.ts
+++ b/examples/typescript/src/gen6/ts/models/DeletePet.ts
@@ -5,9 +5,6 @@
 
 import type { DeletePetStatus200EnumKey } from './DeletePetStatus200Enum'
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -18,29 +15,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200EnumKey>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -48,9 +30,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400

--- a/examples/typescript/src/gen6/ts/models/Dog.ts
+++ b/examples/typescript/src/gen6/ts/models/Dog.ts
@@ -3,17 +3,11 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }

--- a/examples/typescript/src/gen6/ts/models/FindPetsByStatus.ts
+++ b/examples/typescript/src/gen6/ts/models/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen6/ts/models/FindPetsByTags.ts
+++ b/examples/typescript/src/gen6/ts/models/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen6/ts/models/FullAddress.ts
+++ b/examples/typescript/src/gen6/ts/models/FullAddress.ts
@@ -6,13 +6,7 @@
 import type { Address } from './Address'
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }

--- a/examples/typescript/src/gen6/ts/models/GetInventory.ts
+++ b/examples/typescript/src/gen6/ts/models/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/typescript/src/gen6/ts/models/GetOrderById.ts
+++ b/examples/typescript/src/gen6/ts/models/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen6/ts/models/GetPetById.ts
+++ b/examples/typescript/src/gen6/ts/models/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -24,19 +21,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -44,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen6/ts/models/HappyCustomer.ts
+++ b/examples/typescript/src/gen6/ts/models/HappyCustomer.ts
@@ -6,8 +6,5 @@
 import type { Customer } from './Customer'
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }

--- a/examples/typescript/src/gen6/ts/models/Order.ts
+++ b/examples/typescript/src/gen6/ts/models/Order.ts
@@ -7,9 +7,6 @@ import type { OrderHttpStatusEnumKey } from './OrderHttpStatusEnum'
 import type { OrderParamsStatusEnumKey } from './OrderParamsStatusEnum'
 import type { OrderStatusKey } from './OrderStatus'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -25,18 +22,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnumKey
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -61,8 +52,5 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/typescript/src/gen6/ts/models/Pet.ts
+++ b/examples/typescript/src/gen6/ts/models/Pet.ts
@@ -12,15 +12,9 @@ import type { Tag } from './Tag'
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -37,17 +31,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store

--- a/examples/typescript/src/gen6/ts/models/PetNotFound.ts
+++ b/examples/typescript/src/gen6/ts/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/typescript/src/gen6/ts/models/PlaceOrder.ts
+++ b/examples/typescript/src/gen6/ts/models/PlaceOrder.ts
@@ -5,14 +5,8 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -21,21 +15,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -43,9 +28,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/typescript/src/gen6/ts/models/PlaceOrderPatch.ts
+++ b/examples/typescript/src/gen6/ts/models/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/typescript/src/gen6/ts/models/Tag.ts
+++ b/examples/typescript/src/gen6/ts/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/typescript/src/gen6/ts/models/UnhappyCustomer.ts
+++ b/examples/typescript/src/gen6/ts/models/UnhappyCustomer.ts
@@ -6,12 +6,6 @@
 import type { Customer } from './Customer'
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }

--- a/examples/typescript/src/gen6/ts/models/UpdatePet.ts
+++ b/examples/typescript/src/gen6/ts/models/UpdatePet.ts
@@ -11,19 +11,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -43,9 +34,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -53,9 +41,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/typescript/src/gen6/ts/models/UpdatePetWithForm.ts
+++ b/examples/typescript/src/gen6/ts/models/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/typescript/src/gen6/ts/models/UploadFile.ts
+++ b/examples/typescript/src/gen6/ts/models/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,9 +23,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -41,9 +32,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -51,9 +39,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/typescript/src/gen7/modelsInlineLiteral.ts
+++ b/examples/typescript/src/gen7/modelsInlineLiteral.ts
@@ -10,9 +10,6 @@
  */
 export type OrderParamsStatusEnum = 'placed' | 'approved' | 'delivered'
 
-/**
- * @type string
- */
 export type OrderStatus = 'accepted'
 
 /**
@@ -29,9 +26,6 @@ export type OrderHttpStatusEnum = 200 | 400 | 500
  */
 export type CustomerParamsStatusEnum = 'placed' | 'approved' | 'delivered'
 
-/**
- * @type string
- */
 export type PetTypeEnum = 'dog' | 'cat'
 
 /**
@@ -53,14 +47,8 @@ export type AddPetRequestStatusEnum = 'available' | 'pending' | 'sold' | 'in sto
  */
 export type FindPetsByStatusStatus = 'available' | 'pending' | 'sold'
 
-/**
- * @type string
- */
 export type DeletePetStatus200Enum = 'TYPE1' | 'TYPE2' | 'TYPE3'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -76,18 +64,12 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -112,23 +94,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnum
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -147,9 +117,6 @@ export type Address = {
   zip?: string
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -158,18 +125,12 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -177,33 +138,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -219,9 +165,6 @@ export type Category = {
   name?: string
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -229,53 +172,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -292,17 +214,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -311,20 +224,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -338,17 +242,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -356,9 +251,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnum
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -366,19 +258,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -386,9 +269,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -398,19 +278,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -430,9 +301,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -440,9 +308,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -469,9 +334,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -479,9 +341,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -503,9 +362,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -513,9 +369,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -534,9 +387,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -545,26 +395,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatus
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -572,9 +410,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -593,9 +428,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -614,26 +446,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -641,9 +461,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -662,9 +479,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -681,19 +495,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -701,9 +506,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -723,9 +525,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -736,9 +535,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -752,14 +548,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -767,9 +557,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -779,9 +566,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -792,29 +576,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -822,9 +591,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -835,9 +601,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -848,9 +611,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -859,9 +619,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -871,9 +628,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -881,9 +635,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -893,16 +644,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -910,9 +655,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -922,14 +664,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -938,21 +674,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -960,9 +687,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -973,36 +697,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -1010,9 +716,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1023,9 +726,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1036,31 +736,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -1068,9 +753,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1090,9 +772,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1103,19 +782,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -1123,9 +793,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen8/modelsOptionalUndefined.ts
+++ b/examples/typescript/src/gen8/modelsOptionalUndefined.ts
@@ -10,9 +10,6 @@
  */
 export type OrderParamsStatusEnum = 'placed' | 'approved' | 'delivered'
 
-/**
- * @type string
- */
 export type OrderStatus = 'accepted'
 
 /**
@@ -29,9 +26,6 @@ export type OrderHttpStatusEnum = 200 | 400 | 500
  */
 export type CustomerParamsStatusEnum = 'placed' | 'approved' | 'delivered'
 
-/**
- * @type string
- */
 export type PetTypeEnum = 'dog' | 'cat'
 
 /**
@@ -53,14 +47,8 @@ export type AddPetRequestStatusEnum = 'available' | 'pending' | 'sold' | 'in sto
  */
 export type FindPetsByStatusStatus = 'available' | 'pending' | 'sold'
 
-/**
- * @type string
- */
 export type DeletePetStatus200Enum = 'TYPE1' | 'TYPE2' | 'TYPE3'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -76,9 +64,6 @@ export type Order = {
    * @type integer | undefined
    */
   petId: bigint | undefined
-  /**
-   * @type object | undefined
-   */
   params:
     | {
         /**
@@ -86,9 +71,6 @@ export type Order = {
          * @example approved
          */
         status: OrderParamsStatusEnum
-        /**
-         * @type string
-         */
         type: string
       }
     | undefined
@@ -114,23 +96,11 @@ export type Order = {
    * @example 200
    */
   http_status: OrderHttpStatusEnum | undefined
-  /**
-   * @type boolean | undefined
-   */
   complete: boolean | undefined
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName: string | undefined
-  /**
-   * @type string | undefined
-   */
   streetNumber: string | undefined
   /**
    * @example Palo Alto
@@ -149,9 +119,6 @@ export type Address = {
   zip: string | undefined
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -160,9 +127,6 @@ export type Customer = {
    * @type integer | undefined
    */
   id: bigint | undefined
-  /**
-   * @type object | undefined
-   */
   params:
     | {
         /**
@@ -170,9 +134,6 @@ export type Customer = {
          * @example approved
          */
         status: CustomerParamsStatusEnum
-        /**
-         * @type string
-         */
         type: string
       }
     | undefined
@@ -181,33 +142,18 @@ export type Customer = {
    * @type string | undefined
    */
   username: string | undefined
-  /**
-   * @type array | undefined
-   */
   address: Array<Address> | undefined
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy: true | undefined
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy: string | undefined
-  /**
-   * @type boolean | undefined
-   */
   isHappy: false | undefined
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -223,9 +169,6 @@ export type Category = {
   name: string | undefined
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -233,53 +176,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id: bigint | undefined
-  /**
-   * @type string | undefined
-   */
   name: string | undefined
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type: string | undefined
-  /**
-   * @type string | undefined
-   */
   bark: string | undefined
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type: string | undefined
-  /**
-   * @type string | undefined
-   */
   name: string | undefined
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -296,17 +218,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category: Category | undefined
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags: Array<Tag> | undefined
   /**
    * @description pet status in the store
@@ -315,20 +228,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -342,17 +246,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category: Category | undefined
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags: Array<Tag> | undefined
   /**
    * @description pet status in the store
@@ -360,9 +255,6 @@ export type AddPetRequest = {
   status: AddPetRequestStatusEnum | undefined
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -370,19 +262,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code: number | undefined
-  /**
-   * @type string | undefined
-   */
   type: string | undefined
-  /**
-   * @type string | undefined
-   */
   message: string | undefined
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -390,9 +273,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code: number | undefined
-  /**
-   * @type string | undefined
-   */
   message: string | undefined
 }
 
@@ -402,19 +282,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -434,9 +305,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path: never | undefined
@@ -444,9 +312,6 @@ export type UpdatePetOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -473,9 +338,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -483,9 +345,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code: number | undefined
-  /**
-   * @type string | undefined
-   */
   message: string | undefined
 }
 
@@ -507,9 +366,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path: never | undefined
@@ -517,9 +373,6 @@ export type AddPetOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -538,9 +391,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -549,26 +399,14 @@ export type FindPetsByStatusQuery = {
   status: FindPetsByStatusStatus | undefined
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body: never | undefined
   path: never | undefined
@@ -576,9 +414,6 @@ export type FindPetsByStatusOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -597,9 +432,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -618,26 +450,14 @@ export type FindPetsByTagsQuery = {
   pageSize: string | undefined
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body: never | undefined
   path: never | undefined
@@ -645,9 +465,6 @@ export type FindPetsByTagsOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -666,9 +483,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -685,19 +499,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body: never | undefined
   path: GetPetByIdPath
@@ -705,9 +510,6 @@ export type GetPetByIdOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -727,9 +529,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -740,9 +539,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -756,14 +552,8 @@ export type UpdatePetWithFormQuery = {
   status: string | undefined
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body: never | undefined
   path: UpdatePetWithFormPath
@@ -771,9 +561,6 @@ export type UpdatePetWithFormOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -783,9 +570,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -796,29 +580,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key: string | undefined
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body: never | undefined
   path: DeletePetPath
@@ -826,9 +595,6 @@ export type DeletePetOptions = {
   headers: DeletePetHeaders | undefined
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -839,9 +605,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -852,9 +615,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -863,9 +623,6 @@ export type UploadFileQuery = {
   additionalMetadata: string | undefined
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -875,9 +632,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -885,9 +639,6 @@ export type UploadFileOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -897,16 +648,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body: never | undefined
   path: never | undefined
@@ -914,9 +659,6 @@ export type GetInventoryOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -926,14 +668,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -942,21 +678,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path: never | undefined
@@ -964,9 +691,6 @@ export type PlaceOrderOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -977,36 +701,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path: never | undefined
@@ -1014,9 +720,6 @@ export type PlaceOrderPatchOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1027,9 +730,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1040,31 +740,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body: never | undefined
   path: GetOrderByIdPath
@@ -1072,9 +757,6 @@ export type GetOrderByIdOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1094,9 +776,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1107,19 +786,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body: never | undefined
   path: DeleteOrderPath
@@ -1127,9 +797,6 @@ export type DeleteOrderOptions = {
   headers: never | undefined
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/gen9/modelsOptionalBoth.ts
+++ b/examples/typescript/src/gen9/modelsOptionalBoth.ts
@@ -10,9 +10,6 @@
  */
 export type OrderParamsStatusEnum = 'placed' | 'approved' | 'delivered'
 
-/**
- * @type string
- */
 export type OrderStatus = 'accepted'
 
 /**
@@ -29,9 +26,6 @@ export type OrderHttpStatusEnum = 200 | 400 | 500
  */
 export type CustomerParamsStatusEnum = 'placed' | 'approved' | 'delivered'
 
-/**
- * @type string
- */
 export type PetTypeEnum = 'dog' | 'cat'
 
 /**
@@ -53,14 +47,8 @@ export type AddPetRequestStatusEnum = 'available' | 'pending' | 'sold' | 'in sto
  */
 export type FindPetsByStatusStatus = 'available' | 'pending' | 'sold'
 
-/**
- * @type string
- */
 export type DeletePetStatus200Enum = 'TYPE1' | 'TYPE2' | 'TYPE3'
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -76,9 +64,6 @@ export type Order = {
    * @type integer | undefined
    */
   petId?: bigint | undefined
-  /**
-   * @type object | undefined
-   */
   params?:
     | {
         /**
@@ -86,9 +71,6 @@ export type Order = {
          * @example approved
          */
         status: OrderParamsStatusEnum
-        /**
-         * @type string
-         */
         type: string
       }
     | undefined
@@ -114,23 +96,11 @@ export type Order = {
    * @example 200
    */
   http_status?: OrderHttpStatusEnum | undefined
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean | undefined
 }
 
-/**
- * @type object
- */
 export type Address = {
-  /**
-   * @type string | undefined
-   */
   streetName?: string | undefined
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string | undefined
   /**
    * @example Palo Alto
@@ -149,9 +119,6 @@ export type Address = {
   zip?: string | undefined
 }
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -160,9 +127,6 @@ export type Customer = {
    * @type integer | undefined
    */
   id?: bigint | undefined
-  /**
-   * @type object | undefined
-   */
   params?:
     | {
         /**
@@ -170,9 +134,6 @@ export type Customer = {
          * @example approved
          */
         status: CustomerParamsStatusEnum
-        /**
-         * @type string
-         */
         type: string
       }
     | undefined
@@ -181,33 +142,18 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string | undefined
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address> | undefined
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true | undefined
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string | undefined
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false | undefined
 }
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -223,9 +169,6 @@ export type Category = {
   name?: string | undefined
 }
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -233,53 +176,32 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint | undefined
-  /**
-   * @type string | undefined
-   */
   name?: string | undefined
 }
 
-/**
- * @type object
- */
 export type Dog = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string | undefined
-  /**
-   * @type string | undefined
-   */
   bark?: string | undefined
 }
 
-/**
- * @type object
- */
 export type Cat = {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string | undefined
-  /**
-   * @type string | undefined
-   */
   name?: string | undefined
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -296,17 +218,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category | undefined
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag> | undefined
   /**
    * @description pet status in the store
@@ -315,20 +228,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -342,17 +246,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category | undefined
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag> | undefined
   /**
    * @description pet status in the store
@@ -360,9 +255,6 @@ export type AddPetRequest = {
   status?: AddPetRequestStatusEnum | undefined
 }
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -370,19 +262,10 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number | undefined
-  /**
-   * @type string | undefined
-   */
   type?: string | undefined
-  /**
-   * @type string | undefined
-   */
   message?: string | undefined
 }
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -390,9 +273,6 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number | undefined
-  /**
-   * @type string | undefined
-   */
   message?: string | undefined
 }
 
@@ -402,19 +282,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -434,9 +305,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never | undefined
@@ -444,9 +312,6 @@ export type UpdatePetOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {
@@ -473,9 +338,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -483,9 +345,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number | undefined
-  /**
-   * @type string | undefined
-   */
   message?: string | undefined
 }
 
@@ -507,9 +366,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never | undefined
@@ -517,9 +373,6 @@ export type AddPetOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {
@@ -538,9 +391,6 @@ export type AddPetResponses = {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -549,26 +399,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatus | undefined
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never | undefined
   path?: never | undefined
@@ -576,9 +414,6 @@ export type FindPetsByStatusOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {
@@ -597,9 +432,6 @@ export type FindPetsByStatusResponses = {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -618,26 +450,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string | undefined
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never | undefined
   path?: never | undefined
@@ -645,9 +465,6 @@ export type FindPetsByTagsOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {
@@ -666,9 +483,6 @@ export type FindPetsByTagsResponses = {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -685,19 +499,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never | undefined
   path: GetPetByIdPath
@@ -705,9 +510,6 @@ export type GetPetByIdOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {
@@ -727,9 +529,6 @@ export type GetPetByIdResponses = {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -740,9 +539,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -756,14 +552,8 @@ export type UpdatePetWithFormQuery = {
   status?: string | undefined
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never | undefined
   path: UpdatePetWithFormPath
@@ -771,9 +561,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }
@@ -783,9 +570,6 @@ export type UpdatePetWithFormResponses = {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -796,29 +580,14 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string | undefined
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never | undefined
   path: DeletePetPath
@@ -826,9 +595,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders | undefined
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -839,9 +605,6 @@ export type DeletePetResponses = {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -852,9 +615,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -863,9 +623,6 @@ export type UploadFileQuery = {
   additionalMetadata?: string | undefined
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -875,9 +632,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -885,9 +639,6 @@ export type UploadFileOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }
@@ -897,16 +648,10 @@ export type UploadFileResponses = {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never | undefined
   path?: never | undefined
@@ -914,9 +659,6 @@ export type GetInventoryOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }
@@ -926,14 +668,8 @@ export type GetInventoryResponses = {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -942,21 +678,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never | undefined
@@ -964,9 +691,6 @@ export type PlaceOrderOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -977,36 +701,18 @@ export type PlaceOrderResponses = {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never | undefined
@@ -1014,9 +720,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1027,9 +730,6 @@ export type PlaceOrderPatchResponses = {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -1040,31 +740,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never | undefined
   path: GetOrderByIdPath
@@ -1072,9 +757,6 @@ export type GetOrderByIdOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {
@@ -1094,9 +776,6 @@ export type GetOrderByIdResponses = {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -1107,19 +786,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never | undefined
   path: DeleteOrderPath
@@ -1127,9 +797,6 @@ export type DeleteOrderOptions = {
   headers?: never | undefined
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/typescript/src/legacy/models.ts
+++ b/examples/typescript/src/legacy/models.ts
@@ -55,9 +55,6 @@ export enum DeletePetStatus200Enum {
   TYPE3 = 'TYPE3',
 }
 
-/**
- * @type object
- */
 export interface Order {
   /**
    * @description
@@ -73,18 +70,12 @@ export interface Order {
    * @type integer | undefined
    */
   petId?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: OrderParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -109,23 +100,11 @@ export interface Order {
    * @example 200
    */
   http_status?: OrderHttpStatusEnum
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }
 
-/**
- * @type object
- */
 export interface Address {
-  /**
-   * @type string | undefined
-   */
   streetName?: string
-  /**
-   * @type string | undefined
-   */
   streetNumber?: string
   /**
    * @example Palo Alto
@@ -144,9 +123,6 @@ export interface Address {
   zip?: string
 }
 
-/**
- * @type object
- */
 export interface Customer {
   /**
    * @description
@@ -155,18 +131,12 @@ export interface Customer {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type object | undefined
-   */
   params?: {
     /**
      * @description Order Status
      * @example approved
      */
     status: CustomerParamsStatusEnum
-    /**
-     * @type string
-     */
     type: string
   }
   /**
@@ -174,33 +144,18 @@ export interface Customer {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Array<Address>
 }
 
 export type HappyCustomer = Customer & {
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: true
 }
 
 export type UnhappyCustomer = Customer & {
-  /**
-   * @type string | undefined
-   */
   reasonToBeUnhappy?: string
-  /**
-   * @type boolean | undefined
-   */
   isHappy?: false
 }
 
-/**
- * @type object
- */
 export interface Category {
   /**
    * @description
@@ -216,9 +171,6 @@ export interface Category {
   name?: string
 }
 
-/**
- * @type object
- */
 export interface Tag {
   /**
    * @description
@@ -226,53 +178,32 @@ export interface Tag {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
-/**
- * @type object
- */
 export interface Dog {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   bark?: string
 }
 
-/**
- * @type object
- */
 export interface Cat {
   /**
    * @minLength 1
    * @type string | undefined
    */
   readonly type?: string
-  /**
-   * @type string | undefined
-   */
   name?: string
 }
 
 export type Pet = (
   | (Dog & {
-      /**
-       * @type string
-       */
       readonly type: 'dog'
     })
   | (Cat & {
-      /**
-       * @type string
-       */
       readonly type: 'cat'
     })
 ) & {
@@ -289,17 +220,8 @@ export type Pet = (
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   readonly tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -308,20 +230,11 @@ export type Pet = (
 }
 
 export type FullAddress = Address & {
-  /**
-   * @type string
-   */
   streetNumber: string
 } & {
-  /**
-   * @type string
-   */
   streetName: string
 }
 
-/**
- * @type object
- */
 export interface AddPetRequest {
   /**
    * @description
@@ -335,17 +248,8 @@ export interface AddPetRequest {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store
@@ -353,9 +257,6 @@ export interface AddPetRequest {
   status?: AddPetRequestStatusEnum
 }
 
-/**
- * @type object
- */
 export interface ApiResponse {
   /**
    * @description
@@ -363,19 +264,10 @@ export interface ApiResponse {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
-/**
- * @type object
- */
 export interface PetNotFound {
   /**
    * @description
@@ -383,9 +275,6 @@ export interface PetNotFound {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -395,19 +284,10 @@ export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -427,9 +307,6 @@ export type UpdatePetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface UpdatePetOptions {
   body: UpdatePetBody
   path?: never
@@ -437,9 +314,6 @@ export interface UpdatePetOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface UpdatePetResponses {
   '200':
     | {
@@ -466,9 +340,6 @@ export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export interface AddPetStatus405 {
   /**
    * @description
@@ -476,9 +347,6 @@ export interface AddPetStatus405 {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -500,9 +368,6 @@ export type AddPetBodyFormUrlEncoded = Omit<NonNullable<Pet>, 'type' | 'tags'>
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface AddPetOptions {
   body: AddPetBody
   path?: never
@@ -510,9 +375,6 @@ export interface AddPetOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface AddPetResponses {
   '200':
     | {
@@ -531,9 +393,6 @@ export interface AddPetResponses {
  */
 export type AddPetResponse = AddPetStatus200 | AddPetStatus405
 
-/**
- * @type object
- */
 export interface FindPetsByStatusQuery {
   /**
    * @description Status values that need to be considered for filter
@@ -542,26 +401,14 @@ export interface FindPetsByStatusQuery {
   status?: FindPetsByStatusStatus
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export interface FindPetsByStatusOptions {
   body?: never
   path?: never
@@ -569,9 +416,6 @@ export interface FindPetsByStatusOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface FindPetsByStatusResponses {
   '200':
     | {
@@ -590,9 +434,6 @@ export interface FindPetsByStatusResponses {
  */
 export type FindPetsByStatusResponse = FindPetsByStatusStatus200 | FindPetsByStatusStatus400
 
-/**
- * @type object
- */
 export interface FindPetsByTagsQuery {
   /**
    * @description Tags to filter by
@@ -611,26 +452,14 @@ export interface FindPetsByTagsQuery {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export interface FindPetsByTagsOptions {
   body?: never
   path?: never
@@ -638,9 +467,6 @@ export interface FindPetsByTagsOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface FindPetsByTagsResponses {
   '200':
     | {
@@ -659,9 +485,6 @@ export interface FindPetsByTagsResponses {
  */
 export type FindPetsByTagsResponse = FindPetsByTagsStatus200 | FindPetsByTagsStatus400
 
-/**
- * @type object
- */
 export interface GetPetByIdPath {
   /**
    * @description ID of pet to return
@@ -678,19 +501,10 @@ export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export interface GetPetByIdOptions {
   body?: never
   path: GetPetByIdPath
@@ -698,9 +512,6 @@ export interface GetPetByIdOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface GetPetByIdResponses {
   '200':
     | {
@@ -720,9 +531,6 @@ export interface GetPetByIdResponses {
  */
 export type GetPetByIdResponse = GetPetByIdStatus200 | GetPetByIdStatus400 | GetPetByIdStatus404
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormPath {
   /**
    * @description ID of pet that needs to be updated
@@ -733,9 +541,6 @@ export interface UpdatePetWithFormPath {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormQuery {
   /**
    * @description Name of pet that needs to be updated
@@ -749,14 +554,8 @@ export interface UpdatePetWithFormQuery {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormOptions {
   body?: never
   path: UpdatePetWithFormPath
@@ -764,9 +563,6 @@ export interface UpdatePetWithFormOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface UpdatePetWithFormResponses {
   '405': UpdatePetWithFormStatus405
 }
@@ -776,9 +572,6 @@ export interface UpdatePetWithFormResponses {
  */
 export type UpdatePetWithFormResponse = UpdatePetWithFormStatus405
 
-/**
- * @type object
- */
 export interface DeletePetPath {
   /**
    * @description Pet id to delete
@@ -789,29 +582,14 @@ export interface DeletePetPath {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export interface DeletePetHeaders {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type array
- */
 export type DeletePetStatus200 = Array<DeletePetStatus200Enum>
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export interface DeletePetOptions {
   body?: never
   path: DeletePetPath
@@ -819,9 +597,6 @@ export interface DeletePetOptions {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export interface DeletePetResponses {
   '200': DeletePetStatus200
   '400': DeletePetStatus400
@@ -832,9 +607,6 @@ export interface DeletePetResponses {
  */
 export type DeletePetResponse = DeletePetStatus200 | DeletePetStatus400
 
-/**
- * @type object
- */
 export interface UploadFilePath {
   /**
    * @description ID of pet to update
@@ -845,9 +617,6 @@ export interface UploadFilePath {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export interface UploadFileQuery {
   /**
    * @description Additional Metadata
@@ -856,9 +625,6 @@ export interface UploadFileQuery {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
 /**
@@ -868,9 +634,6 @@ export type UploadFileStatus200 = ApiResponse
  */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export interface UploadFileOptions {
   body: UploadFileBody
   path: UploadFilePath
@@ -878,9 +641,6 @@ export interface UploadFileOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface UploadFileResponses {
   '200': UploadFileStatus200
 }
@@ -890,16 +650,10 @@ export interface UploadFileResponses {
  */
 export type UploadFileResponse = UploadFileStatus200
 
-/**
- * @type object
- */
 export interface GetInventoryStatus200 {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export interface GetInventoryOptions {
   body?: never
   path?: never
@@ -907,9 +661,6 @@ export interface GetInventoryOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface GetInventoryResponses {
   '200': GetInventoryStatus200
 }
@@ -919,14 +670,8 @@ export interface GetInventoryResponses {
  */
 export type GetInventoryResponse = GetInventoryStatus200
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
 /**
@@ -935,21 +680,12 @@ export type PlaceOrderStatus405 = unknown
  */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface PlaceOrderOptions {
   body: PlaceOrderBody
   path?: never
@@ -957,9 +693,6 @@ export interface PlaceOrderOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface PlaceOrderResponses {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405
@@ -970,36 +703,18 @@ export interface PlaceOrderResponses {
  */
 export type PlaceOrderResponse = PlaceOrderStatus200 | PlaceOrderStatus405
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export interface PlaceOrderPatchOptions {
   body: PlaceOrderPatchBody
   path?: never
@@ -1007,9 +722,6 @@ export interface PlaceOrderPatchOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface PlaceOrderPatchResponses {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405
@@ -1020,9 +732,6 @@ export interface PlaceOrderPatchResponses {
  */
 export type PlaceOrderPatchResponse = PlaceOrderPatchStatus200 | PlaceOrderPatchStatus405
 
-/**
- * @type object
- */
 export interface GetOrderByIdPath {
   /**
    * @description ID of order that needs to be fetched
@@ -1033,31 +742,16 @@ export interface GetOrderByIdPath {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export interface GetOrderByIdOptions {
   body?: never
   path: GetOrderByIdPath
@@ -1065,9 +759,6 @@ export interface GetOrderByIdOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface GetOrderByIdResponses {
   '200':
     | {
@@ -1087,9 +778,6 @@ export interface GetOrderByIdResponses {
  */
 export type GetOrderByIdResponse = GetOrderByIdStatus200 | GetOrderByIdStatus400 | GetOrderByIdStatus404
 
-/**
- * @type object
- */
 export interface DeleteOrderPath {
   /**
    * @description ID of the order that needs to be deleted
@@ -1100,19 +788,10 @@ export interface DeleteOrderPath {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export interface DeleteOrderOptions {
   body?: never
   path: DeleteOrderPath
@@ -1120,9 +799,6 @@ export interface DeleteOrderOptions {
   headers?: never
 }
 
-/**
- * @type object
- */
 export interface DeleteOrderResponses {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/vue-query/src/gen/models/AddPetRequest.ts
+++ b/examples/vue-query/src/gen/models/AddPetRequest.ts
@@ -14,9 +14,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/vue-query/src/gen/models/Address.ts
+++ b/examples/vue-query/src/gen/models/Address.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Address = {
   /**
    * @example 437 Lytton

--- a/examples/vue-query/src/gen/models/ApiResponse.ts
+++ b/examples/vue-query/src/gen/models/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/vue-query/src/gen/models/Category.ts
+++ b/examples/vue-query/src/gen/models/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description

--- a/examples/vue-query/src/gen/models/Customer.ts
+++ b/examples/vue-query/src/gen/models/Customer.ts
@@ -5,9 +5,6 @@
 
 import type { Address } from './Address'
 
-/**
- * @type object
- */
 export type Customer = {
   /**
    * @description
@@ -21,8 +18,5 @@ export type Customer = {
    * @type string | undefined
    */
   username?: string
-  /**
-   * @type array | undefined
-   */
   address?: Address[]
 }

--- a/examples/vue-query/src/gen/models/Order.ts
+++ b/examples/vue-query/src/gen/models/Order.ts
@@ -19,9 +19,6 @@ export const orderHttpStatusEnum = {
 
 export type OrderHttpStatusEnumKey = (typeof orderHttpStatusEnum)[keyof typeof orderHttpStatusEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -62,8 +59,5 @@ export type Order = {
    * @type number | undefined
    */
   http_status?: OrderHttpStatusEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/vue-query/src/gen/models/Pet.ts
+++ b/examples/vue-query/src/gen/models/Pet.ts
@@ -14,9 +14,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: string[]
-  /**
-   * @type array | undefined
-   */
   tags?: Tag[]
   /**
    * @description pet status in the store

--- a/examples/vue-query/src/gen/models/PetNotFound.ts
+++ b/examples/vue-query/src/gen/models/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/vue-query/src/gen/models/Tag.ts
+++ b/examples/vue-query/src/gen/models/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/vue-query/src/gen/models/User.ts
+++ b/examples/vue-query/src/gen/models/User.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type User = {
   /**
    * @description

--- a/examples/vue-query/src/gen/models/UserArray.ts
+++ b/examples/vue-query/src/gen/models/UserArray.ts
@@ -5,7 +5,4 @@
 
 import type { User } from './User'
 
-/**
- * @type array
- */
 export type UserArray = User[]

--- a/examples/vue-query/src/gen/models/pet/AddPet.ts
+++ b/examples/vue-query/src/gen/models/pet/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from '../AddPetRequest'
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/pet/DeletePet.ts
+++ b/examples/vue-query/src/gen/models/pet/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/vue-query/src/gen/models/pet/FindPetsByStatus.ts
+++ b/examples/vue-query/src/gen/models/pet/FindPetsByStatus.ts
@@ -13,9 +13,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -25,26 +22,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Pet[]
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -52,9 +37,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/pet/FindPetsByTags.ts
+++ b/examples/vue-query/src/gen/models/pet/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -26,26 +23,14 @@ export type FindPetsByTagsQuery = {
   pageSize?: string
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Pet[]
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Pet[]
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -53,9 +38,6 @@ export type FindPetsByTagsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/pet/GetPetById.ts
+++ b/examples/vue-query/src/gen/models/pet/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/pet/UpdatePet.ts
+++ b/examples/vue-query/src/gen/models/pet/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from '../Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/pet/UpdatePetWithForm.ts
+++ b/examples/vue-query/src/gen/models/pet/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/vue-query/src/gen/models/pet/UploadFile.ts
+++ b/examples/vue-query/src/gen/models/pet/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from '../ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,14 +23,8 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type object
- */
 export type UploadFileBodyJson = {
   /**
    * @description URL of the image to upload
@@ -47,21 +35,12 @@ export type UploadFileBodyJson = {
   url: string
 }
 
-/**
- * @type object
- */
 export type UploadFileBodyFormData = {
-  /**
-   * @type string
-   */
   file: Blob
 }
 
 export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -69,9 +48,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/examples/vue-query/src/gen/models/store/DeleteOrder.ts
+++ b/examples/vue-query/src/gen/models/store/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/vue-query/src/gen/models/store/GetInventory.ts
+++ b/examples/vue-query/src/gen/models/store/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/vue-query/src/gen/models/store/GetOrderById.ts
+++ b/examples/vue-query/src/gen/models/store/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/store/PlaceOrder.ts
+++ b/examples/vue-query/src/gen/models/store/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/vue-query/src/gen/models/store/PlaceOrderPatch.ts
+++ b/examples/vue-query/src/gen/models/store/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from '../Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/vue-query/src/gen/models/user/CreateUser.ts
+++ b/examples/vue-query/src/gen/models/user/CreateUser.ts
@@ -5,14 +5,8 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultJson = User
 
-/**
- * @type object
- */
 export type CreateUserStatusDefaultXml = User
 
 export type CreateUserStatusDefault = CreateUserStatusDefaultJson | CreateUserStatusDefaultXml
@@ -37,9 +31,6 @@ export type CreateUserBodyFormUrlEncoded = User | undefined
 
 export type CreateUserBody = CreateUserBodyJson | CreateUserBodyXml | CreateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type CreateUserOptions = {
   body: CreateUserBody
   path?: never
@@ -47,9 +38,6 @@ export type CreateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUserResponses = {
   default:
     | {

--- a/examples/vue-query/src/gen/models/user/CreateUsersWithListInput.ts
+++ b/examples/vue-query/src/gen/models/user/CreateUsersWithListInput.ts
@@ -5,31 +5,16 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Json = User
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputStatus200Xml = User
 
 export type CreateUsersWithListInputStatus200 = CreateUsersWithListInputStatus200Json | CreateUsersWithListInputStatus200Xml
 
-/**
- * @type unknown
- */
 export type CreateUsersWithListInputStatusDefault = unknown
 
-/**
- * @type array | undefined
- */
 export type CreateUsersWithListInputBody = User[] | undefined
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputOptions = {
   body: CreateUsersWithListInputBody
   path?: never
@@ -37,9 +22,6 @@ export type CreateUsersWithListInputOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type CreateUsersWithListInputResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/user/DeleteUser.ts
+++ b/examples/vue-query/src/gen/models/user/DeleteUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteUserPath = {
   /**
    * @description The name that needs to be deleted
@@ -14,19 +11,10 @@ export type DeleteUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteUserStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteUserOptions = {
   body?: never
   path: DeleteUserPath
@@ -34,9 +22,6 @@ export type DeleteUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteUserResponses = {
   '400': DeleteUserStatus400
   '404': DeleteUserStatus404

--- a/examples/vue-query/src/gen/models/user/GetUserByName.ts
+++ b/examples/vue-query/src/gen/models/user/GetUserByName.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type GetUserByNamePath = {
   /**
    * @description The name that needs to be fetched. Use user1 for testing.
@@ -16,31 +13,16 @@ export type GetUserByNamePath = {
   username: string
 }
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Json = User
 
-/**
- * @type object
- */
 export type GetUserByNameStatus200Xml = User
 
 export type GetUserByNameStatus200 = GetUserByNameStatus200Json | GetUserByNameStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetUserByNameStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetUserByNameOptions = {
   body?: never
   path: GetUserByNamePath
@@ -48,9 +30,6 @@ export type GetUserByNameOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetUserByNameResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/user/LoginUser.ts
+++ b/examples/vue-query/src/gen/models/user/LoginUser.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type LoginUserQuery = {
   /**
    * @description The user name for login
@@ -19,26 +16,14 @@ export type LoginUserQuery = {
   password?: string
 }
 
-/**
- * @type string
- */
 export type LoginUserStatus200Xml = string
 
-/**
- * @type string
- */
 export type LoginUserStatus200Json = string
 
 export type LoginUserStatus200 = LoginUserStatus200Xml | LoginUserStatus200Json
 
-/**
- * @type unknown
- */
 export type LoginUserStatus400 = unknown
 
-/**
- * @type object
- */
 export type LoginUserOptions = {
   body?: never
   path?: never
@@ -46,9 +31,6 @@ export type LoginUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LoginUserResponses = {
   '200':
     | {

--- a/examples/vue-query/src/gen/models/user/LogoutUser.ts
+++ b/examples/vue-query/src/gen/models/user/LogoutUser.ts
@@ -3,14 +3,8 @@
  * Do not edit manually.
  */
 
-/**
- * @type unknown
- */
 export type LogoutUserStatusDefault = unknown
 
-/**
- * @type object
- */
 export type LogoutUserOptions = {
   body?: never
   path?: never
@@ -18,9 +12,6 @@ export type LogoutUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type LogoutUserResponses = {
   default: LogoutUserStatusDefault
 }

--- a/examples/vue-query/src/gen/models/user/UpdateUser.ts
+++ b/examples/vue-query/src/gen/models/user/UpdateUser.ts
@@ -5,9 +5,6 @@
 
 import type { User } from '../User'
 
-/**
- * @type object
- */
 export type UpdateUserPath = {
   /**
    * @description name that need to be deleted
@@ -16,9 +13,6 @@ export type UpdateUserPath = {
   username: string
 }
 
-/**
- * @type unknown
- */
 export type UpdateUserStatusDefault = unknown
 
 /**
@@ -41,9 +35,6 @@ export type UpdateUserBodyFormUrlEncoded = User | undefined
 
 export type UpdateUserBody = UpdateUserBodyJson | UpdateUserBodyXml | UpdateUserBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdateUserOptions = {
   body: UpdateUserBody
   path: UpdateUserPath
@@ -51,9 +42,6 @@ export type UpdateUserOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdateUserResponses = {
   default: UpdateUserStatusDefault
 }

--- a/examples/zod/src/zod/ts/AddPet.ts
+++ b/examples/zod/src/zod/ts/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type AddPetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type AddPetStatus200Xml = Pet
 
 export type AddPetStatus200 = AddPetStatus200Json | AddPetStatus200Xml
 
-/**
- * @type object
- */
 export type AddPetStatus405 = {
   /**
    * @description
@@ -28,9 +19,6 @@ export type AddPetStatus405 = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }
 
@@ -54,9 +42,6 @@ export type AddPetBodyFormUrlEncoded = Pet
 
 export type AddPetBody = AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -64,9 +49,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200':
     | {

--- a/examples/zod/src/zod/ts/AddPetRequest.ts
+++ b/examples/zod/src/zod/ts/AddPetRequest.ts
@@ -14,9 +14,6 @@ export const addPetRequestStatusEnum = {
 
 export type AddPetRequestStatusEnumKey = (typeof addPetRequestStatusEnum)[keyof typeof addPetRequestStatusEnum]
 
-/**
- * @type object
- */
 export type AddPetRequest = {
   /**
    * @description
@@ -30,17 +27,8 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store

--- a/examples/zod/src/zod/ts/ApiResponse.ts
+++ b/examples/zod/src/zod/ts/ApiResponse.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type ApiResponse = {
   /**
    * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   type?: string
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/zod/src/zod/ts/Category.ts
+++ b/examples/zod/src/zod/ts/Category.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Category = {
   /**
    * @description
@@ -19,8 +16,5 @@ export type Category = {
    * @type string | undefined
    */
   name?: string
-  /**
-   * @type object | undefined
-   */
   parent?: Category
 }

--- a/examples/zod/src/zod/ts/CreatePets.ts
+++ b/examples/zod/src/zod/ts/CreatePets.ts
@@ -5,9 +5,6 @@
 
 import type { PetNotFound } from './PetNotFound'
 
-/**
- * @type object
- */
 export type CreatePetsPath = {
   /**
    * @description UUID
@@ -16,9 +13,6 @@ export type CreatePetsPath = {
   uuid: string
 }
 
-/**
- * @type object
- */
 export type CreatePetsQuery = {
   /**
    * @description Offset
@@ -35,9 +29,6 @@ export const createPetsXEXAMPLE = {
 
 export type CreatePetsXEXAMPLEKey = (typeof createPetsXEXAMPLE)[keyof typeof createPetsXEXAMPLE]
 
-/**
- * @type object
- */
 export type CreatePetsHeaders = {
   /**
    * @description Header parameters
@@ -46,9 +37,6 @@ export type CreatePetsHeaders = {
   'X-EXAMPLE': CreatePetsXEXAMPLEKey
 }
 
-/**
- * @type unknown
- */
 export type CreatePetsStatus201 = unknown
 
 /**
@@ -57,23 +45,11 @@ export type CreatePetsStatus201 = unknown
  */
 export type CreatePetsStatusDefault = PetNotFound
 
-/**
- * @type object
- */
 export type CreatePetsBody = {
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string
-   */
   tag: string
 }
 
-/**
- * @type object
- */
 export type CreatePetsOptions = {
   body: CreatePetsBody
   path: CreatePetsPath
@@ -81,9 +57,6 @@ export type CreatePetsOptions = {
   headers: CreatePetsHeaders
 }
 
-/**
- * @type object
- */
 export type CreatePetsResponses = {
   '201': CreatePetsStatus201
   default: CreatePetsStatusDefault

--- a/examples/zod/src/zod/ts/DeleteOrder.ts
+++ b/examples/zod/src/zod/ts/DeleteOrder.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeleteOrderPath = {
   /**
    * @description ID of the order that needs to be deleted
@@ -16,19 +13,10 @@ export type DeleteOrderPath = {
   orderId: bigint
 }
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type DeleteOrderStatus404 = unknown
 
-/**
- * @type object
- */
 export type DeleteOrderOptions = {
   body?: never
   path: DeleteOrderPath
@@ -36,9 +24,6 @@ export type DeleteOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeleteOrderResponses = {
   '400': DeleteOrderStatus400
   '404': DeleteOrderStatus404

--- a/examples/zod/src/zod/ts/DeletePet.ts
+++ b/examples/zod/src/zod/ts/DeletePet.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
   /**
    * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type DeletePetHeaders = {
-  /**
-   * @type string | undefined
-   */
   api_key?: string
 }
 
-/**
- * @type unknown
- */
 export type DeletePetStatus400 = unknown
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
   headers?: DeletePetHeaders
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '400': DeletePetStatus400
 }

--- a/examples/zod/src/zod/ts/FindPetsByStatus.ts
+++ b/examples/zod/src/zod/ts/FindPetsByStatus.ts
@@ -13,9 +13,6 @@ export const findPetsByStatusStatus = {
 
 export type FindPetsByStatusStatusKey = (typeof findPetsByStatusStatus)[keyof typeof findPetsByStatusStatus]
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
   /**
    * @description Status values that need to be considered for filter
@@ -25,26 +22,14 @@ export type FindPetsByStatusQuery = {
   status?: FindPetsByStatusStatusKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByStatusStatus200Xml = Array<Pet>
 
 export type FindPetsByStatusStatus200 = FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByStatusStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -52,9 +37,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200':
     | {

--- a/examples/zod/src/zod/ts/FindPetsByTags.ts
+++ b/examples/zod/src/zod/ts/FindPetsByTags.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type FindPetsByTagsQuery = {
   /**
    * @description Tags to filter by
@@ -34,9 +31,6 @@ export const findPetsByTagsXEXAMPLE = {
 
 export type FindPetsByTagsXEXAMPLEKey = (typeof findPetsByTagsXEXAMPLE)[keyof typeof findPetsByTagsXEXAMPLE]
 
-/**
- * @type object
- */
 export type FindPetsByTagsHeaders = {
   /**
    * @description Header parameters
@@ -45,26 +39,14 @@ export type FindPetsByTagsHeaders = {
   'X-EXAMPLE': FindPetsByTagsXEXAMPLEKey
 }
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Json = Array<Pet>
 
-/**
- * @type array
- */
 export type FindPetsByTagsStatus200Xml = Array<Pet>
 
 export type FindPetsByTagsStatus200 = FindPetsByTagsStatus200Json | FindPetsByTagsStatus200Xml
 
-/**
- * @type unknown
- */
 export type FindPetsByTagsStatus400 = unknown
 
-/**
- * @type object
- */
 export type FindPetsByTagsOptions = {
   body?: never
   path?: never
@@ -72,9 +54,6 @@ export type FindPetsByTagsOptions = {
   headers: FindPetsByTagsHeaders
 }
 
-/**
- * @type object
- */
 export type FindPetsByTagsResponses = {
   '200':
     | {

--- a/examples/zod/src/zod/ts/GetInventory.ts
+++ b/examples/zod/src/zod/ts/GetInventory.ts
@@ -3,16 +3,10 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type GetInventoryStatus200 = {
   [key: string]: number
 }
 
-/**
- * @type object
- */
 export type GetInventoryOptions = {
   body?: never
   path?: never
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetInventoryResponses = {
   '200': GetInventoryStatus200
 }

--- a/examples/zod/src/zod/ts/GetOrderById.ts
+++ b/examples/zod/src/zod/ts/GetOrderById.ts
@@ -5,9 +5,6 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type GetOrderByIdPath = {
   /**
    * @description ID of order that needs to be fetched
@@ -18,31 +15,16 @@ export type GetOrderByIdPath = {
   orderId: bigint
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Json = Order
 
-/**
- * @type object
- */
 export type GetOrderByIdStatus200Xml = Order
 
 export type GetOrderByIdStatus200 = GetOrderByIdStatus200Json | GetOrderByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetOrderByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetOrderByIdOptions = {
   body?: never
   path: GetOrderByIdPath
@@ -50,9 +32,6 @@ export type GetOrderByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetOrderByIdResponses = {
   '200':
     | {

--- a/examples/zod/src/zod/ts/GetPetById.ts
+++ b/examples/zod/src/zod/ts/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
   /**
    * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = Pet
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = Pet
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type GetPetByIdStatus404 = unknown
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/examples/zod/src/zod/ts/GetThings.ts
+++ b/examples/zod/src/zod/ts/GetThings.ts
@@ -5,9 +5,6 @@
 
 import type { PetNotFound } from './PetNotFound'
 
-/**
- * @type object
- */
 export type GetThingsQuery = {
   /**
    * @description Maximum number of things to return
@@ -26,9 +23,6 @@ export type GetThingsQuery = {
   skip?: number
 }
 
-/**
- * @type unknown
- */
 export type GetThingsStatus201 = unknown
 
 /**
@@ -37,9 +31,6 @@ export type GetThingsStatus201 = unknown
  */
 export type GetThingsStatusDefault = PetNotFound
 
-/**
- * @type object
- */
 export type GetThingsOptions = {
   body?: never
   path?: never
@@ -47,9 +38,6 @@ export type GetThingsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetThingsResponses = {
   '201': GetThingsStatus201
   default: GetThingsStatusDefault

--- a/examples/zod/src/zod/ts/Order.ts
+++ b/examples/zod/src/zod/ts/Order.ts
@@ -30,9 +30,6 @@ export const orderValueEnum = {
 
 export type OrderValueEnumKey = (typeof orderValueEnum)[keyof typeof orderValueEnum]
 
-/**
- * @type object
- */
 export type Order = {
   /**
    * @description
@@ -79,8 +76,5 @@ export type Order = {
    * @type number | undefined
    */
   value?: OrderValueEnumKey
-  /**
-   * @type boolean | undefined
-   */
   complete?: boolean
 }

--- a/examples/zod/src/zod/ts/Pet.ts
+++ b/examples/zod/src/zod/ts/Pet.ts
@@ -14,9 +14,6 @@ export const petStatusEnum = {
 
 export type PetStatusEnumKey = (typeof petStatusEnum)[keyof typeof petStatusEnum]
 
-/**
- * @type object
- */
 export type Pet = {
   /**
    * @description
@@ -25,9 +22,6 @@ export type Pet = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type array | undefined
-   */
   parent?: Array<Pet>
   /**
    * @pattern ^[0-9]{1,19}$
@@ -40,17 +34,8 @@ export type Pet = {
    * @type string
    */
   name: string
-  /**
-   * @type object | undefined
-   */
   category?: Category
-  /**
-   * @type array
-   */
   photoUrls: Array<string>
-  /**
-   * @type array | undefined
-   */
   tags?: Array<Tag>
   /**
    * @description pet status in the store

--- a/examples/zod/src/zod/ts/PetNotFound.ts
+++ b/examples/zod/src/zod/ts/PetNotFound.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type PetNotFound = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type PetNotFound = {
    * @type integer | undefined
    */
   code?: number
-  /**
-   * @type string | undefined
-   */
   message?: string
 }

--- a/examples/zod/src/zod/ts/PlaceOrder.ts
+++ b/examples/zod/src/zod/ts/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderBody = PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderOptions = {
   body: PlaceOrderBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderResponses = {
   '200': PlaceOrderStatus200
   '405': PlaceOrderStatus405

--- a/examples/zod/src/zod/ts/PlaceOrderPatch.ts
+++ b/examples/zod/src/zod/ts/PlaceOrderPatch.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = Order
 
-/**
- * @type unknown
- */
 export type PlaceOrderPatchStatus405 = unknown
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyJson = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyXml = Order | undefined
 
-/**
- * @type object | undefined
- */
 export type PlaceOrderPatchBodyFormUrlEncoded = Order | undefined
 
 export type PlaceOrderPatchBody = PlaceOrderPatchBodyJson | PlaceOrderPatchBodyXml | PlaceOrderPatchBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path?: never
@@ -42,9 +24,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/examples/zod/src/zod/ts/Tag.ts
+++ b/examples/zod/src/zod/ts/Tag.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type Tag = {
   /**
    * @description
@@ -13,8 +10,5 @@ export type Tag = {
    * @type integer | undefined
    */
   id?: bigint
-  /**
-   * @type string | undefined
-   */
   name?: string
 }

--- a/examples/zod/src/zod/ts/UpdatePet.ts
+++ b/examples/zod/src/zod/ts/UpdatePet.ts
@@ -5,31 +5,16 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Json = Pet
 
-/**
- * @type object
- */
 export type UpdatePetStatus200Xml = Pet
 
 export type UpdatePetStatus200 = UpdatePetStatus200Json | UpdatePetStatus200Xml
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus400 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus404 = unknown
 
-/**
- * @type unknown
- */
 export type UpdatePetStatus405 = unknown
 
 /**
@@ -52,9 +37,6 @@ export type UpdatePetBodyFormUrlEncoded = Pet
 
 export type UpdatePetBody = UpdatePetBodyJson | UpdatePetBodyXml | UpdatePetBodyFormUrlEncoded
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path?: never
@@ -62,9 +44,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200':
     | {

--- a/examples/zod/src/zod/ts/UpdatePetWithForm.ts
+++ b/examples/zod/src/zod/ts/UpdatePetWithForm.ts
@@ -3,9 +3,6 @@
  * Do not edit manually.
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
   /**
    * @description ID of pet that needs to be updated
@@ -16,9 +13,6 @@ export type UpdatePetWithFormPath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
   /**
    * @description Name of pet that needs to be updated
@@ -32,14 +26,8 @@ export type UpdatePetWithFormQuery = {
   status?: string
 }
 
-/**
- * @type unknown
- */
 export type UpdatePetWithFormStatus405 = unknown
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -47,9 +35,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '405': UpdatePetWithFormStatus405
 }

--- a/examples/zod/src/zod/ts/UploadFile.ts
+++ b/examples/zod/src/zod/ts/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
- */
 export type UploadFilePath = {
   /**
    * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
   petId: bigint
 }
 
-/**
- * @type object
- */
 export type UploadFileQuery = {
   /**
    * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
   additionalMetadata?: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = ApiResponse
 
-/**
- * @type string | undefined
- */
 export type UploadFileBody = Blob | undefined
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/addPetPOSTWithRequestBody/AddPet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/addPetPOSTWithRequestBody/AddPet.ts
@@ -4,24 +4,12 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type AddPetStatus200 = object
 
-/**
- * @type object
- */
 export type AddPetStatus405 = object
 
-/**
- * @type object
- */
 export type AddPetBody = object
 
-/**
- * @type object
- */
 export type AddPetOptions = {
   body: AddPetBody
   path?: never
@@ -29,9 +17,6 @@ export type AddPetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type AddPetResponses = {
   '200': AddPetStatus200
   '405': AddPetStatus405

--- a/packages/plugin-ts/src/generators/__snapshots__/arrayOfObjectWithNestedEnumRegressionForKubbLabsKubb3475/GetArrayOfObject.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/arrayOfObjectWithNestedEnumRegressionForKubbLabsKubb3475/GetArrayOfObject.ts
@@ -11,23 +11,11 @@ export const arrayOfObjectStatusEnum = {
 
 export type ArrayOfObjectStatusEnumKey = (typeof arrayOfObjectStatusEnum)[keyof typeof arrayOfObjectStatusEnum]
 
-/**
- * @type array
- */
 export type GetArrayOfObjectStatus200 = {
-  /**
-   * @type number
-   */
   id: number
-  /**
-   * @type string
-   */
   status: ArrayOfObjectStatusEnumKey
 }[]
 
-/**
- * @type object
- */
 export type GetArrayOfObjectOptions = {
   body?: never
   path?: never
@@ -35,9 +23,6 @@ export type GetArrayOfObjectOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetArrayOfObjectResponses = {
   '200': GetArrayOfObjectStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/arrayTypeArray/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/arrayTypeArray/Pet.ts
@@ -4,24 +4,9 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Pet = {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string | undefined
-   */
   description?: string
-  /**
-   * @type array | undefined
-   */
   tags?: string[]
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/arrayTypeGeneric/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/arrayTypeGeneric/Pet.ts
@@ -4,24 +4,9 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Pet = {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string | undefined
-   */
   description?: string
-  /**
-   * @type array | undefined
-   */
   tags?: Array<string>
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/constAsConst/Status.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/constAsConst/Status.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type Status = 'active'

--- a/packages/plugin-ts/src/generators/__snapshots__/constConstEnum/Status.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/constConstEnum/Status.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type Status = 'active'

--- a/packages/plugin-ts/src/generators/__snapshots__/constEnum/Status.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/constEnum/Status.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type Status = 'active'

--- a/packages/plugin-ts/src/generators/__snapshots__/constInlineLiteral/Status.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/constInlineLiteral/Status.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type Status = 'active'

--- a/packages/plugin-ts/src/generators/__snapshots__/constLiteral/Status.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/constLiteral/Status.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type Status = 'active'

--- a/packages/plugin-ts/src/generators/__snapshots__/deletePetDELETEWithNoResponseBody/DeletePet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/deletePetDELETEWithNoResponseBody/DeletePet.ts
@@ -4,24 +4,12 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type DeletePetPath = {
-  /**
-   * @type string
-   */
   petId: string
 }
 
-/**
- * @type void
- */
 export type DeletePetStatus204 = void
 
-/**
- * @type object
- */
 export type DeletePetOptions = {
   body?: never
   path: DeletePetPath
@@ -29,9 +17,6 @@ export type DeletePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type DeletePetResponses = {
   '204': DeletePetStatus204
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/emptyStringEnumInlineLiteral/ProxyHostALPN.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/emptyStringEnumInlineLiteral/ProxyHostALPN.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type ProxyHostALPN = '' | 'h3' | 'h2' | 'http/1.1'

--- a/packages/plugin-ts/src/generators/__snapshots__/enumNamesTypeInlineLiteral/Type.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/enumNamesTypeInlineLiteral/Type.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type EnumNamesType = 'available' | 'pending' | 'sold'

--- a/packages/plugin-ts/src/generators/__snapshots__/enumTypeInlineLiteral/PetStatus.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/enumTypeInlineLiteral/PetStatus.ts
@@ -4,7 +4,4 @@
  * Source: text content
  */
 
-/**
- * @type string
- */
 export type PetStatus = 'available' | 'pending' | 'sold'

--- a/packages/plugin-ts/src/generators/__snapshots__/findArtifactsGETWithMultipleQueryParams/FindArtifacts.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/findArtifactsGETWithMultipleQueryParams/FindArtifacts.ts
@@ -4,32 +4,14 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type FindArtifactsQuery = {
-  /**
-   * @type integer | undefined
-   */
   page?: number
-  /**
-   * @type integer | undefined
-   */
   limit?: number
-  /**
-   * @type string | undefined
-   */
   sort?: string
 }
 
-/**
- * @type object
- */
 export type FindArtifactsStatus200 = object
 
-/**
- * @type object
- */
 export type FindArtifactsOptions = {
   body?: never
   path?: never
@@ -37,9 +19,6 @@ export type FindArtifactsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindArtifactsResponses = {
   '200': FindArtifactsStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/findPetsByStatusGETWithQueryParamEnum/FindPetsByStatus.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/findPetsByStatusGETWithQueryParamEnum/FindPetsByStatus.ts
@@ -4,24 +4,12 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type FindPetsByStatusQuery = {
-  /**
-   * @type string | undefined
-   */
   status?: 'available' | 'pending' | 'sold'
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusStatus200 = object
 
-/**
- * @type object
- */
 export type FindPetsByStatusOptions = {
   body?: never
   path?: never
@@ -29,9 +17,6 @@ export type FindPetsByStatusOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type FindPetsByStatusResponses = {
   '200': FindPetsByStatusStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/getPreferencesUnitsGETWithInlineArrayOfObjectResponseContainingANestedEnum/GetPreferencesUnits.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/getPreferencesUnitsGETWithInlineArrayOfObjectResponseContainingANestedEnum/GetPreferencesUnits.ts
@@ -12,27 +12,12 @@ export const getPreferencesUnitsStatus200TypeEnum = {
 
 export type GetPreferencesUnitsStatus200TypeEnumKey = (typeof getPreferencesUnitsStatus200TypeEnum)[keyof typeof getPreferencesUnitsStatus200TypeEnum]
 
-/**
- * @type array
- */
 export type GetPreferencesUnitsStatus200 = {
-  /**
-   * @type number
-   */
   id: number
-  /**
-   * @type string
-   */
   type: GetPreferencesUnitsStatus200TypeEnumKey
-  /**
-   * @type string
-   */
   value: string
 }[]
 
-/**
- * @type object
- */
 export type GetPreferencesUnitsOptions = {
   body?: never
   path?: never
@@ -40,9 +25,6 @@ export type GetPreferencesUnitsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPreferencesUnitsResponses = {
   '200': GetPreferencesUnitsStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/listPetsGETWithQueryParams/ListPets.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/listPetsGETWithQueryParams/ListPets.ts
@@ -4,29 +4,14 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type ListPetsQuery = {
-  /**
-   * @type integer | undefined
-   */
   limit?: number
 }
 
-/**
- * @type object
- */
 export type ListPetsStatus200 = object
 
-/**
- * @type object
- */
 export type ListPetsStatusDefault = object
 
-/**
- * @type object
- */
 export type ListPetsOptions = {
   body?: never
   path?: never
@@ -34,9 +19,6 @@ export type ListPetsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type ListPetsResponses = {
   '200': ListPetsStatus200
   default: ListPetsStatusDefault

--- a/packages/plugin-ts/src/generators/__snapshots__/multiContentTypeGETWithJsonAndXmlResponseBody/GetPetById.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/multiContentTypeGETWithJsonAndXmlResponseBody/GetPetById.ts
@@ -4,41 +4,20 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type GetPetByIdPath = {
-  /**
-   * @type string
-   */
   petId: string
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Json = {
-  /**
-   * @type string
-   */
   name: string
 }
 
-/**
- * @type object
- */
 export type GetPetByIdStatus200Xml = {
-  /**
-   * @type integer
-   */
   id: number
 }
 
 export type GetPetByIdStatus200 = GetPetByIdStatus200Json | GetPetByIdStatus200Xml
 
-/**
- * @type object
- */
 export type GetPetByIdOptions = {
   body?: never
   path: GetPetByIdPath
@@ -46,9 +25,6 @@ export type GetPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetPetByIdResponses = {
   '200':
     | {

--- a/packages/plugin-ts/src/generators/__snapshots__/multiContentTypePOSTWithJsonAndFormDataRequestBody/UploadFile.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/multiContentTypePOSTWithJsonAndFormDataRequestBody/UploadFile.ts
@@ -4,46 +4,22 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type UploadFilePath = {
-  /**
-   * @type string
-   */
   petId: string
 }
 
-/**
- * @type object
- */
 export type UploadFileStatus200 = object
 
-/**
- * @type object
- */
 export type UploadFileBodyJson = {
-  /**
-   * @type string
-   */
   name: string
 }
 
-/**
- * @type object
- */
 export type UploadFileBodyFormData = {
-  /**
-   * @type string
-   */
   file: string
 }
 
 export type UploadFileBody = UploadFileBodyJson | UploadFileBodyFormData
 
-/**
- * @type object
- */
 export type UploadFileOptions = {
   body: UploadFileBody
   path: UploadFilePath
@@ -51,9 +27,6 @@ export type UploadFileOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UploadFileResponses = {
   '200': UploadFileStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/noTagsOperationGETWithNoTags/GetEnterpriseConfigurationsIdV20250.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/noTagsOperationGETWithNoTags/GetEnterpriseConfigurationsIdV20250.ts
@@ -4,24 +4,12 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type GetEnterpriseConfigurationsIdV20250Path = {
-  /**
-   * @type string
-   */
   enterprise_id: string
 }
 
-/**
- * @type object
- */
 export type GetEnterpriseConfigurationsIdV20250Status200 = object
 
-/**
- * @type object
- */
 export type GetEnterpriseConfigurationsIdV20250Options = {
   body?: never
   path: GetEnterpriseConfigurationsIdV20250Path
@@ -29,9 +17,6 @@ export type GetEnterpriseConfigurationsIdV20250Options = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type GetEnterpriseConfigurationsIdV20250Responses = {
   '200': GetEnterpriseConfigurationsIdV20250Status200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/optionalTypeQuestionToken/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/optionalTypeQuestionToken/Pet.ts
@@ -4,24 +4,9 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Pet = {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string | undefined
-   */
   description?: string
-  /**
-   * @type array | undefined
-   */
   tags?: string[]
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/optionalTypeQuestionTokenAndUndefined/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/optionalTypeQuestionTokenAndUndefined/Pet.ts
@@ -4,24 +4,9 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Pet = {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string | undefined
-   */
   description?: string | undefined
-  /**
-   * @type array | undefined
-   */
   tags?: string[] | undefined
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/optionalTypeUndefined/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/optionalTypeUndefined/Pet.ts
@@ -4,24 +4,9 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Pet = {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string | undefined
-   */
   description: string | undefined
-  /**
-   * @type array | undefined
-   */
   tags: string[] | undefined
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/paramsCasingCamelcase/UpdatePet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/paramsCasingCamelcase/UpdatePet.ts
@@ -4,48 +4,21 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type UpdatePetPath = {
-  /**
-   * @type string
-   */
   pet_id: string
 }
 
-/**
- * @type object
- */
 export type UpdatePetQuery = {
-  /**
-   * @type boolean | undefined
-   */
   include_deleted?: boolean
-  /**
-   * @type string | undefined
-   */
   request_source?: string
 }
 
-/**
- * @type object
- */
 export type UpdatePetStatus200 = object
 
-/**
- * @type object
- */
 export type UpdatePetBody = {
-  /**
-   * @type string
-   */
   name: string
 }
 
-/**
- * @type object
- */
 export type UpdatePetOptions = {
   body: UpdatePetBody
   path: UpdatePetPath
@@ -53,9 +26,6 @@ export type UpdatePetOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetResponses = {
   '200': UpdatePetStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/paramsCasingDistinctNames/ListUploads.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/paramsCasingDistinctNames/ListUploads.ts
@@ -4,32 +4,14 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type ListUploadsQuery = {
-  /**
-   * @type integer | undefined
-   */
   'max-uploads'?: number
-  /**
-   * @type string | undefined
-   */
   prefix?: string
-  /**
-   * @type integer | undefined
-   */
   MaxUploads?: number
 }
 
-/**
- * @type object
- */
 export type ListUploadsStatus200 = object
 
-/**
- * @type object
- */
 export type ListUploadsOptions = {
   body?: never
   path?: never
@@ -37,9 +19,6 @@ export type ListUploadsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type ListUploadsResponses = {
   '200': ListUploadsStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/paramsCasingDuplicateNames/ListUploads.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/paramsCasingDuplicateNames/ListUploads.ts
@@ -4,28 +4,13 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type ListUploadsQuery = {
-  /**
-   * @type integer | undefined
-   */
   'max-uploads'?: number
-  /**
-   * @type string | undefined
-   */
   prefix?: string
 }
 
-/**
- * @type object
- */
 export type ListUploadsStatus200 = object
 
-/**
- * @type object
- */
 export type ListUploadsOptions = {
   body?: never
   path?: never
@@ -33,9 +18,6 @@ export type ListUploadsOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type ListUploadsResponses = {
   '200': ListUploadsStatus200
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/PlaceOrderPatch.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/placeOrderPatchPATCHWithPathParamsRequestBodyMultipleStatusCodes/PlaceOrderPatch.ts
@@ -4,24 +4,12 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type PlaceOrderPatchPath = {
-  /**
-   * @type integer
-   */
   orderId: number
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus200 = object
 
-/**
- * @type object
- */
 export type PlaceOrderPatchStatus405 = object
 
 /**
@@ -30,9 +18,6 @@ export type PlaceOrderPatchStatus405 = object
  */
 export type PlaceOrderPatchBody = object
 
-/**
- * @type object
- */
 export type PlaceOrderPatchOptions = {
   body: PlaceOrderPatchBody
   path: PlaceOrderPatchPath
@@ -40,9 +25,6 @@ export type PlaceOrderPatchOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type PlaceOrderPatchResponses = {
   '200': PlaceOrderPatchStatus200
   '405': PlaceOrderPatchStatus405

--- a/packages/plugin-ts/src/generators/__snapshots__/showPetByIdGETWithPathParam/ShowPetById.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/showPetByIdGETWithPathParam/ShowPetById.ts
@@ -4,29 +4,14 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type ShowPetByIdPath = {
-  /**
-   * @type string
-   */
   petId: string
 }
 
-/**
- * @type object
- */
 export type ShowPetByIdStatus200 = object
 
-/**
- * @type object
- */
 export type ShowPetByIdStatusDefault = object
 
-/**
- * @type object
- */
 export type ShowPetByIdOptions = {
   body?: never
   path: ShowPetByIdPath
@@ -34,9 +19,6 @@ export type ShowPetByIdOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type ShowPetByIdResponses = {
   '200': ShowPetByIdStatus200
   default: ShowPetByIdStatusDefault

--- a/packages/plugin-ts/src/generators/__snapshots__/syntaxTypeInterface/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/syntaxTypeInterface/Pet.ts
@@ -4,24 +4,9 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export interface Pet {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string | undefined
-   */
   description?: string
-  /**
-   * @type array | undefined
-   */
   tags?: string[]
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/syntaxTypeType/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/syntaxTypeType/Pet.ts
@@ -4,24 +4,9 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Pet = {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
-  /**
-   * @type string | undefined
-   */
   description?: string
-  /**
-   * @type array | undefined
-   */
   tags?: string[]
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/transformersIntegerToString/Order.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/transformersIntegerToString/Order.ts
@@ -4,20 +4,8 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Order = {
-  /**
-   * @type integer
-   */
   id: string
-  /**
-   * @type integer | undefined
-   */
   quantity?: string
-  /**
-   * @type string
-   */
   status: string
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/transformersRemoveOptionalProperties/Pet.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/transformersRemoveOptionalProperties/Pet.ts
@@ -4,16 +4,7 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type Pet = {
-  /**
-   * @type string
-   */
   id: string
-  /**
-   * @type string
-   */
   name: string
 }

--- a/packages/plugin-ts/src/generators/__snapshots__/updatePetWithFormPOSTWithPathAndQueryParams/UpdatePetWithForm.ts
+++ b/packages/plugin-ts/src/generators/__snapshots__/updatePetWithFormPOSTWithPathAndQueryParams/UpdatePetWithForm.ts
@@ -4,43 +4,19 @@
  * Source: text content
  */
 
-/**
- * @type object
- */
 export type UpdatePetWithFormPath = {
-  /**
-   * @type integer
-   */
   petId: number
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormQuery = {
-  /**
-   * @type string | undefined
-   */
   name?: string
-  /**
-   * @type string | undefined
-   */
   status?: string
 }
 
-/**
- * @type void
- */
 export type UpdatePetWithFormStatus200 = void
 
-/**
- * @type object
- */
 export type UpdatePetWithFormStatus405 = object
 
-/**
- * @type object
- */
 export type UpdatePetWithFormOptions = {
   body?: never
   path: UpdatePetWithFormPath
@@ -48,9 +24,6 @@ export type UpdatePetWithFormOptions = {
   headers?: never
 }
 
-/**
- * @type object
- */
 export type UpdatePetWithFormResponses = {
   '200': UpdatePetWithFormStatus200
   '405': UpdatePetWithFormStatus405

--- a/packages/plugin-ts/src/printers/printerTs.test.ts
+++ b/packages/plugin-ts/src/printers/printerTs.test.ts
@@ -355,14 +355,8 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type string
-           */
           a: string
         } & {
-          /**
-           * @type number
-           */
           b: number
         }"
       `)
@@ -487,13 +481,7 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type number
-           */
           id: number
-          /**
-           * @type string
-           */
           name: string
         }"
       `)
@@ -509,9 +497,6 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type string | undefined
-           */
           tag?: string
         }"
       `)
@@ -528,9 +513,6 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type string | undefined
-           */
           tag: string | undefined
         }"
       `)
@@ -547,9 +529,6 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type string | undefined
-           */
           tag?: string | undefined
         }"
       `)
@@ -565,9 +544,6 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type string
-           */
           value: string | null
         }"
       `)
@@ -583,9 +559,6 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type number
-           */
           readonly id: number
         }"
       `)
@@ -631,9 +604,6 @@ describe('printerTs', () => {
       )
 
       expect(await formatTS(result)).toBe(`{
-  /**
-   * @type number
-   */
   id: number
   [key: string]: unknown
 }`)
@@ -726,9 +696,6 @@ describe('printerTs', () => {
       )
 
       expect(await formatTS(result)).toBe(`{
-  /**
-   * @type number
-   */
   id: number
   [key: string]: unknown
 }`)
@@ -744,9 +711,6 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type string | undefined
-           */
           tag?: string
         }"
       `)
@@ -763,9 +727,6 @@ describe('printerTs', () => {
 
       expect(await formatTS(result)).toMatchInlineSnapshot(`
         "{
-          /**
-           * @type string | undefined
-           */
           tag: string | undefined
         }"
       `)
@@ -865,10 +826,7 @@ describe('printerTs', () => {
       const result = p.print(ast.factory.createSchema({ type: 'string' }))
 
       expect(await format(result ?? '')).toMatchInlineSnapshot(`
-        "/**
-         * @type string
-         */
-        export type MyType = string
+        "export type MyType = string
         "
       `)
     })
@@ -883,13 +841,7 @@ describe('printerTs', () => {
       )
 
       expect(await format(result ?? '')).toMatchInlineSnapshot(`
-        "/**
-         * @type object
-         */
-        export type MyObject = {
-          /**
-           * @type number | undefined
-           */
+        "export type MyObject = {
           id?: number
         }
         "
@@ -913,13 +865,7 @@ describe('printerTs', () => {
       )
 
       expect(await format(result ?? '')).toMatchInlineSnapshot(`
-        "/**
-         * @type object
-         */
-        export type MyObject = {
-          /**
-           * @type number | undefined
-           */
+        "export type MyObject = {
           id?: number
         }
         "
@@ -931,10 +877,7 @@ describe('printerTs', () => {
       const result = p.print(ast.factory.createSchema({ type: 'string', nullable: true }))
 
       expect(await format(result ?? '')).toMatchInlineSnapshot(`
-        "/**
-         * @type string
-         */
-        export type Status = string | null
+        "export type Status = string | null
         "
       `)
     })
@@ -950,10 +893,7 @@ describe('printerTs', () => {
       const result = p.print(ast.factory.createSchema({ type: 'string', optional: true }))
 
       expect(await format(result ?? '')).toMatchInlineSnapshot(`
-        "/**
-         * @type string | undefined
-         */
-        export type MaybeValue = string | undefined
+        "export type MaybeValue = string | undefined
         "
       `)
     })
@@ -1000,22 +940,10 @@ describe('printerTs', () => {
       )
 
       expect(await format(result ?? '')).toMatchInlineSnapshot(`
-        "/**
-         * @type object
-         */
-        export type Partial = Omit<
+        "export type Partial = Omit<
           NonNullable<{
-            /**
-             * @type number | undefined
-             */
             id?: number
-            /**
-             * @type string | undefined
-             */
             name?: string
-            /**
-             * @type string | undefined
-             */
             createdAt?: string
           }>,
           'id' | 'createdAt'

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -28,9 +28,6 @@ describe('buildParams', () => {
 
     expect(printSchema(buildParams({ params }))).toMatchInlineSnapshot(`
       "{
-          /**
-           * @type string
-          */
           petId: string;
       }"
     `)
@@ -41,9 +38,6 @@ describe('buildParams', () => {
 
     expect(printSchema(buildParams({ params }))).toMatchInlineSnapshot(`
       "{
-          /**
-           * @type integer | undefined
-          */
           limit?: number;
       }"
     `)
@@ -197,5 +191,19 @@ describe('buildPropertyJSDocComments', () => {
     const comments = buildPropertyJSDocComments(schema)
 
     expect(comments).toContain('@example {"label":"*\\/"}')
+  })
+
+  it('omits @type when it would be the only annotation', () => {
+    const schema = ast.factory.createSchema({ type: 'string' })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).toStrictEqual([])
+  })
+
+  it('keeps @type when another annotation already justifies the comment', () => {
+    const schema = ast.factory.createSchema({ type: 'string', description: 'A pet name' })
+    const comments = buildPropertyJSDocComments(schema)
+
+    expect(comments).toContain('@type string')
   })
 })

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -55,7 +55,7 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: bo
   // OAS 3.1 carries schema examples as an `examples` array, one `@example` line each.
   const exampleValues = meta?.examples ?? []
 
-  return [
+  const comments = [
     hasDescription ? `@description ${jsStringEscape(meta.description)}` : null,
     ...formatComment,
     meta && 'deprecated' in meta && meta.deprecated ? '@deprecated' : null,
@@ -67,10 +67,17 @@ export function buildPropertyJSDocComments(schema: ast.SchemaNode, optional?: bo
       ? `@default ${'primitive' in meta && meta.primitive === 'string' && typeof meta.default === 'string' ? stringify(meta.default) : meta.default}`
       : null,
     ...exampleValues.map((example) => `@example ${formatExample(example)}`),
-    meta && 'primitive' in meta && meta.primitive
-      ? [`@type ${meta.primitive}`, (optional ?? isSchemaOptional(schema)) ? ' | undefined' : null].filter(Boolean).join('')
-      : null,
   ].filter(Boolean)
+
+  // `@type` merely repeats the TypeScript type already sitting next to the property, so it only
+  // earns its place inside a comment block that exists for another reason. Bare, it would just
+  // add bytes with no information a reader can't already see in the signature.
+  const typeTag =
+    comments.length && meta && 'primitive' in meta && meta.primitive
+      ? [`@type ${meta.primitive}`, (optional ?? isSchemaOptional(schema)) ? ' | undefined' : null].filter(Boolean).join('')
+      : null
+
+  return [...comments, typeTag].filter(Boolean)
 }
 
 type BuildParamsSchemaOptions = {

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/Config.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/Config.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Config = {
-    /**
-     * @type string | undefined
-    */
     id?: string;
-    /**
-     * @type string | undefined
-    */
     name?: string;
-    /**
-     * @type string | undefined
-    */
     version?: string;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/ConfigCreate.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/ConfigCreate.ts
@@ -3,12 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ConfigCreate = {
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/CreateConfigV20250.ts
@@ -6,19 +6,10 @@
 import type { Config } from './Config'
 import type { ConfigCreate } from './ConfigCreate'
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Status201 = Config;
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Body = ConfigCreate;
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Options = {
     body: CreateConfigV20250Body;
     path?: never;
@@ -26,9 +17,6 @@ export type CreateConfigV20250Options = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Responses = {
     "201": CreateConfigV20250Status201;
 };

--- a/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/GetConfigIdV20250.ts
+++ b/tests/3.0.x/__snapshots__/cypressPlugin/noTagsGroup/types/GetConfigIdV20250.ts
@@ -5,24 +5,12 @@
 
 import type { Config } from './Config'
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Path = {
-    /**
-     * @type string
-    */
     config_id: string;
 };
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Status200 = Config;
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Options = {
     body?: never;
     path: GetConfigIdV20250Path;
@@ -30,9 +18,6 @@ export type GetConfigIdV20250Options = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Responses = {
     "200": GetConfigIdV20250Status200;
 };

--- a/tests/3.0.x/__snapshots__/main/asConstEnum/types/Task.ts
+++ b/tests/3.0.x/__snapshots__/main/asConstEnum/types/Task.ts
@@ -6,24 +6,9 @@
 import type { PriorityKey } from './Priority'
 import type { StatusKey } from './Status'
 
-/**
- * @type object
-*/
 export type Task = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     status: StatusKey;
-    /**
-     * @type string | undefined
-    */
     priority?: PriorityKey;
-    /**
-     * @type string | undefined
-    */
     title?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/CreateOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/CreateOrder.ts
@@ -5,9 +5,6 @@
 
 import type { OrderSchema } from './OrderSchema'
 
-/**
- * @type object
-*/
 export type CreateOrderStatus201 = OrderSchema;
 
 /**
@@ -15,19 +12,10 @@ export type CreateOrderStatus201 = OrderSchema;
  * @type object | undefined
 */
 export type CreateOrderBody = {
-    /**
-     * @type string | undefined
-    */
     userId?: string;
-    /**
-     * @type array | undefined
-    */
     productIds?: string[];
 } | undefined;
 
-/**
- * @type object
-*/
 export type CreateOrderOptions = {
     body: CreateOrderBody;
     path?: never;
@@ -35,9 +23,6 @@ export type CreateOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type CreateOrderResponses = {
     "201": CreateOrderStatus201;
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetProducts.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetProducts.ts
@@ -3,27 +3,12 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetProductsStatus200 = {
-    /**
-     * @type string | undefined
-    */
     productId?: string;
-    /**
-     * @type string | undefined
-    */
     productName?: string;
-    /**
-     * @type integer | undefined
-    */
     stock?: number;
 };
 
-/**
- * @type object
-*/
 export type GetProductsOptions = {
     body?: never;
     path?: never;
@@ -31,9 +16,6 @@ export type GetProductsOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetProductsResponses = {
     "200": GetProductsStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetVariants.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/GetVariants.ts
@@ -5,14 +5,8 @@
 
 import type { Variant } from './Variant'
 
-/**
- * @type object
-*/
 export type GetVariantsStatus200 = Variant;
 
-/**
- * @type object
-*/
 export type GetVariantsOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetVariantsOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetVariantsResponses = {
     "200": GetVariantsStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/OrderRequest.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/OrderRequest.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type OrderRequest = {
-    /**
-     * @type string | undefined
-    */
     userId?: string;
-    /**
-     * @type array | undefined
-    */
     productIds?: string[];
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/OrderSchema.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/OrderSchema.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type OrderSchema = {
-    /**
-     * @type string | undefined
-    */
     id?: string;
-    /**
-     * @type string | undefined
-    */
     customerId?: string;
-    /**
-     * @type array | undefined
-    */
     items?: string[];
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/ProductResponse.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/ProductResponse.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ProductResponse = {
-    /**
-     * @type string | undefined
-    */
     productId?: string;
-    /**
-     * @type string | undefined
-    */
     productName?: string;
-    /**
-     * @type integer | undefined
-    */
     stock?: number;
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/ProductSchema.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/ProductSchema.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ProductSchema = {
-    /**
-     * @type string | undefined
-    */
     id?: string;
-    /**
-     * @type string | undefined
-    */
     name?: string;
-    /**
-     * @type number | undefined
-    */
     price?: number;
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/Variant.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/Variant.ts
@@ -5,17 +5,8 @@
 
 import type { VariantTypeEnumKey } from './VariantTypeEnum'
 
-/**
- * @type object
-*/
 export type Variant = {
-    /**
-     * @type string | undefined
-    */
     id?: string;
-    /**
-     * @type string | undefined
-    */
     name?: string;
     type?: VariantTypeEnumKey;
 };

--- a/tests/3.0.x/__snapshots__/main/caseSensitivity/types/Variant2.ts
+++ b/tests/3.0.x/__snapshots__/main/caseSensitivity/types/Variant2.ts
@@ -5,17 +5,8 @@
 
 import type { Variant2CategoryEnumKey } from './Variant2CategoryEnum'
 
-/**
- * @type object
-*/
 export type Variant2 = {
-    /**
-     * @type string | undefined
-    */
     id?: string;
-    /**
-     * @type string | undefined
-    */
     label?: string;
     category?: Variant2CategoryEnumKey;
 };

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/BankTransferPayment.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/BankTransferPayment.ts
@@ -6,8 +6,5 @@
 import type { PaymentMethod } from './PaymentMethod'
 
 export type BankTransferPayment = (PaymentMethod & {
-    /**
-     * @type string | undefined
-    */
     iban?: string;
 });

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/BankTransferPaymentMapped.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/BankTransferPaymentMapped.ts
@@ -6,8 +6,5 @@
 import type { PaymentMethodMapped } from './PaymentMethodMapped'
 
 export type BankTransferPaymentMapped = (PaymentMethodMapped & {
-    /**
-     * @type string | undefined
-    */
     iban?: string;
 });

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/BankTransferPaymentUnion.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/BankTransferPaymentUnion.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type BankTransferPaymentUnion = {
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     iban?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/CardPayment.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/CardPayment.ts
@@ -6,8 +6,5 @@
 import type { PaymentMethod } from './PaymentMethod'
 
 export type CardPayment = (PaymentMethod & {
-    /**
-     * @type string | undefined
-    */
     cardNumber?: string;
 });

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/CardPaymentMapped.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/CardPaymentMapped.ts
@@ -6,8 +6,5 @@
 import type { PaymentMethodMapped } from './PaymentMethodMapped'
 
 export type CardPaymentMapped = (PaymentMethodMapped & {
-    /**
-     * @type string | undefined
-    */
     cardNumber?: string;
 });

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/CardPaymentUnion.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/CardPaymentUnion.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type CardPaymentUnion = {
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     cardNumber?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/PaymentMethod.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/PaymentMethod.ts
@@ -3,12 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PaymentMethod = {
-    /**
-     * @type string
-    */
     type: string;
 };

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/PaymentMethodMapped.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/PaymentMethodMapped.ts
@@ -5,9 +5,6 @@
 
 import type { PaymentMethodMappedTypeEnumKey } from './PaymentMethodMappedTypeEnum'
 
-/**
- * @type object
-*/
 export type PaymentMethodMapped = {
     type: PaymentMethodMappedTypeEnumKey;
 };

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/PaymentMethodUnion.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/PaymentMethodUnion.ts
@@ -7,13 +7,7 @@ import type { BankTransferPaymentUnion } from './BankTransferPaymentUnion'
 import type { CardPaymentUnion } from './CardPaymentUnion'
 
 export type PaymentMethodUnion = ((CardPaymentUnion & {
-    /**
-     * @type string
-    */
     type: "card";
 }) | (BankTransferPaymentUnion & {
-    /**
-     * @type string
-    */
     type: "bank_transfer";
 }));

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/WalletPayment.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/WalletPayment.ts
@@ -6,8 +6,5 @@
 import type { PaymentMethod } from './PaymentMethod'
 
 export type WalletPayment = (PaymentMethod & {
-    /**
-     * @type string | undefined
-    */
     walletId?: string;
 });

--- a/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/WalletPaymentMapped.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAllOf/types/WalletPaymentMapped.ts
@@ -6,8 +6,5 @@
 import type { PaymentMethodMapped } from './PaymentMethodMapped'
 
 export type WalletPaymentMapped = (PaymentMethodMapped & {
-    /**
-     * @type string | undefined
-    */
     walletId?: string;
 });

--- a/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/Car.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/Car.ts
@@ -7,13 +7,7 @@ import type { SUV } from './SUV'
 import type { Sedan } from './Sedan'
 
 export type Car = ((Sedan & {
-    /**
-     * @type string
-    */
     type: "Sedan";
 }) | (SUV & {
-    /**
-     * @type string
-    */
     type: "SUV";
 }));

--- a/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/Vehicle.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/Vehicle.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Vehicle = {
     /**
      * @description Unique vehicle identifier

--- a/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/VehicleChoice.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorAnyOf/types/VehicleChoice.ts
@@ -8,18 +8,9 @@ import type { SUV } from './SUV'
 import type { Sedan } from './Sedan'
 
 export type VehicleChoice = ((Sedan & {
-    /**
-     * @type string
-    */
     type: "Sedan";
 }) | (SUV & {
-    /**
-     * @type string
-    */
     type: "SUV";
 }) | (ElectricCar & {
-    /**
-     * @type string
-    */
     type: "ElectricCar";
 }));

--- a/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/Car.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/Car.ts
@@ -7,13 +7,7 @@ import type { SUV } from './SUV'
 import type { Sedan } from './Sedan'
 
 export type Car = ((Sedan & {
-    /**
-     * @type string
-    */
     type: "Sedan";
 }) | (SUV & {
-    /**
-     * @type string
-    */
     type: "SUV";
 }));

--- a/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/Vehicle.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/Vehicle.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Vehicle = {
     /**
      * @description Unique vehicle identifier

--- a/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/VehicleChoice.ts
+++ b/tests/3.0.x/__snapshots__/main/discriminatorOneOf/types/VehicleChoice.ts
@@ -8,18 +8,9 @@ import type { SUV } from './SUV'
 import type { Sedan } from './Sedan'
 
 export type VehicleChoice = ((Sedan & {
-    /**
-     * @type string
-    */
     type: "Sedan";
 }) | (SUV & {
-    /**
-     * @type string
-    */
     type: "SUV";
 }) | (ElectricCar & {
-    /**
-     * @type string
-    */
     type: "ElectricCar";
 }));

--- a/tests/3.0.x/__snapshots__/main/duplicateEnum/types/GetNotifications.ts
+++ b/tests/3.0.x/__snapshots__/main/duplicateEnum/types/GetNotifications.ts
@@ -6,14 +6,8 @@
 import type { NotificationTypeA } from './NotificationTypeA'
 import type { NotificationTypeB } from './NotificationTypeB'
 
-/**
- * @type array
-*/
 export type GetNotificationsStatus200 = (NotificationTypeA | NotificationTypeB)[];
 
-/**
- * @type object
-*/
 export type GetNotificationsOptions = {
     body?: never;
     path?: never;
@@ -21,9 +15,6 @@ export type GetNotificationsOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetNotificationsResponses = {
     "200": GetNotificationsStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/duplicateEnum/types/NotificationTypeA.ts
+++ b/tests/3.0.x/__snapshots__/main/duplicateEnum/types/NotificationTypeA.ts
@@ -5,22 +5,10 @@
 
 import type { NotificationTypeAParamsChannelEnumKey } from './NotificationTypeAParamsChannelEnum'
 
-/**
- * @type object
-*/
 export type NotificationTypeA = {
-    /**
-     * @type string
-    */
     type: string;
-    /**
-     * @type object
-    */
     params: {
         channel: NotificationTypeAParamsChannelEnumKey;
-        /**
-         * @type string
-        */
         messageA: string;
     };
 };

--- a/tests/3.0.x/__snapshots__/main/duplicateEnum/types/NotificationTypeB.ts
+++ b/tests/3.0.x/__snapshots__/main/duplicateEnum/types/NotificationTypeB.ts
@@ -5,22 +5,10 @@
 
 import type { NotificationTypeBParamsChannelEnumKey } from './NotificationTypeBParamsChannelEnum'
 
-/**
- * @type object
-*/
 export type NotificationTypeB = {
-    /**
-     * @type string
-    */
     type: string;
-    /**
-     * @type object
-    */
     params: {
         channel: NotificationTypeBParamsChannelEnumKey;
-        /**
-         * @type string
-        */
         messageB: string;
     };
 };

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/AppState.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/AppState.ts
@@ -6,16 +6,7 @@
 import type { Employer } from './Employer'
 import type { User } from './User'
 
-/**
- * @type object
-*/
 export type AppState = {
-    /**
-     * @type object | undefined
-    */
     currentUser?: User;
-    /**
-     * @type array | undefined
-    */
     employers?: Employer[];
 };

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/Employer.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/Employer.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Employer = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     industry?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/GetEmployers.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/GetEmployers.ts
@@ -5,14 +5,8 @@
 
 import type { Employer } from './Employer'
 
-/**
- * @type array
-*/
 export type GetEmployersStatus200 = Employer[];
 
-/**
- * @type object
-*/
 export type GetEmployersOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetEmployersOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetEmployersResponses = {
     "200": GetEmployersStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/GetMe.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/GetMe.ts
@@ -5,14 +5,8 @@
 
 import type { User } from './User'
 
-/**
- * @type object
-*/
 export type GetMeStatus200 = User;
 
-/**
- * @type object
-*/
 export type GetMeOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetMeOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetMeResponses = {
     "200": GetMeStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/issue2696/types/User.ts
+++ b/tests/3.0.x/__snapshots__/main/issue2696/types/User.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type User = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     email: string;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/Config.ts
+++ b/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/Config.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Config = {
-    /**
-     * @type string | undefined
-    */
     id?: string;
-    /**
-     * @type string | undefined
-    */
     name?: string;
-    /**
-     * @type string | undefined
-    */
     version?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/ConfigCreate.ts
+++ b/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/ConfigCreate.ts
@@ -3,12 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ConfigCreate = {
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/CreateConfigV20250.ts
@@ -6,19 +6,10 @@
 import type { Config } from '../Config'
 import type { ConfigCreate } from '../ConfigCreate'
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Status201 = Config;
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Body = ConfigCreate;
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Options = {
     body: CreateConfigV20250Body;
     path?: never;
@@ -26,9 +17,6 @@ export type CreateConfigV20250Options = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Responses = {
     "201": CreateConfigV20250Status201;
 };

--- a/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
+++ b/tests/3.0.x/__snapshots__/main/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
@@ -5,24 +5,12 @@
 
 import type { Config } from '../Config'
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Path = {
-    /**
-     * @type string
-    */
     config_id: string;
 };
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Status200 = Config;
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Options = {
     body?: never;
     path: GetConfigIdV20250Path;
@@ -30,9 +18,6 @@ export type GetConfigIdV20250Options = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Responses = {
     "200": GetConfigIdV20250Status200;
 };

--- a/tests/3.0.x/__snapshots__/main/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/main/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/main/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/main/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/main/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/main/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/main/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/main/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/petStore/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/resolverCustomPrefix/types/GetItem.ts
@@ -2,9 +2,6 @@
 
 import type { CustomItem } from './Item'
 
-/**
- * @type object
-*/
 export type CustomGetItemPath = {
     /**
      * @description
@@ -20,9 +17,6 @@ export type CustomGetItemPath = {
 */
 export type CustomGetItemStatus200 = CustomItem;
 
-/**
- * @type object
-*/
 export type CustomGetItemOptions = {
     body?: never;
     path: CustomGetItemPath;
@@ -30,9 +24,6 @@ export type CustomGetItemOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type CustomGetItemResponses = {
     "200": CustomGetItemStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/simple/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/main/simple/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/main/simple/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/simple/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/main/simple/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/main/simple/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/main/simple/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/simple/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/main/simple/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/main/simple/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/main/simple/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/main/simple/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/main/simple/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
+++ b/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/GetItem.ts
@@ -5,9 +5,6 @@
 
 import type { Item } from './Item'
 
-/**
- * @type object
-*/
 export type GetItemPath = {
     /**
      * @description
@@ -17,14 +14,8 @@ export type GetItemPath = {
     id: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetItemStatus200 = Item;
 
-/**
- * @type object
-*/
 export type GetItemOptions = {
     body?: never;
     path: GetItemPath;
@@ -32,9 +23,6 @@ export type GetItemOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetItemResponses = {
     "200": GetItemStatus200;
 };

--- a/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/Item.ts
+++ b/tests/3.0.x/__snapshots__/main/transformerStripDescriptions/types/Item.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Item = {
     /**
      * @description
@@ -13,9 +10,6 @@ export type Item = {
      * @type integer
     */
     id: bigint;
-    /**
-     * @type string
-    */
     name: string;
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/default/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/default/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/Pet.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Pet = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/PetUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/PetUpdate.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PetUpdate = {
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     description?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/paramsCasing/types/UpdatePet.ts
@@ -6,53 +6,23 @@
 import type { Pet } from './Pet'
 import type { PetUpdate } from './PetUpdate'
 
-/**
- * @type object
-*/
 export type UpdatePetPath = {
-    /**
-     * @type string
-    */
     pet_id: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetQuery = {
-    /**
-     * @type boolean | undefined
-    */
     include_deleted?: boolean;
-    /**
-     * @type string | undefined
-    */
     request_source?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     "X-Request-ID"?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetStatus200 = Pet;
 
-/**
- * @type object
-*/
 export type UpdatePetBody = PetUpdate;
 
-/**
- * @type object
-*/
 export type UpdatePetOptions = {
     body: UpdatePetBody;
     path: UpdatePetPath;
@@ -60,9 +30,6 @@ export type UpdatePetOptions = {
     headers?: UpdatePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetResponses = {
     "200": UpdatePetStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClass/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkClassWithName/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginAxios/sdkSingle/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/dateParserDayjs/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/groupByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/locale/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/macros/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/macros/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/Pet.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Pet = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/PetUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/PetUpdate.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PetUpdate = {
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     description?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/paramsCasing/types/UpdatePet.ts
@@ -6,53 +6,23 @@
 import type { Pet } from './Pet'
 import type { PetUpdate } from './PetUpdate'
 
-/**
- * @type object
-*/
 export type UpdatePetPath = {
-    /**
-     * @type string
-    */
     pet_id: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetQuery = {
-    /**
-     * @type boolean | undefined
-    */
     include_deleted?: boolean;
-    /**
-     * @type string | undefined
-    */
     request_source?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     "X-Request-ID"?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetStatus200 = Pet;
 
-/**
- * @type object
-*/
 export type UpdatePetBody = PetUpdate;
 
-/**
- * @type object
-*/
 export type UpdatePetOptions = {
     body: UpdatePetBody;
     path: UpdatePetPath;
@@ -60,9 +30,6 @@ export type UpdatePetOptions = {
     headers?: UpdatePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetResponses = {
     "200": UpdatePetStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/petStore/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/regexGeneratorRandexp/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFaker/seed/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/default/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/default/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/Pet.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Pet = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/PetUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/PetUpdate.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PetUpdate = {
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     description?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/paramsCasing/types/UpdatePet.ts
@@ -6,53 +6,23 @@
 import type { Pet } from './Pet'
 import type { PetUpdate } from './PetUpdate'
 
-/**
- * @type object
-*/
 export type UpdatePetPath = {
-    /**
-     * @type string
-    */
     pet_id: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetQuery = {
-    /**
-     * @type boolean | undefined
-    */
     include_deleted?: boolean;
-    /**
-     * @type string | undefined
-    */
     request_source?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     "X-Request-ID"?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetStatus200 = Pet;
 
-/**
- * @type object
-*/
 export type UpdatePetBody = PetUpdate;
 
-/**
- * @type object
-*/
 export type UpdatePetOptions = {
     body: UpdatePetBody;
     path: UpdatePetPath;
@@ -60,9 +30,6 @@ export type UpdatePetOptions = {
     headers?: UpdatePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetResponses = {
     "200": UpdatePetStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClass/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkClassWithName/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginFetch/sdkSingle/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/groupByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/Pet.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Pet = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/PetUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/PetUpdate.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PetUpdate = {
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     description?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/paramsCasing/types/UpdatePet.ts
@@ -6,53 +6,23 @@
 import type { Pet } from './Pet'
 import type { PetUpdate } from './PetUpdate'
 
-/**
- * @type object
-*/
 export type UpdatePetPath = {
-    /**
-     * @type string
-    */
     pet_id: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetQuery = {
-    /**
-     * @type boolean | undefined
-    */
     include_deleted?: boolean;
-    /**
-     * @type string | undefined
-    */
     request_source?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     "X-Request-ID"?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetStatus200 = Pet;
 
-/**
- * @type object
-*/
 export type UpdatePetBody = PetUpdate;
 
-/**
- * @type object
-*/
 export type UpdatePetOptions = {
     body: UpdatePetBody;
     path: UpdatePetPath;
@@ -60,9 +30,6 @@ export type UpdatePetOptions = {
     headers?: UpdatePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetResponses = {
     "200": UpdatePetStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/petStore/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMcp/withClientPlugin/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/baseURL/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/groupByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/handlers/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/parserFaker/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginMsw/petStore/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/groupByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/infinite/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/mutationDisabled/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/Pet.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Pet = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/PetUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/PetUpdate.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PetUpdate = {
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     description?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/paramsCasing/types/UpdatePet.ts
@@ -6,53 +6,23 @@
 import type { Pet } from './Pet'
 import type { PetUpdate } from './PetUpdate'
 
-/**
- * @type object
-*/
 export type UpdatePetPath = {
-    /**
-     * @type string
-    */
     pet_id: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetQuery = {
-    /**
-     * @type boolean | undefined
-    */
     include_deleted?: boolean;
-    /**
-     * @type string | undefined
-    */
     request_source?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     "X-Request-ID"?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetStatus200 = Pet;
 
-/**
- * @type object
-*/
 export type UpdatePetBody = PetUpdate;
 
-/**
- * @type object
-*/
 export type UpdatePetOptions = {
     body: UpdatePetBody;
     path: UpdatePetPath;
@@ -60,9 +30,6 @@ export type UpdatePetOptions = {
     headers?: UpdatePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetResponses = {
     "200": UpdatePetStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/parserZod/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/petStore/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/queryMethods/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/suspense/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginReactQuery/withClientPlugin/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/groupByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/mutationDisabled/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/Pet.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Pet = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/PetUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/PetUpdate.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PetUpdate = {
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     description?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/paramsCasing/types/UpdatePet.ts
@@ -6,53 +6,23 @@
 import type { Pet } from './Pet'
 import type { PetUpdate } from './PetUpdate'
 
-/**
- * @type object
-*/
 export type UpdatePetPath = {
-    /**
-     * @type string
-    */
     pet_id: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetQuery = {
-    /**
-     * @type boolean | undefined
-    */
     include_deleted?: boolean;
-    /**
-     * @type string | undefined
-    */
     request_source?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     "X-Request-ID"?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetStatus200 = Pet;
 
-/**
- * @type object
-*/
 export type UpdatePetBody = PetUpdate;
 
-/**
- * @type object
-*/
 export type UpdatePetOptions = {
     body: UpdatePetBody;
     path: UpdatePetPath;
@@ -60,9 +30,6 @@ export type UpdatePetOptions = {
     headers?: UpdatePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetResponses = {
     "200": UpdatePetStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/parserZod/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/petStore/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryDisabled/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/queryMethods/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginSwr/withClientPlugin/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/Config.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/Config.ts
@@ -3,20 +3,8 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Config = {
-    /**
-     * @type string | undefined
-    */
     id?: string;
-    /**
-     * @type string | undefined
-    */
     name?: string;
-    /**
-     * @type string | undefined
-    */
     version?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/ConfigCreate.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/ConfigCreate.ts
@@ -3,12 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ConfigCreate = {
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/CreateConfigV20250.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/CreateConfigV20250.ts
@@ -6,19 +6,10 @@
 import type { Config } from '../Config'
 import type { ConfigCreate } from '../ConfigCreate'
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Status201 = Config;
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Body = ConfigCreate;
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Options = {
     body: CreateConfigV20250Body;
     path?: never;
@@ -26,9 +17,6 @@ export type CreateConfigV20250Options = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type CreateConfigV20250Responses = {
     "201": CreateConfigV20250Status201;
 };

--- a/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
+++ b/tests/3.0.x/__snapshots__/pluginTs/noTagsDotOperationId/types/config/GetConfigIdV20250.ts
@@ -5,24 +5,12 @@
 
 import type { Config } from '../Config'
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Path = {
-    /**
-     * @type string
-    */
     config_id: string;
 };
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Status200 = Config;
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Options = {
     body?: never;
     path: GetConfigIdV20250Path;
@@ -30,9 +18,6 @@ export type GetConfigIdV20250Options = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetConfigIdV20250Responses = {
     "200": GetConfigIdV20250Status200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/excludeByOperationId/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/groupByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/includeByTag/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/infinite/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/mutationDisabled/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/Pet.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Pet = {
-    /**
-     * @type string
-    */
     id: string;
-    /**
-     * @type string
-    */
     name: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/PetUpdate.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/PetUpdate.ts
@@ -3,16 +3,7 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type PetUpdate = {
-    /**
-     * @type string
-    */
     name: string;
-    /**
-     * @type string | undefined
-    */
     description?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/UpdatePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/paramsCasing/types/UpdatePet.ts
@@ -6,53 +6,23 @@
 import type { Pet } from './Pet'
 import type { PetUpdate } from './PetUpdate'
 
-/**
- * @type object
-*/
 export type UpdatePetPath = {
-    /**
-     * @type string
-    */
     pet_id: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetQuery = {
-    /**
-     * @type boolean | undefined
-    */
     include_deleted?: boolean;
-    /**
-     * @type string | undefined
-    */
     request_source?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     "X-Request-ID"?: string;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetStatus200 = Pet;
 
-/**
- * @type object
-*/
 export type UpdatePetBody = PetUpdate;
 
-/**
- * @type object
-*/
 export type UpdatePetOptions = {
     body: UpdatePetBody;
     path: UpdatePetPath;
@@ -60,9 +30,6 @@ export type UpdatePetOptions = {
     headers?: UpdatePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type UpdatePetResponses = {
     "200": UpdatePetStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/parserZod/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/petStore/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPet.ts
@@ -6,21 +6,12 @@
 import type { AddPetRequest } from './AddPetRequest'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type AddPetStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type AddPetStatus200Xml = Pet;
 
 export type AddPetStatus200 = (AddPetStatus200Json | AddPetStatus200Xml);
 
-/**
- * @type any
-*/
 export type AddPetStatus405 = any;
 
 /**
@@ -43,9 +34,6 @@ export type AddPetBodyFormUrlEncoded = Pet;
 
 export type AddPetBody = (AddPetBodyJson | AddPetBodyXml | AddPetBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type AddPetOptions = {
     body: AddPetBody;
     path?: never;
@@ -53,9 +41,6 @@ export type AddPetOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type AddPetResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPetRequest.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/AddPetRequest.ts
@@ -7,9 +7,6 @@ import type { AddPetRequestStatusEnumKey } from './AddPetRequestStatusEnum'
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type AddPetRequest = {
     /**
      * @description
@@ -23,17 +20,8 @@ export type AddPetRequest = {
      * @type string
     */
     name: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/ApiResponse.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/ApiResponse.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type ApiResponse = {
     /**
      * @description
@@ -13,12 +10,6 @@ export type ApiResponse = {
      * @type integer | undefined
     */
     code?: number;
-    /**
-     * @type string | undefined
-    */
     type?: string;
-    /**
-     * @type string | undefined
-    */
     message?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Category.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Category.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Category = {
     /**
      * @description

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeletePet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/DeletePet.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type DeletePetPath = {
     /**
      * @description Pet id to delete
@@ -16,24 +13,12 @@ export type DeletePetPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type DeletePetHeaders = {
-    /**
-     * @type string | undefined
-    */
     api_key?: string;
 };
 
-/**
- * @type any
-*/
 export type DeletePetStatus400 = any;
 
-/**
- * @type object
-*/
 export type DeletePetOptions = {
     body?: never;
     path: DeletePetPath;
@@ -41,9 +26,6 @@ export type DeletePetOptions = {
     headers?: DeletePetHeaders;
 };
 
-/**
- * @type object
-*/
 export type DeletePetResponses = {
     "400": DeletePetStatus400;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/FindPetsByStatus.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/FindPetsByStatus.ts
@@ -6,9 +6,6 @@
 import type { FindPetsByStatusStatusKey } from './FindPetsByStatusStatus'
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type FindPetsByStatusQuery = {
     /**
      * @description Status values that need to be considered for filter
@@ -17,26 +14,14 @@ export type FindPetsByStatusQuery = {
     status?: FindPetsByStatusStatusKey;
 };
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Json = Pet[];
 
-/**
- * @type array
-*/
 export type FindPetsByStatusStatus200Xml = Pet[];
 
 export type FindPetsByStatusStatus200 = (FindPetsByStatusStatus200Json | FindPetsByStatusStatus200Xml);
 
-/**
- * @type any
-*/
 export type FindPetsByStatusStatus400 = any;
 
-/**
- * @type object
-*/
 export type FindPetsByStatusOptions = {
     body?: never;
     path?: never;
@@ -44,9 +29,6 @@ export type FindPetsByStatusOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type FindPetsByStatusResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetInventory.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetInventory.ts
@@ -3,16 +3,10 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type GetInventoryStatus200 = {
     [key: string]: number;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryOptions = {
     body?: never;
     path?: never;
@@ -20,9 +14,6 @@ export type GetInventoryOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetInventoryResponses = {
     "200": GetInventoryStatus200;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetPetById.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/GetPetById.ts
@@ -5,9 +5,6 @@
 
 import type { Pet } from './Pet'
 
-/**
- * @type object
-*/
 export type GetPetByIdPath = {
     /**
      * @description ID of pet to return
@@ -18,31 +15,16 @@ export type GetPetByIdPath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Json = Pet;
 
-/**
- * @type object
-*/
 export type GetPetByIdStatus200Xml = Pet;
 
 export type GetPetByIdStatus200 = (GetPetByIdStatus200Json | GetPetByIdStatus200Xml);
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus400 = any;
 
-/**
- * @type any
-*/
 export type GetPetByIdStatus404 = any;
 
-/**
- * @type object
-*/
 export type GetPetByIdOptions = {
     body?: never;
     path: GetPetByIdPath;
@@ -50,9 +32,6 @@ export type GetPetByIdOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type GetPetByIdResponses = {
     "200": ({
         contentType: "application/json";

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Order.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Order.ts
@@ -5,9 +5,6 @@
 
 import type { OrderStatusEnumKey } from './OrderStatusEnum'
 
-/**
- * @type object
-*/
 export type Order = {
     /**
      * @description
@@ -41,8 +38,5 @@ export type Order = {
      * @example approved
     */
     status?: OrderStatusEnumKey;
-    /**
-     * @type boolean | undefined
-    */
     complete?: boolean;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Pet.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Pet.ts
@@ -7,9 +7,6 @@ import type { Category } from './Category'
 import type { PetStatusEnumKey } from './PetStatusEnum'
 import type { Tag } from './Tag'
 
-/**
- * @type object
-*/
 export type Pet = {
     /**
      * @description
@@ -31,17 +28,8 @@ export type Pet = {
      * @type string | undefined
     */
     log?: string;
-    /**
-     * @type object | undefined
-    */
     category?: Category;
-    /**
-     * @type array
-    */
     photoUrls: string[];
-    /**
-     * @type array | undefined
-    */
     tags?: Tag[];
     /**
      * @description pet status in the store

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/PlaceOrder.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/PlaceOrder.ts
@@ -5,36 +5,18 @@
 
 import type { Order } from './Order'
 
-/**
- * @type object
-*/
 export type PlaceOrderStatus200 = Order;
 
-/**
- * @type any
-*/
 export type PlaceOrderStatus405 = any;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyJson = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyXml = Order | undefined;
 
-/**
- * @type object | undefined
-*/
 export type PlaceOrderBodyFormUrlEncoded = Order | undefined;
 
 export type PlaceOrderBody = (PlaceOrderBodyJson | PlaceOrderBodyXml | PlaceOrderBodyFormUrlEncoded);
 
-/**
- * @type object
-*/
 export type PlaceOrderOptions = {
     body: PlaceOrderBody;
     path?: never;
@@ -42,9 +24,6 @@ export type PlaceOrderOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type PlaceOrderResponses = {
     "200": PlaceOrderStatus200;
     "405": PlaceOrderStatus405;

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Tag.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/Tag.ts
@@ -3,9 +3,6 @@
 * Do not edit manually.
 */
 
-/**
- * @type object
-*/
 export type Tag = {
     /**
      * @description
@@ -13,8 +10,5 @@ export type Tag = {
      * @type integer | undefined
     */
     id?: bigint;
-    /**
-     * @type string | undefined
-    */
     name?: string;
 };

--- a/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
+++ b/tests/3.0.x/__snapshots__/pluginVueQuery/withClientPlugin/types/UploadFile.ts
@@ -5,9 +5,6 @@
 
 import type { ApiResponse } from './ApiResponse'
 
-/**
- * @type object
-*/
 export type UploadFilePath = {
     /**
      * @description ID of pet to update
@@ -18,9 +15,6 @@ export type UploadFilePath = {
     petId: bigint;
 };
 
-/**
- * @type object
-*/
 export type UploadFileQuery = {
     /**
      * @description Additional Metadata
@@ -29,19 +23,10 @@ export type UploadFileQuery = {
     additionalMetadata?: string;
 };
 
-/**
- * @type object
-*/
 export type UploadFileStatus200 = ApiResponse;
 
-/**
- * @type string | undefined
-*/
 export type UploadFileBody = Blob | undefined;
 
-/**
- * @type object
-*/
 export type UploadFileOptions = {
     body: UploadFileBody;
     path: UploadFilePath;
@@ -49,9 +34,6 @@ export type UploadFileOptions = {
     headers?: never;
 };
 
-/**
- * @type object
-*/
 export type UploadFileResponses = {
     "200": UploadFileStatus200;
 };


### PR DESCRIPTION
## 🎯 Changes

Follow-up to #708, this time targeting generated output size rather than plugin source.

`buildPropertyJSDocComments` in `packages/plugin-ts/src/utils.ts` always emitted an `@type <primitive>` tag for every annotated property, even when it was the only line in the comment block. Since the TypeScript type already sits right next to the property (`id?: number`), a standalone `@type number | undefined` comment repeats information the reader can already see and adds nothing.

In a benchmark against the GitHub REST API spec, these bare `@type`-only blocks accounted for roughly 861 KB, about 5.4% of a single-config generated output.

This PR suppresses the `@type` tag when it would be the sole content of a comment block, and keeps it when the block already exists for another reason (`@description`, `@example`, `@pattern`, etc). No plugin option, resolver output, or non-JSDoc generated code changes.

Changes:
- `packages/plugin-ts/src/utils.ts`: `buildPropertyJSDocComments` now only appends `@type` once another annotation has already justified the comment block.
- Test updates in `packages/plugin-ts/src/utils.test.ts` and `packages/plugin-ts/src/printers/printerTs.test.ts`, plus snapshot updates across `packages/plugin-ts` and `tests/3.0.x`.
- Regenerated all 14 examples' generated output to reflect the fix (verified each diff is exclusively bare `@type` removals, no incidental drift).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTm7pZ68FXo7x5YY2XjAWe)_