### PR TITLE
feat(plugin-ts): add operationTypes option to inline base schema types (#16)

### DIFF
--- a/.changeset/operation-types-inlining.md
+++ b/.changeset/operation-types-inlining.md
@@ -1,0 +1,15 @@
+---
+"@kubb/plugin-react-query": minor
+"@kubb/plugin-vue-query": minor
+"@kubb/plugin-cypress": minor
+"@kubb/plugin-faker": minor
+"@kubb/plugin-ts": minor
+"@kubb/plugin-msw": minor
+"@kubb/plugin-swr": minor
+---
+
+Add an `operationTypes` option to `@kubb/plugin-ts` (default `true`). With `operationTypes: false`, a request body or response backed by a single `$ref` references the base component type (for example `Pet`) instead of the per-operation `AddPetData` / `AddPetStatus200` alias, and those aliases are no longer emitted.
+
+The option is carried by the plugin-ts resolver, so every consumer that reads it (the client plugins, react-query, vue-query, swr, faker, msw, cypress) inherits the inlining and imports each base component from its own file. Inline, array, union, multiple-content-type, and `Omit`-based schemas keep their per-operation alias, since no single base type exists.
+
+Default (`true`) output is unchanged. Resolves #16.

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -22,6 +22,7 @@ export {
   resolveContentTypeVariants,
   resolveErrorNames,
   resolveInlinableRefName,
+  resolveOperationTypeImports,
   resolveOperationTypeNames,
   resolveResponseTypes,
   resolveSuccessNames,

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -21,6 +21,7 @@ export {
   operationFileEntry,
   resolveContentTypeVariants,
   resolveErrorNames,
+  resolveInlinableRefName,
   resolveOperationTypeNames,
   resolveResponseTypes,
   resolveSuccessNames,

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -1,4 +1,4 @@
-import { ast, type ResolverFileParams, Url } from 'kubb/kit'
+import { ast, type Group, type Output, type ResolverFileParams, Url } from 'kubb/kit'
 import { dedupeParams } from './params.ts'
 
 /**
@@ -563,6 +563,107 @@ export function resolveOperationTypeNames(
   const result = names.filter((name): name is string => Boolean(name) && !exclude.has(name as string))
   byResolver.set(cacheKey, result)
   return result
+}
+
+/**
+ * A set of type names imported from one source file. Consumer plugins emit one `File.Import` per
+ * group.
+ */
+export type OperationTypeImportGroup = { path: string; names: string[] }
+
+export type OperationTypeImportsResolver = OperationTypeNameResolver & {
+  name(name: string): string
+  file(options: ResolverFileParams & { root: string; output: Output; group?: Group }): { path: string }
+}
+
+export type ResolveOperationTypeImportsOptions = ResolveOperationTypeNameOptions & {
+  /**
+   * The resolved `operationTypes` value from `@kubb/plugin-ts`. When `true` every name lives in the
+   * operation file and this returns a single group, matching {@link resolveOperationTypeNames}. When
+   * `false`, `$ref`-backed bodies and responses resolve to their base component in a separate file.
+   */
+  operationTypes: boolean
+  /**
+   * The path of the operation's `@kubb/plugin-ts` file, where the aliases and aggregates live.
+   */
+  operationFilePath: string
+  /**
+   * Project root and the `@kubb/plugin-ts` output/group, used to resolve a base component's file when
+   * inlining.
+   */
+  root: string
+  output: Output
+  group?: Group
+  /**
+   * Extra names that always live in the operation file, prepended before the resolved names (for
+   * example the `Options` type a client references).
+   */
+  extraNames?: ReadonlyArray<string | null | undefined>
+}
+
+/**
+ * The import-path counterpart to {@link resolveOperationTypeNames}. Groups the type names an
+ * operation needs by the file they are exported from, so consumer plugins inherit `plugin-ts`'s
+ * `operationTypes` inlining without tracking which names moved to a base component file.
+ */
+export function resolveOperationTypeImports(
+  node: ast.OperationNode,
+  resolver: OperationTypeImportsResolver,
+  options: ResolveOperationTypeImportsOptions,
+): OperationTypeImportGroup[] {
+  const { operationTypes, operationFilePath, root, output, group, extraNames = [], ...nameOptions } = options
+
+  if (operationTypes) {
+    const names = [...extraNames, ...resolveOperationTypeNames(node, resolver, nameOptions)].filter((name): name is string => Boolean(name))
+    const unique = [...new Set(names)]
+    return unique.length > 0 ? [{ path: operationFilePath, names: unique }] : []
+  }
+
+  const exclude = new Set(nameOptions.exclude ?? [])
+  const byPath = new Map<string, Set<string>>()
+  const add = (name: string | null | undefined, path: string) => {
+    if (!name || exclude.has(name)) return
+    const set = byPath.get(path) ?? new Set<string>()
+    set.add(name)
+    byPath.set(path, set)
+  }
+  const addContent = (content: ReadonlyArray<ContentVariantInput> | null | undefined, aliasName: string) => {
+    const inlineName = resolveInlinableRefName(content)
+    if (inlineName) return add(resolver.name(inlineName), resolver.file({ name: inlineName, extname: '.ts', root, output, group }).path)
+    return add(aliasName, operationFilePath)
+  }
+
+  for (const name of extraNames) add(name, operationFilePath)
+
+  if (nameOptions.includeParams !== false) {
+    const { path, query, header } = getOperationParameters(node)
+    for (const param of path) add(resolver.param.path(node, param), operationFilePath)
+    for (const param of query) add(resolver.param.query(node, param), operationFilePath)
+    for (const param of header) add(resolver.param.headers(node, param), operationFilePath)
+  }
+
+  if (node.requestBody?.content?.[0]?.schema) {
+    addContent(node.requestBody.content, resolver.response.body(node))
+  }
+  add(resolver.response.response(node), operationFilePath)
+
+  if (nameOptions.responseStatusNames !== false) {
+    const responses = nameOptions.responseStatusNames === 'error' ? node.responses.filter((res) => isErrorStatusCode(res.statusCode)) : node.responses
+    for (const res of responses) {
+      addContent(res.content, resolver.response.status(node, res.statusCode))
+    }
+  }
+
+  const groups: OperationTypeImportGroup[] = []
+  const operationNames = byPath.get(operationFilePath)
+  if (operationNames?.size) {
+    groups.push({ path: operationFilePath, names: [...operationNames] })
+  }
+  for (const [path, names] of byPath) {
+    if (path === operationFilePath || names.size === 0) continue
+    groups.push({ path, names: [...names] })
+  }
+  return groups
 }
 
 export function resolveResponseTypes(node: ast.OperationNode, resolver: ResponseNameResolver): Array<[statusCode: number | 'default', typeName: string]> {

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -248,6 +248,21 @@ export type ContentVariantInput = { contentType: string; schema?: ast.SchemaNode
 export type ContentVariant = { name: string; suffix: string; schema: ast.SchemaNode; keysToOmit?: Array<string> | null; contentType: string }
 
 /**
+ * The base component name a body or response should inline to, or `null` to keep its per-operation
+ * alias. Only content that is a single, bare `$ref` has a base type to point at. Multiple content
+ * types, `keysToOmit` (an `Omit<Base, …>`), inline schemas, arrays, and unions all return `null`, so
+ * they keep the alias.
+ */
+export function resolveInlinableRefName(content: ReadonlyArray<ContentVariantInput> | null | undefined): string | null {
+  if (!content || content.length !== 1) return null
+  const entry = content[0]
+  if (!entry?.schema || (entry.keysToOmit?.length ?? 0) > 0) return null
+  const refNode = ast.narrowSchema(entry.schema, 'ref')
+  if (!refNode?.ref) return null
+  return ast.resolveRefName(refNode)
+}
+
+/**
  * Resolves per-content-type variant names for a set of content entries, deduplicating suffix
  * collisions with a numeric counter. Entries without a schema are skipped. The returned `suffix` is
  * the final (possibly counter-augmented) value, so callers can derive parallel names in another
@@ -415,10 +430,20 @@ export function getOperationParameters(node: ast.OperationNode): OperationParame
  * shape from the same inputs. `primitive: 'object'` is a no-op for the TS printer and tells the Zod
  * printer to emit `z.object(…)` rather than a record.
  */
-export function buildOptionsSchema(node: ast.OperationNode, resolver: OperationTypeNameResolver): ast.SchemaNode {
+export function buildOptionsSchema(
+  node: ast.OperationNode,
+  resolver: OperationTypeNameResolver,
+  { operationTypes = true }: { operationTypes?: boolean } = {},
+): ast.SchemaNode {
   const { path, query, header } = getOperationParameters(node)
   const hasBody = Boolean(node.requestBody?.content?.[0]?.schema)
   const createNever = () => ast.factory.createSchema({ type: 'never', primitive: undefined, optional: true })
+  const bodySchema = () => {
+    if (!hasBody) return createNever()
+    const inlineName = operationTypes ? null : resolveInlinableRefName(node.requestBody?.content)
+    if (inlineName) return node.requestBody!.content!.find((entry) => entry.schema)!.schema!
+    return ast.factory.createSchema({ type: 'ref', name: resolver.response.body(node) })
+  }
   const groups = [
     { name: 'path', params: path, resolve: resolver.param.path },
     { name: 'query', params: query, resolve: resolver.param.query },
@@ -436,7 +461,7 @@ export function buildOptionsSchema(node: ast.OperationNode, resolver: OperationT
       ast.factory.createProperty({
         name: 'body',
         required: hasBody,
-        schema: hasBody ? ast.factory.createSchema({ type: 'ref', name: resolver.response.body(node) }) : createNever(),
+        schema: bodySchema(),
       }),
       ...groups.map(({ name, params, resolve }) => {
         const required = params.some((param) => param.required)

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -578,11 +578,11 @@ export type OperationTypeImportsResolver = OperationTypeNameResolver & {
 
 export type ResolveOperationTypeImportsOptions = ResolveOperationTypeNameOptions & {
   /**
-   * The resolved `operationTypes` value from `@kubb/plugin-ts`. When `true` every name lives in the
-   * operation file and this returns a single group, matching {@link resolveOperationTypeNames}. When
-   * `false`, `$ref`-backed bodies and responses resolve to their base component in a separate file.
+   * The `operationTypes` value from `@kubb/plugin-ts`. Unset or `true` keeps every name in the
+   * operation file and returns a single group, matching {@link resolveOperationTypeNames}. Only
+   * `false` resolves `$ref`-backed bodies and responses to their base component in a separate file.
    */
-  operationTypes: boolean
+  operationTypes?: boolean
   /**
    * The path of the operation's `@kubb/plugin-ts` file, where the aliases and aggregates live.
    */
@@ -613,7 +613,7 @@ export function resolveOperationTypeImports(
 ): OperationTypeImportGroup[] {
   const { operationTypes, operationFilePath, root, output, group, extraNames = [], ...nameOptions } = options
 
-  if (operationTypes) {
+  if (operationTypes !== false) {
     const names = [...extraNames, ...resolveOperationTypeNames(node, resolver, nameOptions)].filter((name): name is string => Boolean(name))
     const unique = [...new Set(names)]
     return unique.length > 0 ? [{ path: operationFilePath, names: unique }] : []

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -1,6 +1,6 @@
 import { resolveOperationTypeImports } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Request } from '../components/Request.tsx'
 import type { PluginCypress } from '../types.ts'
@@ -43,7 +43,7 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
     const typeImportGroups = meta.fileTs
       ? resolveOperationTypeImports(node, tsResolver, {
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-cypress/src/generators/cypressGenerator.tsx
+++ b/packages/plugin-cypress/src/generators/cypressGenerator.tsx
@@ -1,6 +1,6 @@
-import { resolveOperationTypeNames } from '@internals/shared'
+import { resolveOperationTypeImports } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Request } from '../components/Request.tsx'
 import type { PluginCypress } from '../types.ts'
@@ -26,8 +26,6 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
 
     const tsResolver = driver.getResolver(pluginTsName)
 
-    const importedTypeNames = [tsResolver.response.options(node), ...resolveOperationTypeNames(node, tsResolver, { includeParams: false })]
-
     const meta = {
       name: resolver.name(node.operationId),
       file: resolver.file({ name: node.operationId, extname: '.ts', tag: node.tags[0] ?? 'default', path: node.path, root, output, group: group ?? undefined }),
@@ -42,6 +40,18 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
       }),
     } as const
 
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
+
     return (
       <File
         baseName={meta.file.baseName}
@@ -50,7 +60,9 @@ export const cypressGenerator = defineGenerator<PluginCypress>({
         banner={resolver.default.banner(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
         footer={resolver.default.footer(ctx.meta, { output, config, file: { path: meta.file.path, baseName: meta.file.baseName } })}
       >
-        {importedTypeNames.length > 0 && <File.Import name={importedTypeNames} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
         <Request name={meta.name} node={node} resolver={tsResolver} baseURL={baseURL} />
       </File>
     )

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -1,7 +1,7 @@
-import { getOperationParameters, getPerContentTypeName, resolveContentTypeVariants } from '@internals/shared'
+import { getOperationParameters, getPerContentTypeName, resolveContentTypeVariants, resolveInlinableRefName } from '@internals/shared'
 import { aliasConflictingImports, filterUsedImports, rewriteAliasedImports } from '@internals/utils'
 import { ast, defineGenerator } from 'kubb/kit'
-import { buildParams, pluginTsName } from '@kubb/plugin-ts'
+import { buildParams, defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Faker } from '../components/Faker.tsx'
 import { printerFaker } from '../printers/printerFaker.ts'
@@ -156,21 +156,29 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       ]
     }
 
-    const responseUnits = node.responses.flatMap((response) =>
-      expandContentUnits(
+    const operationTypes = pluginTs.options?.operationTypes ?? defaultOperationTypes
+    const componentPathFor = (content: ReadonlyArray<{ contentType: string; schema?: ast.SchemaNode | null; keysToOmit?: Array<string> | null }> | null | undefined) => {
+      const inlineName = operationTypes ? null : resolveInlinableRefName(content)
+      if (!inlineName) return undefined
+      return tsResolver.file({ name: inlineName, extname: '.ts', root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined }).path
+    }
+
+    const responseUnits = node.responses.flatMap((response) => {
+      const componentPath = componentPathFor(response.content)
+      return expandContentUnits(
         response.content ?? [],
         resolver.response.status(node, response.statusCode),
         tsResolver.response.status(node, response.statusCode),
         response.description,
-      ),
-    )
+      ).map((unit) => ({ ...unit, componentPath }))
+    })
     const dataUnits = expandContentUnits(
       node.requestBody?.content ?? [],
       resolver.response.body(node),
       tsResolver.response.body(node),
       node.requestBody?.description,
       (schema) => ({ ...schema, description: node.requestBody?.description ?? schema.description }),
-    )
+    ).map((unit) => ({ ...unit, componentPath: componentPathFor(node.requestBody?.content) }))
     const responseName = resolver.response.response(node)
     const localHelperNames = new Set([
       ...paramGroups.map((group) => group.name),
@@ -203,12 +211,14 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       typeName,
       description,
       skipImportNames = [],
+      componentPath,
     }: {
       schema: ast.SchemaNode | null
       name: string
       typeName: string
       description?: string
       skipImportNames?: Array<string>
+      componentPath?: string
     }) {
       if (!schema) {
         return null
@@ -234,7 +244,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
         name,
         typeName,
         filePath: meta.file.path,
-        typeFilePath: meta.typeFile.path,
+        typeFilePath: componentPath ?? meta.typeFile.path,
       })
 
       return (
@@ -275,6 +285,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
             typeName: unit.typeName,
             description: unit.description,
             skipImportNames: unit.skipImportNames,
+            componentPath: unit.componentPath,
           }),
         )}
         {dataUnits.map((unit) =>
@@ -284,6 +295,7 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
             typeName: unit.typeName,
             description: unit.description,
             skipImportNames: unit.skipImportNames,
+            componentPath: unit.componentPath,
           }),
         )}
         {renderEntry({

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -1,7 +1,7 @@
 import { getOperationParameters, getPerContentTypeName, resolveContentTypeVariants, resolveInlinableRefName } from '@internals/shared'
 import { aliasConflictingImports, filterUsedImports, rewriteAliasedImports } from '@internals/utils'
 import { ast, defineGenerator } from 'kubb/kit'
-import { buildParams, defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { buildParams, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Faker } from '../components/Faker.tsx'
 import { printerFaker } from '../printers/printerFaker.ts'
@@ -156,11 +156,10 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
       ]
     }
 
-    const operationTypes = pluginTs.options?.operationTypes ?? defaultOperationTypes
     const componentPathFor = (
       content: ReadonlyArray<{ contentType: string; schema?: ast.SchemaNode | null; keysToOmit?: Array<string> | null }> | null | undefined,
     ) => {
-      const inlineName = operationTypes ? null : resolveInlinableRefName(content)
+      const inlineName = pluginTs.options?.operationTypes === false ? resolveInlinableRefName(content) : null
       if (!inlineName) return undefined
       return tsResolver.file({
         name: inlineName,

--- a/packages/plugin-faker/src/generators/fakerGenerator.tsx
+++ b/packages/plugin-faker/src/generators/fakerGenerator.tsx
@@ -157,10 +157,18 @@ export const fakerGenerator = defineGenerator<PluginFaker>({
     }
 
     const operationTypes = pluginTs.options?.operationTypes ?? defaultOperationTypes
-    const componentPathFor = (content: ReadonlyArray<{ contentType: string; schema?: ast.SchemaNode | null; keysToOmit?: Array<string> | null }> | null | undefined) => {
+    const componentPathFor = (
+      content: ReadonlyArray<{ contentType: string; schema?: ast.SchemaNode | null; keysToOmit?: Array<string> | null }> | null | undefined,
+    ) => {
       const inlineName = operationTypes ? null : resolveInlinableRefName(content)
       if (!inlineName) return undefined
-      return tsResolver.file({ name: inlineName, extname: '.ts', root, output: pluginTs.options?.output ?? output, group: pluginTs.options?.group ?? undefined }).path
+      return tsResolver.file({
+        name: inlineName,
+        extname: '.ts',
+        root,
+        output: pluginTs.options?.output ?? output,
+        group: pluginTs.options?.group ?? undefined,
+      }).path
     }
 
     const responseUnits = node.responses.flatMap((response) => {

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -1,7 +1,7 @@
-import { getOperationSuccessResponses, resolveResponseTypes } from '@internals/shared'
+import { getOperationSuccessResponses, resolveInlinableRefName, resolveResponseTypes } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
 import { pluginFakerName } from '@kubb/plugin-faker'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mock, Response } from '../components'
 import type { PluginMsw } from '../types'
@@ -61,6 +61,28 @@ export const mswGenerator = defineGenerator<PluginMsw>({
 
     const requestName = node.requestBody?.content?.[0]?.schema ? tsResolver.response.body(node) : null
 
+    const tsOutput = pluginTs.options?.output ?? output
+    const tsGroup = pluginTs.options?.group ?? undefined
+    const operationTypes = pluginTs.options?.operationTypes ?? defaultOperationTypes
+    const componentPath = (refName: string) => tsResolver.file({ name: refName, extname: '.ts', root, output: tsOutput, group: tsGroup }).path
+
+    const typeImportsByPath = new Map<string, Set<string>>()
+    const addTypeImport = (name: string, path: string) => {
+      const names = typeImportsByPath.get(path) ?? new Set<string>()
+      names.add(name)
+      typeImportsByPath.set(path, names)
+    }
+    addTypeImport(type.responseName, type.file.path)
+    for (const response of node.responses) {
+      if (response.statusCode === 'default') continue
+      const inlineName = operationTypes ? null : resolveInlinableRefName(response.content)
+      addTypeImport(tsResolver.response.status(node, response.statusCode), inlineName ? componentPath(inlineName) : type.file.path)
+    }
+    if (requestName) {
+      const inlineBody = operationTypes ? null : resolveInlinableRefName(node.requestBody?.content)
+      addTypeImport(requestName, inlineBody ? componentPath(inlineBody) : type.file.path)
+    }
+
     return (
       <File
         baseName={mock.file.baseName}
@@ -71,12 +93,9 @@ export const mswGenerator = defineGenerator<PluginMsw>({
       >
         <File.Import name={['http']} path="msw" />
         <File.Import name={['HttpResponseResolver']} isTypeOnly path="msw" />
-        <File.Import
-          name={Array.from(new Set([type.responseName, ...types.map((t) => t[1]), ...(requestName ? [requestName] : [])]))}
-          path={type.file.path}
-          root={mock.file.path}
-          isTypeOnly
-        />
+        {Array.from(typeImportsByPath).map(([path, names]) => (
+          <File.Import key={path} name={Array.from(names)} root={mock.file.path} path={path} isTypeOnly />
+        ))}
         {parser === 'faker' && faker && <File.Import name={[faker.name]} root={mock.file.path} path={faker.file.path} />}
 
         {types

--- a/packages/plugin-msw/src/generators/mswGenerator.tsx
+++ b/packages/plugin-msw/src/generators/mswGenerator.tsx
@@ -1,7 +1,7 @@
 import { getOperationSuccessResponses, resolveInlinableRefName, resolveResponseTypes } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
 import { pluginFakerName } from '@kubb/plugin-faker'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mock, Response } from '../components'
 import type { PluginMsw } from '../types'
@@ -63,7 +63,6 @@ export const mswGenerator = defineGenerator<PluginMsw>({
 
     const tsOutput = pluginTs.options?.output ?? output
     const tsGroup = pluginTs.options?.group ?? undefined
-    const operationTypes = pluginTs.options?.operationTypes ?? defaultOperationTypes
     const componentPath = (refName: string) => tsResolver.file({ name: refName, extname: '.ts', root, output: tsOutput, group: tsGroup }).path
 
     const typeImportsByPath = new Map<string, Set<string>>()
@@ -75,11 +74,11 @@ export const mswGenerator = defineGenerator<PluginMsw>({
     addTypeImport(type.responseName, type.file.path)
     for (const response of node.responses) {
       if (response.statusCode === 'default') continue
-      const inlineName = operationTypes ? null : resolveInlinableRefName(response.content)
+      const inlineName = pluginTs.options?.operationTypes === false ? resolveInlinableRefName(response.content) : null
       addTypeImport(tsResolver.response.status(node, response.statusCode), inlineName ? componentPath(inlineName) : type.file.path)
     }
     if (requestName) {
-      const inlineBody = operationTypes ? null : resolveInlinableRefName(node.requestBody?.content)
+      const inlineBody = pluginTs.options?.operationTypes === false ? resolveInlinableRefName(node.requestBody?.content) : null
       addTypeImport(requestName, inlineBody ? componentPath(inlineBody) : type.file.path)
     }
 

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -1,7 +1,7 @@
 import { getOperationParameters, operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import { classifyOperation, resolvePageParamType } from '../utils.ts'
@@ -70,7 +70,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
           exclude: [queryKeyTypeName],
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -1,7 +1,7 @@
-import { getOperationParameters, operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { getOperationParameters, operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import { classifyOperation, resolvePageParamType } from '../utils.ts'
@@ -65,15 +65,19 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
       queryParam: infiniteOptions.queryParam,
     })
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      queryParamsTypeName,
-      ...resolveOperationTypeNames(node, tsResolver, {
-        exclude: [queryKeyTypeName],
-        order: 'body-response-first',
-        includeParams: false,
-      }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          exclude: [queryKeyTypeName],
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node), queryParamsTypeName],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -89,9 +93,9 @@ export const infiniteQueryGenerator = defineGenerator<PluginReactQuery>({
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} root={meta.file.path} path={contractOp.clientPath} isTypeOnly />
 
         {customOptions && <File.Import name={[customOptions.name]} path={customOptions.importPath} />}
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <QueryKey name={queryKeyName} typeName={queryKeyTypeName} node={node} tsResolver={tsResolver} transformer={ctx.options.queryKey} />
 

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -1,7 +1,7 @@
 import { operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mutation, MutationKey, MutationOptions } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -51,7 +51,7 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
       ? resolveOperationTypeImports(node, tsResolver, {
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: tsOutput,

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -1,7 +1,7 @@
-import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mutation, MutationKey, MutationOptions } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -39,20 +39,26 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
     const mutationOptionsName = resolver.mutation.optionsName(node)
     const mutationKeyName = resolver.mutation.keyName(node)
 
+    const tsOutput = pluginTs.options?.output ?? output
+    const tsGroup = pluginTs.options?.group ?? undefined
+
     const meta = {
       file: resolver.file({ ...operationFileEntry(node, mutationHookName), root, output, group: group ?? undefined }),
-      fileTs: tsResolver.file({
-        ...operationFileEntry(node, node.operationId),
-        root,
-        output: pluginTs.options?.output ?? output,
-        group: pluginTs.options?.group ?? undefined,
-      }),
+      fileTs: tsResolver.file({ ...operationFileEntry(node, node.operationId), root, output: tsOutput, group: tsGroup }),
     }
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: tsOutput,
+          group: tsGroup,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -68,9 +74,9 @@ export const mutationGenerator = defineGenerator<PluginReactQuery>({
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} root={meta.file.path} path={contractOp.clientPath} isTypeOnly />
 
         {customOptions && <File.Import name={[customOptions.name]} path={customOptions.importPath} />}
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <MutationKey name={mutationKeyName} node={node} transformer={ctx.options.mutationKey} />
 

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -1,7 +1,7 @@
 import { operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -54,7 +54,7 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
           exclude: [queryKeyTypeName],
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -1,7 +1,7 @@
-import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -49,14 +49,19 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
       }),
     }
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      ...resolveOperationTypeNames(node, tsResolver, {
-        exclude: [queryKeyTypeName],
-        order: 'body-response-first',
-        includeParams: false,
-      }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          exclude: [queryKeyTypeName],
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -72,9 +77,9 @@ export const queryGenerator = defineGenerator<PluginReactQuery>({
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} root={meta.file.path} path={contractOp.clientPath} isTypeOnly />
 
         {customOptions && <File.Import name={[customOptions.name]} path={customOptions.importPath} />}
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <QueryKey name={queryKeyName} typeName={queryKeyTypeName} node={node} tsResolver={tsResolver} transformer={ctx.options.queryKey} />
 

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -1,7 +1,7 @@
-import { getOperationParameters, operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { getOperationParameters, operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -64,11 +64,18 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
         ? tsResolver.param.query(node, rawQueryParams[0]!)
         : null
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      queryParamsTypeName,
-      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node), queryParamsTypeName],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -84,9 +91,9 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} root={meta.file.path} path={contractOp.clientPath} isTypeOnly />
 
         {customOptions && <File.Import name={[customOptions.name]} path={customOptions.importPath} />}
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <QueryKey name={queryKeyName} typeName={queryKeyTypeName} node={node} tsResolver={tsResolver} transformer={ctx.options.queryKey} />
 

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -1,7 +1,7 @@
 import { getOperationParameters, operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -68,7 +68,7 @@ export const suspenseInfiniteQueryGenerator = defineGenerator<PluginReactQuery>(
       ? resolveOperationTypeImports(node, tsResolver, {
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -1,7 +1,7 @@
-import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -52,14 +52,19 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
       }),
     }
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      ...resolveOperationTypeNames(node, tsResolver, {
-        exclude: [queryKeyTypeName],
-        order: 'body-response-first',
-        includeParams: false,
-      }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          exclude: [queryKeyTypeName],
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -75,9 +80,9 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} root={meta.file.path} path={contractOp.clientPath} isTypeOnly />
 
         {customOptions && <File.Import name={[customOptions.name]} path={customOptions.importPath} />}
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <QueryKey name={queryKeyName} typeName={queryKeyTypeName} node={node} tsResolver={tsResolver} transformer={ctx.options.queryKey} />
 

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -1,7 +1,7 @@
 import { operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import { classifyOperation } from '../utils.ts'
@@ -57,7 +57,7 @@ export const suspenseQueryGenerator = defineGenerator<PluginReactQuery>({
           exclude: [queryKeyTypeName],
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-swr/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-swr/src/generators/mutationGenerator.tsx
@@ -2,7 +2,7 @@ import { resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mutation, MutationKey } from '../components'
 import type { PluginSwr } from '../types'
@@ -56,7 +56,7 @@ export const mutationGenerator = defineGenerator<PluginSwr>({
       ? resolveOperationTypeImports(node, tsResolver, {
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-swr/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-swr/src/generators/mutationGenerator.tsx
@@ -1,8 +1,8 @@
-import { resolveOperationTypeNames } from '@internals/shared'
+import { resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mutation, MutationKey } from '../components'
 import type { PluginSwr } from '../types'
@@ -52,10 +52,18 @@ export const mutationGenerator = defineGenerator<PluginSwr>({
       }),
     }
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -70,9 +78,9 @@ export const mutationGenerator = defineGenerator<PluginSwr>({
         <File.Import name={[contractOp.name]} root={meta.file.path} path={contractOp.path} />
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} root={meta.file.path} path={contractOp.clientPath} isTypeOnly />
 
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <MutationKey name={mutationKeyName} typeName={mutationKeyTypeName} node={node} transformer={ctx.options.mutationKey} />
 

--- a/packages/plugin-swr/src/generators/queryGenerator.tsx
+++ b/packages/plugin-swr/src/generators/queryGenerator.tsx
@@ -1,8 +1,8 @@
-import { resolveOperationTypeNames } from '@internals/shared'
+import { resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginSwr } from '../types'
@@ -51,14 +51,19 @@ export const queryGenerator = defineGenerator<PluginSwr>({
       }),
     }
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      ...resolveOperationTypeNames(node, tsResolver, {
-        exclude: [queryKeyTypeName],
-        order: 'body-response-first',
-        includeParams: false,
-      }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          exclude: [queryKeyTypeName],
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -73,9 +78,9 @@ export const queryGenerator = defineGenerator<PluginSwr>({
         <File.Import name={[contractOp.name]} root={meta.file.path} path={contractOp.path} />
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} root={meta.file.path} path={contractOp.clientPath} isTypeOnly />
 
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <QueryKey name={queryKeyName} typeName={queryKeyTypeName} node={node} tsResolver={tsResolver} transformer={ctx.options.queryKey} />
 

--- a/packages/plugin-swr/src/generators/queryGenerator.tsx
+++ b/packages/plugin-swr/src/generators/queryGenerator.tsx
@@ -2,7 +2,7 @@ import { resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginSwr } from '../types'
@@ -56,7 +56,7 @@ export const queryGenerator = defineGenerator<PluginSwr>({
           exclude: [queryKeyTypeName],
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-ts/src/generators/typeGenerator.test.ts
+++ b/packages/plugin-ts/src/generators/typeGenerator.test.ts
@@ -162,11 +162,24 @@ describe('typeGenerator — operationTypes: false', () => {
       path: '/pets',
       tags: ['pets'],
       requestBody: {
-        content: [ast.factory.createContent({ contentType: 'application/json', schema: ast.factory.createSchema({ type: 'ref', name: 'NewPet', ref: '#/components/schemas/NewPet' }) })],
+        content: [
+          ast.factory.createContent({
+            contentType: 'application/json',
+            schema: ast.factory.createSchema({ type: 'ref', name: 'NewPet', ref: '#/components/schemas/NewPet' }),
+          }),
+        ],
       },
       responses: [
-        ast.factory.createResponse({ statusCode: '201', schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }), description: 'Created' }),
-        ast.factory.createResponse({ statusCode: '400', schema: ast.factory.createSchema({ type: 'ref', name: 'ErrorResponse', ref: '#/components/schemas/ErrorResponse' }), description: 'Bad request' }),
+        ast.factory.createResponse({
+          statusCode: '201',
+          schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }),
+          description: 'Created',
+        }),
+        ast.factory.createResponse({
+          statusCode: '400',
+          schema: ast.factory.createSchema({ type: 'ref', name: 'ErrorResponse', ref: '#/components/schemas/ErrorResponse' }),
+          description: 'Bad request',
+        }),
       ],
     })
 
@@ -190,7 +203,9 @@ describe('typeGenerator — operationTypes: false', () => {
       requestBody: {
         content: [ast.factory.createContent({ contentType: 'application/json', schema: ast.factory.createSchema({ type: 'object', properties: [] }) })],
       },
-      responses: [ast.factory.createResponse({ statusCode: '201', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'Created' })],
+      responses: [
+        ast.factory.createResponse({ statusCode: '201', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'Created' }),
+      ],
     })
 
     const source = await renderInline(node)
@@ -214,7 +229,13 @@ describe('typeGenerator — operationTypes: false', () => {
           }),
         ],
       },
-      responses: [ast.factory.createResponse({ statusCode: '201', schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }), description: 'Created' })],
+      responses: [
+        ast.factory.createResponse({
+          statusCode: '201',
+          schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }),
+          description: 'Created',
+        }),
+      ],
     })
 
     const source = await renderInline(node)

--- a/packages/plugin-ts/src/generators/typeGenerator.test.ts
+++ b/packages/plugin-ts/src/generators/typeGenerator.test.ts
@@ -26,6 +26,7 @@ const defaultOptions: PluginTs['resolvedOptions'] = {
   optionalType: 'questionToken',
   arrayType: 'array',
   syntaxType: 'type',
+  operationTypes: true,
   output: { path: '.', mode: 'directory' },
   exclude: [],
   include: undefined,
@@ -139,6 +140,86 @@ describe('typeGenerator — custom resolver', () => {
     expect(source).toContain("import type { ApiPet } from './Pet'")
     expect(source).toContain("import type { ApiErrorResponse } from './ErrorResponse'")
     expect(source).toContain("import type { ApiNewPet } from './NewPet'")
+  })
+})
+
+describe('typeGenerator — operationTypes: false', () => {
+  async function renderInline(node: ast.OperationNode) {
+    const options: PluginTs['resolvedOptions'] = { ...defaultOptions, operationTypes: false }
+    const plugin = createMockedPlugin<PluginTs>({ name: 'plugin-ts', options, resolver: apiResolver })
+    const driver = createMockedPluginDriver({ name: 'operationTypes false' })
+    const adapter = createMockedAdapter()
+
+    await renderGeneratorOperation(typeGenerator, node, { config: testConfig, adapter, driver, plugin, options, resolver: apiResolver })
+
+    return rawSources(driver.fileManager.files).join('\n')
+  }
+
+  test('drops the $ref-backed aliases and points the aggregates at the base component', async () => {
+    const node = ast.factory.createOperation({
+      operationId: 'createPet',
+      method: 'POST',
+      path: '/pets',
+      tags: ['pets'],
+      requestBody: {
+        content: [ast.factory.createContent({ contentType: 'application/json', schema: ast.factory.createSchema({ type: 'ref', name: 'NewPet', ref: '#/components/schemas/NewPet' }) })],
+      },
+      responses: [
+        ast.factory.createResponse({ statusCode: '201', schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }), description: 'Created' }),
+        ast.factory.createResponse({ statusCode: '400', schema: ast.factory.createSchema({ type: 'ref', name: 'ErrorResponse', ref: '#/components/schemas/ErrorResponse' }), description: 'Bad request' }),
+      ],
+    })
+
+    const source = await renderInline(node)
+
+    expect(source).not.toContain('ApiCreatePetStatus201')
+    expect(source).not.toContain('ApiCreatePetStatus400')
+    expect(source).not.toContain('ApiCreatePetBody')
+    expect(source).toContain("import type { ApiPet } from './Pet'")
+    expect(source).toContain("import type { ApiErrorResponse } from './ErrorResponse'")
+    expect(source).toContain("import type { ApiNewPet } from './NewPet'")
+    expect(source).toMatch(/ApiCreatePetResponse = \(?ApiPet \| ApiErrorResponse\)?/)
+  })
+
+  test('keeps the alias when the content is an inline object rather than a $ref', async () => {
+    const node = ast.factory.createOperation({
+      operationId: 'createPet',
+      method: 'POST',
+      path: '/pets',
+      tags: ['pets'],
+      requestBody: {
+        content: [ast.factory.createContent({ contentType: 'application/json', schema: ast.factory.createSchema({ type: 'object', properties: [] }) })],
+      },
+      responses: [ast.factory.createResponse({ statusCode: '201', schema: ast.factory.createSchema({ type: 'object', properties: [] }), description: 'Created' })],
+    })
+
+    const source = await renderInline(node)
+
+    expect(source).toContain('export type ApiCreatePetBody')
+    expect(source).toContain('export type ApiCreatePetStatus201')
+  })
+
+  test('keeps the alias when a $ref carries keysToOmit', async () => {
+    const node = ast.factory.createOperation({
+      operationId: 'createPet',
+      method: 'POST',
+      path: '/pets',
+      tags: ['pets'],
+      requestBody: {
+        content: [
+          ast.factory.createContent({
+            contentType: 'application/json',
+            schema: ast.factory.createSchema({ type: 'ref', name: 'NewPet', ref: '#/components/schemas/NewPet' }),
+            keysToOmit: ['id'],
+          }),
+        ],
+      },
+      responses: [ast.factory.createResponse({ statusCode: '201', schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }), description: 'Created' })],
+    })
+
+    const source = await renderInline(node)
+
+    expect(source).toContain('export type ApiCreatePetBody')
   })
 })
 

--- a/packages/plugin-ts/src/generators/typeGenerator.tsx
+++ b/packages/plugin-ts/src/generators/typeGenerator.tsx
@@ -1,4 +1,4 @@
-import { buildOptionsSchema, collectRefNames, getOperationParameters, resolveContentTypeVariants } from '@internals/shared'
+import { buildOptionsSchema, collectRefNames, getOperationParameters, resolveContentTypeVariants, resolveInlinableRefName } from '@internals/shared'
 import { ast, defineGenerator } from 'kubb/kit'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Type } from '../components/Type.tsx'
@@ -87,7 +87,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
     )
   },
   operation(node, ctx) {
-    const { enum: enumOptions, optionalType, arrayType, syntaxType, group, output, printer } = ctx.options
+    const { enum: enumOptions, optionalType, arrayType, syntaxType, operationTypes, group, output, printer } = ctx.options
     const { config, resolver, root } = ctx
 
     const meta = {
@@ -172,6 +172,9 @@ export const typeGenerator = defineGenerator<PluginTs>({
       if (requestBodyContent.length === 1) {
         const entry = requestBodyContent[0]!
         if (!entry.schema) return null
+        // Inlined: the body is a single `$ref`, so consumers reference the base component directly
+        // and the `XxxData` alias is redundant.
+        if (!operationTypes && resolveInlinableRefName(requestBodyContent)) return null
         return renderSchemaType({
           schema: {
             ...entry.schema,
@@ -197,6 +200,11 @@ export const typeGenerator = defineGenerator<PluginTs>({
       if (variants.length > 1) {
         return buildContentTypeVariants(variants, resolver.response.status(node, res.statusCode))
       }
+      // Inlined: a single-`$ref` response references the base component, so the `XxxStatusNNN` alias
+      // is redundant. The aggregate `XxxResponses` / `XxxResponse` types point at the component.
+      if (!operationTypes && resolveInlinableRefName(res.content)) {
+        return null
+      }
       const primary = variants[0] ?? res.content?.[0]
       return renderSchemaType({
         schema: primary?.schema ?? null,
@@ -206,12 +214,12 @@ export const typeGenerator = defineGenerator<PluginTs>({
     })
 
     const optionsType = renderSchemaType({
-      schema: buildOptionsSchema(node, resolver),
+      schema: buildOptionsSchema(node, resolver, { operationTypes }),
       name: resolver.response.options(node),
     })
 
     const responsesType = renderSchemaType({
-      schema: buildResponses(node, { resolver }),
+      schema: buildResponses(node, { resolver, operationTypes }),
       name: resolver.response.responses(node),
     })
 
@@ -234,7 +242,7 @@ export const typeGenerator = defineGenerator<PluginTs>({
 
       return renderSchemaType({
         schema: {
-          ...buildResponseUnion(node, { resolver })!,
+          ...buildResponseUnion(node, { resolver, operationTypes })!,
           description: 'Union of all possible responses',
         },
         name: responseName,

--- a/packages/plugin-ts/src/index.ts
+++ b/packages/plugin-ts/src/index.ts
@@ -1,7 +1,7 @@
 export { Enum } from './components/Enum.tsx'
 export { Type } from './components/Type.tsx'
 export { typeGenerator } from './generators/typeGenerator.tsx'
-export { default, defaultOperationTypes, pluginTs, pluginTsName } from './plugin.ts'
+export { default, pluginTs, pluginTsName } from './plugin.ts'
 export {
   createFunctionParameter,
   createFunctionParameters,

--- a/packages/plugin-ts/src/index.ts
+++ b/packages/plugin-ts/src/index.ts
@@ -1,7 +1,7 @@
 export { Enum } from './components/Enum.tsx'
 export { Type } from './components/Type.tsx'
 export { typeGenerator } from './generators/typeGenerator.tsx'
-export { default, pluginTs, pluginTsName } from './plugin.ts'
+export { default, defaultOperationTypes, pluginTs, pluginTsName } from './plugin.ts'
 export {
   createFunctionParameter,
   createFunctionParameters,

--- a/packages/plugin-ts/src/plugin.ts
+++ b/packages/plugin-ts/src/plugin.ts
@@ -1,8 +1,8 @@
-import { createGroupConfig } from '@internals/shared'
+import { createGroupConfig, resolveInlinableRefName } from '@internals/shared'
 import { definePlugin, Resolver } from 'kubb/kit'
 import { typeGenerator } from './generators/typeGenerator.tsx'
 import { resolverTs } from './resolvers/resolverTs.ts'
-import type { PluginTs } from './types.ts'
+import type { PluginTs, ResolverTs } from './types.ts'
 
 /**
  * Canonical plugin name for `@kubb/plugin-ts`. Used for driver lookups and
@@ -85,7 +85,24 @@ export const pluginTs = definePlugin<PluginTs>((options) => {
           operationTypes,
           printer,
         })
-        ctx.setResolver(userResolver ? Resolver.merge(resolverTs, userResolver) : resolverTs)
+        // When inlining, the resolved response/body type names become the referenced base component,
+        // so every consumer plugin reading this resolver references `Pet` instead of `AddPetStatus200`.
+        const inlineResolver = operationTypes
+          ? resolverTs
+          : Resolver.merge(resolverTs, {
+              response: {
+                body(this: ResolverTs, node) {
+                  const inlineName = resolveInlinableRefName(node.requestBody?.content)
+                  return inlineName ? this.name(inlineName) : resolverTs.response.body(node)
+                },
+                status(this: ResolverTs, node, statusCode) {
+                  const response = node.responses.find((res) => res.statusCode === statusCode)
+                  const inlineName = response ? resolveInlinableRefName(response.content) : null
+                  return inlineName ? this.name(inlineName) : resolverTs.response.status(node, statusCode)
+                },
+              },
+            })
+        ctx.setResolver(userResolver ? Resolver.merge(inlineResolver, userResolver) : inlineResolver)
         if (userMacros?.length) {
           ctx.setMacros(userMacros)
         }

--- a/packages/plugin-ts/src/plugin.ts
+++ b/packages/plugin-ts/src/plugin.ts
@@ -11,13 +11,6 @@ import type { PluginTs, ResolverTs } from './types.ts'
 export const pluginTsName = 'plugin-ts' satisfies PluginTs['name']
 
 /**
- * Default for the `operationTypes` option. Kept `true` so generated output is unchanged unless a
- * user opts into inlining. Consumer plugins import this to resolve the same default when the option
- * is left unset (`pluginTs.options?.operationTypes ?? defaultOperationTypes`).
- */
-export const defaultOperationTypes = true
-
-/**
  * Generates TypeScript `type` aliases and `interface` declarations from an
  * OpenAPI spec. The foundation that every other Kubb plugin builds on:
  * clients, query hooks, mocks, and validators all reference the names this
@@ -52,7 +45,7 @@ export const pluginTs = definePlugin<PluginTs>((options) => {
     optionalType = 'questionToken',
     arrayType = 'array',
     syntaxType = 'type',
-    operationTypes = defaultOperationTypes,
+    operationTypes = true,
     printer,
     resolver: userResolver,
     macros: userMacros,

--- a/packages/plugin-ts/src/plugin.ts
+++ b/packages/plugin-ts/src/plugin.ts
@@ -11,6 +11,13 @@ import type { PluginTs } from './types.ts'
 export const pluginTsName = 'plugin-ts' satisfies PluginTs['name']
 
 /**
+ * Default for the `operationTypes` option. Kept `true` so generated output is unchanged unless a
+ * user opts into inlining. Consumer plugins import this to resolve the same default when the option
+ * is left unset (`pluginTs.options?.operationTypes ?? defaultOperationTypes`).
+ */
+export const defaultOperationTypes = true
+
+/**
  * Generates TypeScript `type` aliases and `interface` declarations from an
  * OpenAPI spec. The foundation that every other Kubb plugin builds on:
  * clients, query hooks, mocks, and validators all reference the names this
@@ -45,6 +52,7 @@ export const pluginTs = definePlugin<PluginTs>((options) => {
     optionalType = 'questionToken',
     arrayType = 'array',
     syntaxType = 'type',
+    operationTypes = defaultOperationTypes,
     printer,
     resolver: userResolver,
     macros: userMacros,
@@ -74,6 +82,7 @@ export const pluginTs = definePlugin<PluginTs>((options) => {
           arrayType,
           enum: resolvedEnum,
           syntaxType,
+          operationTypes,
           printer,
         })
         ctx.setResolver(userResolver ? Resolver.merge(resolverTs, userResolver) : resolverTs)

--- a/packages/plugin-ts/src/types.ts
+++ b/packages/plugin-ts/src/types.ts
@@ -254,6 +254,15 @@ export type Options = OutputOptions & {
    */
   arrayType?: 'generic' | 'array'
   /**
+   * Whether to keep the per-operation alias layer or reference base component types directly.
+   * With `false`, a body or response backed by a single `$ref` resolves to the referenced component
+   * (for example `Pet`) instead of the `AddPetData` / `AddPetStatus200` alias, and those aliases are
+   * no longer emitted. Inline, array, union, multiple-content-type, and `Omit`-based schemas keep
+   * their per-operation alias, since no single base type exists. Consumer plugins read this through
+   * the plugin driver and inline the same way. Defaults to `true`, which keeps the existing output.
+   */
+  operationTypes?: boolean
+  /**
    * Override how names and file paths are built for generated symbols.
    * Methods you omit fall back to the default `resolverTs`. `this` is bound to the
    * full resolver, so `this.default.name(name)` delegates to the built-in implementation.
@@ -321,6 +330,7 @@ export type ResolvedOptions = {
   optionalType: NonNullable<Options['optionalType']>
   arrayType: NonNullable<Options['arrayType']>
   syntaxType: NonNullable<Options['syntaxType']>
+  operationTypes: NonNullable<Options['operationTypes']>
   printer: Options['printer']
 }
 

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -77,7 +77,7 @@ describe('buildResponses', () => {
       ],
     })
 
-    expect(printSchema(buildResponses(node, { resolver: resolverTs }))).toMatchInlineSnapshot(`
+    expect(printSchema(buildResponses(node, { resolver: resolverTs, operationTypes: true }))).toMatchInlineSnapshot(`
       "{
           "200": ListPetsStatus200;
           default: ListPetsStatusDefault;
@@ -93,7 +93,7 @@ describe('buildResponses', () => {
       responses: [],
     })
 
-    expect(printSchema(buildResponses(node, { resolver: resolverTs }))).toBe('object')
+    expect(printSchema(buildResponses(node, { resolver: resolverTs, operationTypes: true }))).toBe('object')
   })
 })
 
@@ -109,7 +109,21 @@ describe('buildResponseUnion', () => {
       ],
     })
 
-    expect(printSchema(buildResponseUnion(node, { resolver: resolverTs })!)).toMatchInlineSnapshot(`"(ListPetsStatus200 | ListPetsStatus405)"`)
+    expect(printSchema(buildResponseUnion(node, { resolver: resolverTs, operationTypes: true })!)).toMatchInlineSnapshot(`"(ListPetsStatus200 | ListPetsStatus405)"`)
+  })
+
+  it('references base components instead of status aliases when operationTypes is false', () => {
+    const node = ast.factory.createOperation({
+      operationId: 'listPets',
+      method: 'GET',
+      path: '/pets',
+      responses: [
+        ast.factory.createResponse({ statusCode: '200', description: 'OK', schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }) }),
+        ast.factory.createResponse({ statusCode: '405', description: 'Error', schema: ast.factory.createSchema({ type: 'object' }) }),
+      ],
+    })
+
+    expect(printSchema(buildResponseUnion(node, { resolver: resolverTs, operationTypes: false })!)).toMatchInlineSnapshot(`"(Pet | ListPetsStatus405)"`)
   })
 })
 

--- a/packages/plugin-ts/src/utils.test.ts
+++ b/packages/plugin-ts/src/utils.test.ts
@@ -109,7 +109,9 @@ describe('buildResponseUnion', () => {
       ],
     })
 
-    expect(printSchema(buildResponseUnion(node, { resolver: resolverTs, operationTypes: true })!)).toMatchInlineSnapshot(`"(ListPetsStatus200 | ListPetsStatus405)"`)
+    expect(printSchema(buildResponseUnion(node, { resolver: resolverTs, operationTypes: true })!)).toMatchInlineSnapshot(
+      `"(ListPetsStatus200 | ListPetsStatus405)"`,
+    )
   })
 
   it('references base components instead of status aliases when operationTypes is false', () => {
@@ -118,7 +120,11 @@ describe('buildResponseUnion', () => {
       method: 'GET',
       path: '/pets',
       responses: [
-        ast.factory.createResponse({ statusCode: '200', description: 'OK', schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }) }),
+        ast.factory.createResponse({
+          statusCode: '200',
+          description: 'OK',
+          schema: ast.factory.createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }),
+        }),
         ast.factory.createResponse({ statusCode: '405', description: 'Error', schema: ast.factory.createSchema({ type: 'object' }) }),
       ],
     })

--- a/packages/plugin-ts/src/utils.ts
+++ b/packages/plugin-ts/src/utils.ts
@@ -1,4 +1,4 @@
-import { resolveContentTypeVariants } from '@internals/shared'
+import { resolveContentTypeVariants, resolveInlinableRefName } from '@internals/shared'
 import { jsStringEscape, stringify } from '@internals/utils'
 import { ast, syncSchemaRef } from 'kubb/kit'
 import type { ResolverTs } from './types.ts'
@@ -86,6 +86,7 @@ type BuildParamsSchemaOptions = {
 
 type BuildOperationSchemaOptions = {
   resolver: ResolverTs
+  operationTypes: boolean
 }
 
 /**
@@ -112,10 +113,12 @@ export function buildParams({ params }: BuildParamsSchemaOptions): ast.SchemaNod
  * on `result.parsed`, while the standalone `<Name>StatusNNN` alias stays the plain body union that the
  * query hooks and `result.data` use.
  */
-function buildResponseRecordEntry(node: ast.OperationNode, res: ast.ResponseNode, resolver: ResolverTs): ast.SchemaNode {
+function buildResponseRecordEntry(node: ast.OperationNode, res: ast.ResponseNode, resolver: ResolverTs, operationTypes: boolean): ast.SchemaNode {
   const statusName = resolver.response.status(node, res.statusCode)
   const variants = (res.content ?? []).filter((entry) => entry.schema)
   if (variants.length <= 1) {
+    const inlineName = operationTypes ? null : resolveInlinableRefName(res.content)
+    if (inlineName) return variants[0]!.schema!
     return ast.factory.createSchema({ type: 'ref', name: statusName })
   }
 
@@ -141,7 +144,7 @@ function buildResponseRecordEntry(node: ast.OperationNode, res: ast.ResponseNode
   })
 }
 
-export function buildResponses(node: ast.OperationNode, { resolver }: BuildOperationSchemaOptions): ast.SchemaNode {
+export function buildResponses(node: ast.OperationNode, { resolver, operationTypes }: BuildOperationSchemaOptions): ast.SchemaNode {
   // Always emit the keyed responses map, even when an operation declares no responses. An operation
   // with no responses renders as an empty `object`, which keeps every consumer's import (for example
   // the axios SDK's `RequestResult<XResponses>`) resolvable instead of pointing at a missing export.
@@ -151,13 +154,13 @@ export function buildResponses(node: ast.OperationNode, { resolver }: BuildOpera
       ast.factory.createProperty({
         name: String(res.statusCode),
         required: true,
-        schema: buildResponseRecordEntry(node, res, resolver),
+        schema: buildResponseRecordEntry(node, res, resolver, operationTypes),
       }),
     ),
   })
 }
 
-export function buildResponseUnion(node: ast.OperationNode, { resolver }: BuildOperationSchemaOptions): ast.SchemaNode | null {
+export function buildResponseUnion(node: ast.OperationNode, { resolver, operationTypes }: BuildOperationSchemaOptions): ast.SchemaNode | null {
   const responsesWithSchema = node.responses.filter((res) => res.content?.some((entry) => entry.schema))
 
   if (responsesWithSchema.length === 0) {
@@ -166,6 +169,10 @@ export function buildResponseUnion(node: ast.OperationNode, { resolver }: BuildO
 
   return ast.factory.createSchema({
     type: 'union',
-    members: responsesWithSchema.map((res) => ast.factory.createSchema({ type: 'ref', name: resolver.response.status(node, res.statusCode) })),
+    members: responsesWithSchema.map((res) => {
+      const inlineName = operationTypes ? null : resolveInlinableRefName(res.content)
+      if (inlineName) return res.content!.find((entry) => entry.schema)!.schema!
+      return ast.factory.createSchema({ type: 'ref', name: resolver.response.status(node, res.statusCode) })
+    }),
   })
 }

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -1,8 +1,8 @@
-import { getOperationParameters, operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { getOperationParameters, operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation, resolvePageParamType } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginVueQuery } from '../types'
@@ -64,15 +64,19 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
       queryParam: infiniteOptions.queryParam,
     })
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      queryParamsTypeName,
-      ...resolveOperationTypeNames(node, tsResolver, {
-        exclude: [queryKeyTypeName],
-        order: 'body-response-first',
-        includeParams: false,
-      }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          exclude: [queryKeyTypeName],
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node), queryParamsTypeName],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -90,9 +94,9 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
         <File.Import name={['toValue']} path="vue" />
         <File.Import name={['MaybeRefOrGetter']} path="vue" isTypeOnly />
 
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <QueryKey name={queryKeyName} typeName={queryKeyTypeName} node={node} tsResolver={tsResolver} transformer={ctx.options.queryKey} />
 

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -2,7 +2,7 @@ import { getOperationParameters, operationFileEntry, resolveOperationTypeImports
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation, resolvePageParamType } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { InfiniteQuery, InfiniteQueryOptions, QueryKey } from '../components'
 import type { PluginVueQuery } from '../types'
@@ -69,7 +69,7 @@ export const infiniteQueryGenerator = defineGenerator<PluginVueQuery>({
           exclude: [queryKeyTypeName],
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -1,8 +1,8 @@
-import { getRequestGroups, operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { getRequestGroups, operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mutation, MutationKey } from '../components'
 import type { PluginVueQuery } from '../types'
@@ -48,10 +48,18 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
       }),
     }
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      ...resolveOperationTypeNames(node, tsResolver, { order: 'body-response-first', includeParams: false }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -73,9 +81,9 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
         {hasRequestGroups && <File.Import name={['toValue']} path="vue" />}
         <File.Import name={['MaybeRefOrGetter']} path="vue" isTypeOnly />
 
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <MutationKey name={mutationKeyName} node={node} transformer={ctx.options.mutationKey} />
 

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -2,7 +2,7 @@ import { getRequestGroups, operationFileEntry, resolveOperationTypeImports } fro
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Mutation, MutationKey } from '../components'
 import type { PluginVueQuery } from '../types'
@@ -52,7 +52,7 @@ export const mutationGenerator = defineGenerator<PluginVueQuery>({
       ? resolveOperationTypeImports(node, tsResolver, {
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -1,8 +1,8 @@
-import { operationFileEntry, resolveOperationTypeNames } from '@internals/shared'
+import { operationFileEntry, resolveOperationTypeImports } from '@internals/shared'
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { pluginTsName } from '@kubb/plugin-ts'
+import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginVueQuery } from '../types'
@@ -49,14 +49,19 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
       }),
     }
 
-    const importedTypeNames = [
-      tsResolver.response.options(node),
-      ...resolveOperationTypeNames(node, tsResolver, {
-        exclude: [queryKeyTypeName],
-        order: 'body-response-first',
-        includeParams: false,
-      }),
-    ].filter((name): name is string => Boolean(name))
+    const typeImportGroups = meta.fileTs
+      ? resolveOperationTypeImports(node, tsResolver, {
+          exclude: [queryKeyTypeName],
+          order: 'body-response-first',
+          includeParams: false,
+          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationFilePath: meta.fileTs.path,
+          root,
+          output: pluginTs.options?.output ?? output,
+          group: pluginTs.options?.group ?? undefined,
+          extraNames: [tsResolver.response.options(node)],
+        })
+      : []
 
     const calledClientName = contractOp.name
 
@@ -74,9 +79,9 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
         <File.Import name={['toValue']} path="vue" />
         <File.Import name={['MaybeRefOrGetter']} path="vue" isTypeOnly />
 
-        {meta.fileTs && importedTypeNames.length > 0 && (
-          <File.Import name={Array.from(new Set(importedTypeNames))} root={meta.file.path} path={meta.fileTs.path} isTypeOnly />
-        )}
+        {typeImportGroups.map((typeImport) => (
+          <File.Import key={typeImport.path} name={typeImport.names} root={meta.file.path} path={typeImport.path} isTypeOnly />
+        ))}
 
         <QueryKey name={queryKeyName} typeName={queryKeyTypeName} node={node} tsResolver={tsResolver} transformer={ctx.options.queryKey} />
 

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -2,7 +2,7 @@ import { operationFileEntry, resolveOperationTypeImports } from '@internals/shar
 import { resolveClientOperation } from '@internals/client'
 import { classifyOperation } from '@internals/tanstack-query'
 import { ast, defineGenerator } from 'kubb/kit'
-import { defaultOperationTypes, pluginTsName } from '@kubb/plugin-ts'
+import { pluginTsName } from '@kubb/plugin-ts'
 import { File, jsxRenderer } from 'kubb/jsx'
 import { Query, QueryKey, QueryOptions } from '../components'
 import type { PluginVueQuery } from '../types'
@@ -54,7 +54,7 @@ export const queryGenerator = defineGenerator<PluginVueQuery>({
           exclude: [queryKeyTypeName],
           order: 'body-response-first',
           includeParams: false,
-          operationTypes: pluginTs.options?.operationTypes ?? defaultOperationTypes,
+          operationTypes: pluginTs.options?.operationTypes,
           operationFilePath: meta.fileTs.path,
           root,
           output: pluginTs.options?.output ?? output,


### PR DESCRIPTION
## 🎯 Changes

Add an `operationTypes` option to `@kubb/plugin-ts` (default `true`), addressing #16. With `operationTypes: false`, a request body or response backed by a single `$ref` references the base component type (for example `Pet`) instead of the per-operation `AddPetData` / `AddPetStatus200` alias, and those aliases are no longer emitted.

The option is implemented through the plugin-ts resolver rather than a flag threaded through every consumer:

- **plugin-ts** installs an inline resolver preset when `operationTypes` is `false`, so `response.status` and `response.body` resolve single-`$ref` slots to the base component. The type generator skips the redundant `$ref`-backed aliases and points the `XxxResponses` / `XxxResponse` / `XxxOptions` aggregates at the base component.
- **@internals/shared** adds `resolveInlinableRefName` (the single "is this a bare `$ref`?" decision) and `resolveOperationTypeImports` (groups an operation's type imports by source file).
- **Consumers** (react-query, vue-query, swr, cypress, faker, msw) route type imports through the resolver, so an inlined `Pet` is imported from its own file. The client plugins reference only the `Options` and `Responses` aggregates, so they inherit inlining with no change.

Inline, array, union, multiple-content-type, and `Omit`-based schemas keep their per-operation alias, since no single base type exists. Default (`true`) output is byte-identical.

Verified end to end: generating a single-`$ref` spec with `operationTypes: false` produces `import type { Pet } from '../models/Pet'` and `mutationOptions<Pet, …>`, and the generated output type-checks. A multi-content spec correctly keeps its aliases. Full suite: 1226 tests passing, with typecheck, lint, and format clean.

The core `reference` / `collectImports` generalization is intentionally left as a follow-up. This PR delivers the feature entirely within the plugins repo, keeping the default non-breaking and avoiding a cross-repo version dependency. Docs: kubb-labs/docs#(companion PR).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FsS6LFAiRXigzcnrsJvwPy

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsS6LFAiRXigzcnrsJvwPy)_