### PR TITLE
fix(shared): cache getOperationParameters per operation node

### DIFF
--- a/internals/shared/src/operation.test.ts
+++ b/internals/shared/src/operation.test.ts
@@ -269,6 +269,32 @@ describe('getOperationParameters', () => {
     expect(grouped.header.map((param) => param.name)).toStrictEqual(['x-api-key'])
     expect(grouped.cookie.map((param) => param.name)).toStrictEqual(['session-id'])
   })
+
+  test('caches the grouped result per node so repeat calls for the same operation skip re-grouping', () => {
+    const node = ast.factory.createOperation({
+      operationId: 'showPet',
+      method: 'GET',
+      path: '/pets/{petId}',
+      parameters: [ast.factory.createParameter({ name: 'petId', in: 'path', schema: ast.factory.createSchema({ type: 'string' }) })],
+    })
+
+    expect(getOperationParameters(node)).toBe(getOperationParameters(node))
+  })
+
+  test('does not share cached results between distinct, structurally identical nodes', () => {
+    const buildNode = () =>
+      ast.factory.createOperation({
+        operationId: 'showPet',
+        method: 'GET',
+        path: '/pets/{petId}',
+        parameters: [ast.factory.createParameter({ name: 'petId', in: 'path', schema: ast.factory.createSchema({ type: 'string' }) })],
+      })
+
+    const grouped = getOperationParameters(buildNode())
+
+    expect(getOperationParameters(buildNode())).not.toBe(grouped)
+    expect(getOperationParameters(buildNode())).toStrictEqual(grouped)
+  })
 })
 
 describe('buildOptionsSchema', () => {

--- a/internals/shared/src/operation.ts
+++ b/internals/shared/src/operation.ts
@@ -399,13 +399,27 @@ export function buildOperationComments(node: ast.OperationNode, options: BuildOp
   return filteredComments.flatMap((text) => text.split(/\r?\n/).map((line) => line.trim())).filter((comment): comment is string => Boolean(comment))
 }
 
+const operationParameterGroupsByNode = new WeakMap<ast.OperationNode, OperationParameterGroups>()
+
+/**
+ * Groups an operation's parameters by location (`path`/`query`/`header`/`cookie`), deduping each
+ * group by name. Every plugin generator visiting the same `OperationNode` shares one AST instance
+ * (see `KubbDriver`), so the result is cached per node to avoid re-filtering and re-deduping the
+ * same parameters once per plugin.
+ */
 export function getOperationParameters(node: ast.OperationNode): OperationParameterGroups {
-  return {
+  const cached = operationParameterGroupsByNode.get(node)
+  if (cached) return cached
+
+  const groups: OperationParameterGroups = {
     path: dedupeParams(node.parameters.filter((param) => param.in === 'path')),
     query: dedupeParams(node.parameters.filter((param) => param.in === 'query')),
     header: dedupeParams(node.parameters.filter((param) => param.in === 'header')),
     cookie: dedupeParams(node.parameters.filter((param) => param.in === 'cookie')),
   }
+
+  operationParameterGroupsByNode.set(node, groups)
+  return groups
 }
 
 /**


### PR DESCRIPTION
## 🎯 Changes

`getOperationParameters(node)` in `internals/shared/src/operation.ts` re-filtered and re-deduped `node.parameters` into path/query/header/cookie groups on every call. It's called repeatedly for the same operation across the ts, zod, client, and tanstack-query plugins (and more than once within a single plugin), so the same grouping work ran many times per operation during a single generation run.

`OperationNode` instances are shared by reference across plugins in the default configuration (no custom `macros`) — `KubbDriver` parses the OpenAPI document once into a shared array of `OperationNode`s and passes the same object to every plugin generator. That means a per-node cache genuinely collapses the redundant work to one computation per operation for the whole run, not just within one plugin.

Memoized the grouped result in a `WeakMap<ast.OperationNode, OperationParameterGroups>` keyed by node identity, so repeat calls for the same operation return the cached grouping instead of re-filtering and re-deduping.

This is an internal-only change (`@internals/shared` is excluded from changesets) with no output difference — verified by running the full test suites of every package that consumes this helper (`plugin-ts`, `plugin-zod`, `plugin-react-query`, `plugin-vue-query`, `@internals/client`, `@internals/tanstack-query`), all green with no snapshot changes.

Fixes kubb-labs/kubb#3815

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

`@internals/shared` is excluded from changesets (`.changeset/config.json` ignore list) and no public package's output changes, so no changeset is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K6jNhNBFpmoqFUBtthoGv9)_